### PR TITLE
Orcid Profile Caching

### DIFF
--- a/desci-server/prisma/migrations/20230719172545_add_orcid_cache/migration.sql
+++ b/desci-server/prisma/migrations/20230719172545_add_orcid_cache/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "OrcidProfile" (
+    "id" SERIAL NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "expiresIn" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrcidProfile_pkey" PRIMARY KEY ("id")
+);

--- a/desci-server/prisma/migrations/20230719181835_fix_orcid_profile_model/migration.sql
+++ b/desci-server/prisma/migrations/20230719181835_fix_orcid_profile_model/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[orcidId]` on the table `OrcidProfile` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `orcidId` to the `OrcidProfile` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "OrcidProfile" ADD COLUMN     "orcidId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrcidProfile_orcidId_key" ON "OrcidProfile"("orcidId");
+
+-- CreateIndex
+CREATE INDEX "OrcidProfile_orcidId_idx" ON "OrcidProfile"("orcidId");

--- a/desci-server/prisma/migrations/20230719193032_add_json_profile/migration.sql
+++ b/desci-server/prisma/migrations/20230719193032_add_json_profile/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `profile` to the `OrcidProfile` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "OrcidProfile" ADD COLUMN     "profile" JSONB NOT NULL;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -458,8 +458,12 @@ model UserOrganizations {
 
 model OrcidProfile {
   id        Int      @id @default(autoincrement())
+  orcidId   String   @unique
   updatedAt DateTime @updatedAt
   expiresIn DateTime
+  profile   Json
+
+  @@index([orcidId])
 }
 
 enum FriendReferralStatus {

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -456,6 +456,12 @@ model UserOrganizations {
   @@id([userId, organizationId])
 }
 
+model OrcidProfile {
+  id        Int      @id @default(autoincrement())
+  updatedAt DateTime @updatedAt
+  expiresIn DateTime
+}
+
 enum FriendReferralStatus {
   PENDING
   ACCEPTED

--- a/desci-server/src/controllers/proxy/orcidProfile.ts
+++ b/desci-server/src/controllers/proxy/orcidProfile.ts
@@ -64,7 +64,7 @@ export const orcidProfile = async (
       logger.info({}, 'No cached result found, or refresh triggered, fetching');
       const { data, status } = await axios.get<any, any>(`${ORCID_API_URL}/${orcidId}/public-record.json`, {});
 
-      if (data?.lastModifiedDate === null) {
+      if (data?.lastModifiedTime === null) {
         return res.status(422).send({ ok: false, error: 'Invalid ORCID Id' });
       }
 

--- a/desci-server/src/controllers/proxy/orcidProfile.ts
+++ b/desci-server/src/controllers/proxy/orcidProfile.ts
@@ -15,12 +15,19 @@ interface OrcidQueryResponseError {
   error: string;
 }
 
-export const orcidQuery = async (
+const orcidProfileTtl = 1000 * 60 * 60 * 24; // 1 day
+
+export const orcidProfile = async (
   req: Request,
   res: Response<OrcidQueryResponse | OrcidQueryResponseError>,
   next: NextFunction,
 ) => {
-  const { orcidId, refresh } = req.query;
+  debugger;
+  const orcidId = req.params.orcidId as string;
+
+  const { refresh: refreshQuery } = req.query;
+  const refresh = refreshQuery === 'true';
+
   if (!orcidId) return res.status(400).json({ ok: false, error: 'orcidId required' });
 
   const logger = parentLogger.child({
@@ -53,7 +60,7 @@ export const orcidQuery = async (
 
       const updateEntry = {
         profile: data,
-        expiresIn: new Date(Date.now() + 1000 * 60 * 60 * 24), // 1 day
+        expiresIn: new Date(Date.now() + orcidProfileTtl),
       };
 
       const upsertResult = await prisma.orcidProfile.upsert({

--- a/desci-server/src/controllers/proxy/orcidProfile.ts
+++ b/desci-server/src/controllers/proxy/orcidProfile.ts
@@ -8,7 +8,7 @@ export const ORCID_API_URL = 'https://orcid.org';
 
 interface OrcidQueryResponse {
   ok: boolean;
-  profile: Record<any, any>;
+  profile: any;
 }
 interface OrcidQueryResponseError {
   ok: boolean;
@@ -48,7 +48,7 @@ export const orcidProfile = async (
         { updatedAt: cachedResult.updatedAt, expiresIn: cachedResult.expiresIn },
         'Cached result found, returning',
       );
-      return res.status(200).send({ ok: true, profile: cachedResult });
+      return res.status(200).send({ ok: true, profile: cachedResult.profile });
     } else {
       //rate limit on refresh
       if (cachedResult && refresh) {
@@ -84,7 +84,7 @@ export const orcidProfile = async (
         create: { orcidId, ...updateEntry },
       });
       logger.info({ newExpiry: upsertResult.expiresIn }, 'Upserted ORCID profile');
-      return res.status(200).send({ ok: true, profile: upsertResult });
+      return res.status(200).send({ ok: true, profile: upsertResult.profile });
     }
   } catch (e) {
     logger.error({ e }, 'Error fetching ORCID profile');

--- a/desci-server/src/controllers/proxy/orcidProfile.ts
+++ b/desci-server/src/controllers/proxy/orcidProfile.ts
@@ -64,8 +64,12 @@ export const orcidProfile = async (
       logger.info({}, 'No cached result found, or refresh triggered, fetching');
       const { data, status } = await axios.get<any, any>(`${ORCID_API_URL}/${orcidId}/public-record.json`, {});
 
+      if (data?.lastModifiedDate === null) {
+        return res.status(422).send({ ok: false, error: 'Invalid ORCID Id' });
+      }
+
       if (status !== 200) {
-        logger.error({ status, data }, 'Error fetching ORCID profile');
+        logger.warn({ status, data }, 'Error fetching ORCID profile');
         return res.status(status).send({ ok: false, error: 'Error fetching ORCID profile' });
       }
 

--- a/desci-server/src/controllers/proxy/orcidQuery.ts
+++ b/desci-server/src/controllers/proxy/orcidQuery.ts
@@ -1,0 +1,71 @@
+import axios from 'axios';
+import { Request, Response, NextFunction } from 'express';
+
+import prisma from 'client';
+import parentLogger from 'logger';
+
+export const ORCID_API_URL = 'https://orcid.org';
+
+interface OrcidQueryResponse {
+  ok: boolean;
+  profile: Record<any, any>;
+}
+interface OrcidQueryResponseError {
+  ok: boolean;
+  error: string;
+}
+
+export const orcidQuery = async (
+  req: Request,
+  res: Response<OrcidQueryResponse | OrcidQueryResponseError>,
+  next: NextFunction,
+) => {
+  const { orcidId, refresh } = req.query;
+  if (!orcidId) return res.status(400).json({ ok: false, error: 'orcidId required' });
+
+  const logger = parentLogger.child({
+    module: 'SERVICES::orcidQueryController',
+    orcidId,
+    refresh,
+  });
+
+  try {
+    // fetch from cache
+    const cachedResult = await prisma.orcidProfile.findFirst({ where: { orcidId: orcidId } });
+    // check ttl against last updated
+    const isFresh = cachedResult?.updatedAt < cachedResult?.expiresIn;
+
+    if (cachedResult && isFresh && !refresh) {
+      logger.info(
+        { updatedAt: cachedResult.updatedAt, expiresIn: cachedResult.expiresIn },
+        'Cached result found, returning',
+      );
+      return res.status(200).send({ ok: true, profile: cachedResult });
+    } else {
+      //rate limit on refresh
+      logger.info({}, 'No cached result found, or refresh triggered, fetching');
+      const { data, status } = await axios.get<any, any>(`${ORCID_API_URL}/${orcidId}/public-record.json`, {});
+
+      if (status !== 200) {
+        logger.error({ status, data }, 'Error fetching ORCID profile');
+        return res.status(status).send({ ok: false, error: 'Error fetching ORCID profile' });
+      }
+
+      const updateEntry = {
+        profile: data,
+        expiresIn: new Date(Date.now() + 1000 * 60 * 60 * 24), // 1 day
+      };
+
+      const upsertResult = await prisma.orcidProfile.upsert({
+        where: { orcidId },
+        update: updateEntry,
+        create: { orcidId, ...updateEntry },
+      });
+      logger.info({ newExpiry: upsertResult.expiresIn }, 'Upserted ORCID profile');
+      return res.status(200).send({ ok: true, profile: upsertResult });
+    }
+  } catch (e) {
+    logger.error({ e }, 'Error fetching ORCID profile');
+    return res.status(500).send({ ok: false, error: 'Error fetching ORCID profile' });
+  }
+};

--- a/desci-server/src/routes/v1/index.ts
+++ b/desci-server/src/routes/v1/index.ts
@@ -14,6 +14,7 @@ import log from './log';
 import nodes from './nodes';
 import pub from './pub';
 import referral from './referral';
+import services from './services';
 import users from './users';
 import waitlist from './waitlist';
 
@@ -42,6 +43,7 @@ router.use('/waitlist', waitlist);
 router.use('/pub', pub);
 router.use('/data', data);
 router.use('/log', log);
+router.use('/services', services);
 
 router.get('/nft/:id', nft);
 router.use('/referral', referral);

--- a/desci-server/src/routes/v1/services.ts
+++ b/desci-server/src/routes/v1/services.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 
-import { orcidQuery } from 'controllers/proxy/orcidQuery';
+import { orcidProfile } from 'controllers/proxy/orcidProfile';
 
 const router = Router();
 
-router.get('/orcid/profile/:orcidId/:refresh?', [], orcidQuery);
+router.get('/orcid/profile/:orcidId', [], orcidProfile);
 
 export default router;

--- a/desci-server/src/routes/v1/services.ts
+++ b/desci-server/src/routes/v1/services.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+import { orcidQuery } from 'controllers/proxy/orcidQuery';
+
+const router = Router();
+
+router.get('/orcid/profile/:orcidId/:refresh?', [], orcidQuery);
+
+export default router;


### PR DESCRIPTION
Closes #99

## Description of the Problem / Feature
Add caching of orcid profiles to prevent spamming the API
## Explanation of the solution
Added a route to query the orcid api for an orcids profile, caching the result in psql, cache set at a daily ttl.
Added an option to invalidate the cache and force a refresh sooner than the daily ttl
Rate limited the refresh to prevent spamming the ORCID API
## Instructions on making this work
Call to
`/v1/services/orcid/profile/:orcidId`
Append "refresh=true" query param to invalidate the cache immediately
`v1/services/orcid/profile/:orcidId?refresh=true`
