### PR TITLE
fix watch mode

### DIFF
--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -6,7 +6,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "dev": "debug=* NODE_PATH=./src ts-node-dev --inspect=0.0.0.0:9229 --respawn --exit-child ./src/index.ts",
+    "dev": "debug=* NODE_PATH=./src ts-node-dev --inspect=0.0.0.0:9229 --respawn --watch --exit-child ./src/index.ts",
     "script:fix-mirrors": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/retry-mirrors.ts",
     "script:upgrade-manifests": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/upgradeManifests.ts",
     "script:test-upgrade-manifests": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/testUpgradeManifests.ts",


### PR DESCRIPTION
## Description of the Problem / Feature

when developing on desci-server,  ts-node-dev would unreliably restart the server after code change

## Explanation of the solution

add `--watch` flag to package json for `yarn dev`

## Instructions on making this work

use as normal