### PR TITLE
Bug Fix: Invalid data route causing crash

### DIFF
--- a/desci-server/src/controllers/data/retrieve.ts
+++ b/desci-server/src/controllers/data/retrieve.ts
@@ -260,7 +260,7 @@ export const pubTree = async (req: Request, res: Response<PubTreeResponse | Erro
 
   const depthTree = await getOrCache(depthCacheKey, async () => {
     const tree = hasDataBucket ? [findAndPruneNode(filledTree[0], dataPath, depth)] : filledTree;
-    if (tree[0].type === 'file' && hasDataBucket) {
+    if (tree[0]?.type === 'file' && hasDataBucket) {
       const poppedDataPath = dataPath.substring(0, dataPath.lastIndexOf('/'));
       return hasDataBucket ? [findAndPruneNode(filledTree[0], poppedDataPath, depth)] : filledTree;
     } else {


### PR DESCRIPTION

Closes #103 

## Description of the Problem / Feature
Invalid routes for pubTree api not unhandled
## Explanation of the solution
Fixed crash from invalid route when using pubTree api
