### PR TITLE
debug output for ts-node-dev

### DIFF
--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -6,7 +6,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "dev": "debug=* NODE_PATH=./src ts-node-dev --inspect=0.0.0.0:9229 --respawn --watch --exit-child ./src/index.ts",
+    "dev": "debug=* NODE_PATH=./src ts-node-dev --inspect=0.0.0.0:9229 --respawn --transpile-only --watch --debug --exit-child ./src/index.ts",
     "script:fix-mirrors": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/retry-mirrors.ts",
     "script:upgrade-manifests": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/upgradeManifests.ts",
     "script:test-upgrade-manifests": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/testUpgradeManifests.ts",


### PR DESCRIPTION
## Description of the Problem / Feature

need more transparency to what ts-node-dev is doing / waiting for server to start

## Explanation of the solution

add --debug flag to package.json for desci-server

## Instructions on making this work

use as normal, can see debug output