### PR TITLE
External CID DAG resolution failing handling

### DIFF
--- a/desci-server/src/controllers/data/update.ts
+++ b/desci-server/src/controllers/data/update.ts
@@ -279,7 +279,7 @@ export const update = async (req: Request, res: Response<UpdateResponse | ErrorR
             { extCid },
             '[UPDATE DATASET] External DAG tree resolution failed, the contents within the DAG were unable to be retrieved, rejecting update.',
           );
-          res
+          return res
             .status(400)
             .json({ error: 'Failed resolving external dag tree, the DAG or its contents were unable to be retrieved' });
         }

--- a/desci-server/src/services/ipfs.ts
+++ b/desci-server/src/services/ipfs.ts
@@ -54,7 +54,7 @@ export const publicIpfs = ipfs.create({ url: process.env.PUBLIC_IPFS_RESOLVER })
 
 // Timeouts for resolution on internal and external IPFS nodes, to prevent server hanging, in ms.
 const INTERNAL_IPFS_TIMEOUT = 5000;
-const EXTERNAL_IPFS_TIMEOUT = 15000;
+const EXTERNAL_IPFS_TIMEOUT = 30000;
 
 export const updateManifestAndAddToIpfs = async (
   manifest: ResearchObjectV1,
@@ -491,7 +491,7 @@ export async function mixedLs(dagCid: string, externalCidMap: ExternalCidMap, ca
 export const pubRecursiveLs = async (cid: string, carryPath?: string) => {
   carryPath = carryPath || convertToCidV1(cid);
   const tree = [];
-  const lsOp = await publicIpfs.ls(cid);
+  const lsOp = await publicIpfs.ls(cid, { timeout: EXTERNAL_IPFS_TIMEOUT });
   for await (const filedir of lsOp) {
     const res: any = filedir;
     const pathSplit = res.path.split('/');


### PR DESCRIPTION
## Description of the Problem / Feature
Updating a DAG with an external CID containing a DAG that failed to resolve all contents within the DAG was unhandled, the assumption was made that if the DAG resolved, all contents within would resolve also - false.
## Explanation of the solution
Added extra handling around the edge case where an external CID DAG resolves but its contents fail to resolve, failing to build the tree.

