### PR TITLE
draws mnemonic from nodes/ .env adds to shell scripts relevant to doc…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ SESSION_KEY=
 
 
 # LOCAL DEV
+MNEMONIC='test test test test test test test test test test test junk'
 # http://localhost:1984 
 #
 # LIVE:

--- a/desci-contracts/.env.example
+++ b/desci-contracts/.env.example
@@ -2,3 +2,4 @@ COINMARKETCAP_API_KEY=
 REACT_APP_SUPPORTED_CHAINS=
 # private key for the deployer (goerli / prod)
 PRIVATE_KEY=
+MNEMONIC='test test test test test test test test test test test junk'

--- a/desci-contracts/hardhat.config.ts
+++ b/desci-contracts/hardhat.config.ts
@@ -55,7 +55,7 @@ module.exports = {
       live: false,
       url: "http://127.0.0.1:8545",
       accounts: {
-        mnemonic: "test test test test test test test test test test test junk",
+        mnemonic: process.env.MNEMONIC,
       },
     },
     rinkeby: {

--- a/desci-contracts/package.json
+++ b/desci-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/desci-contracts",
-  "description": "Smart contracts implementing DeSci Noeds on-chain state and logic",
+  "description": "Smart contracts implementing DeSci Nodes on-chain state and logic",
   "version": "0.2.0",
   "license": "BSD-4-Clause",
   "scripts": {

--- a/desci-contracts/scripts/seedLocalChain.sh
+++ b/desci-contracts/scripts/seedLocalChain.sh
@@ -1,5 +1,5 @@
 FILE=.openzeppelin/unknown-research-object.json
-
+MNEMONIC=$(grep MNEMONIC ../.env | cut -d '=' -f 2-)
 RUNNING=true
 function check() {
     FILE=.openzeppelin/unknown-research-object.json
@@ -38,7 +38,7 @@ else
     sudo chown -R $(whoami) ../local-data/ganache
     (echo "sleeping until contract deployed" && check ) &
     child=$!
-    npx ganache-cli -i 1111 --quiet -h 0.0.0.0 --mnemonic "test test test test test test test test test test test junk" --db ../local-data/ganache
+    npx ganache-cli -i 1111 --quiet -h 0.0.0.0 --mnemonic "${MNEMONIC}" --db ../local-data/ganache
     wait "$child"
 fi
 

--- a/desci-contracts/scripts/seedLocalDpid.sh
+++ b/desci-contracts/scripts/seedLocalDpid.sh
@@ -1,5 +1,5 @@
 FILE=.openzeppelin/unknown-dpid.json
-
+MNEMONIC=$(grep MNEMONIC ../.env | cut -d '=' -f 2-)
 RUNNING=true
 function check() {
     FILE=.openzeppelin/unknown-dpid.json
@@ -38,7 +38,7 @@ else
     sudo chown -R $(whoami) ../local-data/ganache
     (echo "sleeping until contract deployed" && check ) &
     child=$!
-    npx ganache-cli -i 1111 --quiet -h 0.0.0.0 --mnemonic "test test test test test test test test test test test junk" --db ../local-data/ganache
+    npx ganache-cli -i 1111 --quiet -h 0.0.0.0 --mnemonic "${MNEMONIC}" --db ../local-data/ganache
     wait "$child"
 fi
 

--- a/desci-contracts/scripts/startTestChain.sh
+++ b/desci-contracts/scripts/startTestChain.sh
@@ -12,4 +12,4 @@ fi
 echo "SHOULD_UPGRADE=$SHOULD_UPGRADE"
 (echo "waiting for ganache..." && sleep 10 && (scripts/checkTestDeployments.sh ".openzeppelin/unknown-dpid.json" && yarn deploy:dpid:ganache) ; sleep 10 && (scripts/checkTestDeployments.sh ".openzeppelin/unknown-research-object.json" && yarn deploy:ganache) ; sleep 10 && ( [ $SHOULD_UPGRADE = 1 ] && yarn upgrade:local ) ) &
 (echo "deploy subgraph..." && sleep 30 && scripts/deployLocalSubgraph.sh ) &
-npx ganache-cli -i 1111 --quiet -h 0.0.0.0 --mnemonic "test test test test test test test test test test test junk" --db /data
+npx ganache-cli -i 1111 --quiet -h 0.0.0.0 --mnemonic "${MNEMONIC}" --db /data

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,8 @@ services:
     restart: always
     ports:
       - "8545:8545"
+    env_file:
+      - .env
     extra_hosts:
       - host.docker.internal:host-gateway
     volumes:

--- a/dockerDev.sh
+++ b/dockerDev.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
 [ ! -f ".env" ] && cp .env.example .env
+MNEMONIC=$(grep MNEMONIC .env)
+
 [ ! -f "./nodes-media/.env" ] && cp ./nodes-media/.env.example ./nodes-media/.env
 [ ! -f "../nodes-web/.env" ] && cp ../nodes-web/.env.example ../nodes-web/.env
 
+if [ ! -f "./desci-contracts/.env" ]; then
+  touch ./desci-contracts/.env
+  [ ! -z "$MNEMONIC" ] && echo $MNEMONIC >> ./desci-contracts/.env
+fi
 if [ -d "desci-contracts" ]; then
     cd desci-contracts
     yarn


### PR DESCRIPTION
…kerDev.sh, spelling in package.json

Asana ticket: no ticket
Closes # no issue number

## Description of the Problem / Feature
Hardhats default mnemonic was hardcoded into the development pipeline, Thought i'd create the capability to bring ones own mnemonic
## Explanation of the solution
MNEMONIC environment variable is created in nodes/.env.example which is injected through docker-compose with the env_file flag, scripts that run outside the docker environment pull with some common bash primitives (not sure about the zsh story!)

## Instructions on making this work
remove `./desci-contracts/.openzeppelin/unknown-dpid.json` and the `./desci-contracts/.openzeppelin/unknown-research-object.json` and `sudo rm -rf ./local-data` to trigger redeployment and a clean slate. run `./dockerDev.sh` 
the the .env folder change the MNEMONIC to your own
may error due to ganache being in use, so `sudo netstat -lntp` find the process id under 8545 `kill -9 <pid> and rerun the script, 
 
## UI changes for review
no UI changes for review 

