### PR TITLE
Bug fixes/Update Data

### DIFF
--- a/desci-server/src/controllers/data/update.ts
+++ b/desci-server/src/controllers/data/update.ts
@@ -61,7 +61,7 @@ export function updateManifestDataBucket({ manifest, dataBucketId, newRootCid }:
 export const update = async (req: Request, res: Response) => {
   debugger;
   const owner = (req as any).user as User;
-  const { uuid, manifest, contextPath, componentType, componentSubType, newFolderName } = req.body;
+  const { uuid, manifest, contextPath, componentType, componentSubtype, newFolderName } = req.body;
   let { externalUrl, externalCids } = req.body;
   //Require XOR (files, externalCid, externalUrl)
   //ExternalURL - url + type, code (github) & external pdfs for now
@@ -332,7 +332,7 @@ export const update = async (req: Request, res: Response) => {
         path: neutralFullPath,
         cid: file.cid,
         componentType,
-        componentSubType,
+        componentSubtype,
         star: true,
         ...(externalUrl && { externalUrl: externalUrl.url }),
       };

--- a/desci-server/src/controllers/data/update.ts
+++ b/desci-server/src/controllers/data/update.ts
@@ -59,7 +59,7 @@ export function updateManifestDataBucket({ manifest, dataBucketId, newRootCid }:
 }
 
 export const update = async (req: Request, res: Response) => {
-  debugger;
+  // debugger;
   const owner = (req as any).user as User;
   const { uuid, manifest, contextPath, componentType, componentSubtype, newFolderName } = req.body;
   let { externalUrl, externalCids } = req.body;
@@ -196,11 +196,13 @@ export const update = async (req: Request, res: Response) => {
   console.log('[UPDATE DATASET] cleanContextPath: ', cleanContextPath);
 
   //ensure all paths are unique to prevent borking datasets, reject if fails unique check
+  // debugger;
   const OldTreePaths = oldFlatTree.map((e) => e.path);
   let newPathsFormatted: string[] = [];
   const header = !!cleanContextPath ? rootCid + '/' + cleanContextPath : rootCid;
   if (files.length) {
     newPathsFormatted = files.map((f) => {
+      if (f.originalname[0] !== '/') f.originalname = '/' + f.originalname;
       return header + f.originalname;
     });
   }

--- a/desci-server/src/middleware/upgradeManifest.ts
+++ b/desci-server/src/middleware/upgradeManifest.ts
@@ -30,7 +30,6 @@ export const upgradeManifestTransformer = async (req: Request, res: Response, ne
   }
 
   let manifestObj = await getLatestManifest(node.uuid, req.query?.g as string, node);
-  debugger;
 
   const hasDataBucket =
     manifestObj?.components[0]?.type === ResearchObjectComponentType.DATA_BUCKET

--- a/desci-server/src/routes/v1/data.ts
+++ b/desci-server/src/routes/v1/data.ts
@@ -8,7 +8,7 @@ import { upgradeManifestTransformer } from 'middleware/upgradeManifest';
 const router = Router();
 const upload = multer({ preservePath: true });
 
-router.post('/update', [ensureUser, upload.array('files'), upgradeManifestTransformer], update);
+router.post('/update', [ensureUser, upload.array('files')], update);
 router.post('/delete', [ensureUser], deleteData);
 router.post('/rename', [ensureUser], renameData);
 router.get('/retrieveTree/:nodeUuid/:cid', [ensureUser], retrieveTree);


### PR DESCRIPTION

## Description of the Problem / Feature
Predefined component subtype assignment was failing
Duplicate path check was failing if component added through manual add flow (non dnd)
## Explanation of the solution
Case consistency of subtype keyword fixed the type assignment problem
Drag and drop browser uploads vs modal browser uploads resulted in a path discrepancy being forwarded to the backend, added a check to see ensure there's a preceding slash in the path to ensure path consistency between both upload methods.
