### PR TITLE
Data/Extend external url support, add rename component ability to renaming files

### DIFF
--- a/desci-server/src/controllers/data/utils.ts
+++ b/desci-server/src/controllers/data/utils.ts
@@ -78,3 +78,13 @@ export async function getLatestManifest(
 
   return manifestUrl ? await (await axios.get(manifestUrl)).data : null;
 }
+
+export function separateFileNameAndExtension(fileName: string): {
+  fileName: string;
+  extension?: string;
+} {
+  const splitName = fileName.split('.');
+  const extension = splitName.length > 1 ? splitName.pop() : '';
+  const name = splitName.join('.');
+  return { fileName: name, extension };
+}


### PR DESCRIPTION
## Description of the Problem / Feature
External URLs only supported code
Renaming a file wouldn't be in sync with its component, as file name !== component name, adding support for this on the frontend would cause a race condition between the dag being updated and the component name being changed in the manifest.
## Explanation of the solution
Added pdf support for external URLs
Added rename component support on dag rename controller

