### PR TITLE
Improve backfilling for nodes with external data

### DIFF
--- a/desci-server/src/controllers/data/retrieve.ts
+++ b/desci-server/src/controllers/data/retrieve.ts
@@ -243,7 +243,7 @@ export const pubTree = async (req: Request, res: Response<PubTreeResponse | Erro
   const hasDataBucket = manifest.components.find((c) => c.type === ResearchObjectComponentType.DATA_BUCKET);
 
   const fetchCb = hasDataBucket
-    ? async () => await getTreeAndFill(manifest, uuid)
+    ? async () => await getTreeAndFill(manifest, uuid, undefined, true)
     : async () => await getTreeAndFillDeprecated(rootCid, uuid, dataSource);
 
   const cacheKey = hasDataBucket ? `pub-filled-tree-${manifestCid}` : `deprecated-filled-tree-${rootCid}`;

--- a/desci-server/src/scripts/dataRefDoctor.ts
+++ b/desci-server/src/scripts/dataRefDoctor.ts
@@ -234,7 +234,6 @@ async function fillPublic(nodeUuid: string, userEmail: string, workingTreeUrl?: 
         nodeUuid: node.uuid,
         manifestCid,
         publicRefs: true,
-        markExternals: true,
         txHash,
         workingTreeUrl,
       });

--- a/desci-server/src/scripts/dataRefDoctor.ts
+++ b/desci-server/src/scripts/dataRefDoctor.ts
@@ -19,6 +19,7 @@ Usage Guidelines:
 - MARK_EXTERNALS is an optional flag, if true, it will mark external refs as external, downside is that it can take significantly longer to process, also size diff checking disabled when marking externals.
 - TX_HASH is an optional param, used for fixing node version of a specific published node version. (Edgecase of multiple publishes with same manifestCid)
 - USER_EMAIL is only required for the fillPublic operation
+- WORKING_TREE_URL is only required for the fillPublic operation, useful if a node is known to contain external cids, it can cut down the backfill time significantly for dags with external cids.
 
 Operation Types [validate, heal, validateAll, healAll]
 
@@ -37,7 +38,7 @@ const logger = parentLogger.child({ module: 'SCRIPTS::dataRefDoctor' });
 
 main();
 function main() {
-  const { operation, nodeUuid, manifestCid, publicRefs, start, end, markExternals, txHash, userEmail } =
+  const { operation, nodeUuid, manifestCid, publicRefs, start, end, markExternals, txHash, userEmail, workingTreeUrl } =
     getOperationEnvs();
   const startIterator = isNaN(start as any) ? undefined : parseInt(start);
   const endIterator = isNaN(end as any) ? undefined : parseInt(end);
@@ -45,11 +46,11 @@ function main() {
   switch (operation) {
     case 'validate':
       if (!nodeUuid && !manifestCid) return logger.error('Missing NODE_UUID or MANIFEST_CID');
-      validateDataReferences(nodeUuid, manifestCid, publicRefs, markExternals, txHash);
+      validateDataReferences({ nodeUuid, manifestCid, publicRefs, markExternals, txHash });
       break;
     case 'heal':
       if (!nodeUuid && !manifestCid) return logger.error('Missing NODE_UUID or MANIFEST_CID');
-      validateAndHealDataRefs(nodeUuid, manifestCid, publicRefs, markExternals, txHash);
+      validateAndHealDataRefs({ nodeUuid, manifestCid, publicRefs, markExternals, txHash });
       break;
     case 'validateAll':
       dataRefDoctor(false, publicRefs, startIterator, endIterator, markExternals);
@@ -59,7 +60,7 @@ function main() {
       break;
     case 'fillPublic':
       if (!nodeUuid && !userEmail) return logger.error('Missing NODE_UUID or USER_EMAIL');
-      fillPublic(nodeUuid, userEmail, markExternals);
+      fillPublic(nodeUuid, userEmail, workingTreeUrl);
       break;
     default:
       logger.error('Invalid operation, valid operations include: validate, heal, validateAll, healAll');
@@ -77,6 +78,7 @@ function getOperationEnvs() {
     end: process.env.END,
     markExternals: process.env.MARK_EXTERNALS?.toLowerCase() === 'true' ? true : false,
     txHash: process.env.TX_HASH || null,
+    workingTreeUrl: process.env.WORKING_TREE_URL || null,
     userEmail: process.env.USER_EMAIL || null,
   };
 }
@@ -121,17 +123,33 @@ async function dataRefDoctor(
           const txHash = indexedNode.versions[nodeVersIdx]?.id;
           const manifestCid = hexToCid(hexCid);
           if (heal) {
-            await validateAndHealDataRefs(node.uuid, manifestCid, true, markExternals, txHash);
+            await validateAndHealDataRefs({
+              nodeUuid: node.uuid,
+              manifestCid,
+              publicRefs: true,
+              markExternals,
+              txHash,
+            });
           } else {
-            validateDataReferences(node.uuid, manifestCid, true, markExternals, txHash);
+            validateDataReferences({ nodeUuid: node.uuid, manifestCid, publicRefs: true, markExternals, txHash });
           }
         }
       }
       if (!publicRefs) {
         if (heal) {
-          await validateAndHealDataRefs(node.uuid, node.manifestUrl, false, markExternals);
+          await validateAndHealDataRefs({
+            nodeUuid: node.uuid,
+            manifestCid: node.manifestUrl,
+            publicRefs: false,
+            markExternals,
+          });
         } else {
-          await validateDataReferences(node.uuid, node.manifestUrl, false, markExternals);
+          await validateDataReferences({
+            nodeUuid: node.uuid,
+            manifestCid: node.manifestUrl,
+            publicRefs: false,
+            markExternals,
+          });
         }
       }
     } catch (e) {
@@ -140,7 +158,7 @@ async function dataRefDoctor(
   }
 }
 
-async function fillPublic(nodeUuid: string, userEmail: string, externalCidMode = false) {
+async function fillPublic(nodeUuid: string, userEmail: string, workingTreeUrl?: string) {
   const user = await prisma.user.findUnique({ where: { email: userEmail } });
   if (!user) return logger.error(`[FillPublic] Failed to find user with email: ${userEmail}`);
 
@@ -212,7 +230,14 @@ async function fillPublic(nodeUuid: string, userEmail: string, externalCidMode =
       await prisma.publicDataReference.create({ data: manifestEntry });
 
       //generate pub drefs for the bucket
-      await validateAndHealDataRefs(node.uuid, manifestCid, true, true, txHash);
+      await validateAndHealDataRefs({
+        nodeUuid: node.uuid,
+        manifestCid,
+        publicRefs: true,
+        markExternals: true,
+        txHash,
+        workingTreeUrl,
+      });
       logger.info(
         `[DataRefDoctor]Successfully processed indexed node v: ${nodeVersIdx}, with txHash: ${indexedNode.versions[nodeVersIdx]?.id}, under user: ${user.email}`,
       );

--- a/desci-server/src/scripts/dataRefDoctor.ts
+++ b/desci-server/src/scripts/dataRefDoctor.ts
@@ -59,7 +59,7 @@ function main() {
       break;
     case 'fillPublic':
       if (!nodeUuid && !userEmail) return logger.error('Missing NODE_UUID or USER_EMAIL');
-      fillPublic(nodeUuid, userEmail);
+      fillPublic(nodeUuid, userEmail, markExternals);
       break;
     default:
       logger.error('Invalid operation, valid operations include: validate, heal, validateAll, healAll');
@@ -140,7 +140,7 @@ async function dataRefDoctor(
   }
 }
 
-async function fillPublic(nodeUuid: string, userEmail: string) {
+async function fillPublic(nodeUuid: string, userEmail: string, externalCidMode = false) {
   const user = await prisma.user.findUnique({ where: { email: userEmail } });
   if (!user) return logger.error(`[FillPublic] Failed to find user with email: ${userEmail}`);
 
@@ -205,6 +205,10 @@ async function fillPublic(nodeUuid: string, userEmail: string) {
         nodeId: node.id,
         versionId: nodeVersion.id,
       };
+      logger.info(
+        { manifestEntry },
+        `[DataRefDoctor] Manifest entry being created for indexed version ${nodeVersIdx}, with txHash: ${indexedNode.versions[nodeVersIdx]?.id}`,
+      );
       await prisma.publicDataReference.create({ data: manifestEntry });
 
       //generate pub drefs for the bucket

--- a/desci-server/src/services/ipfs.ts
+++ b/desci-server/src/services/ipfs.ts
@@ -557,6 +557,7 @@ export const pubRecursiveLs = async (cid: string, carryPath?: string) => {
 
 // Used for recursively lsing a DAG without knowing if it contains public or private cids, slow and INEFFICIENT!
 export async function discoveryLs(dagCid: string, externalCidMap: ExternalCidMap, carryPath?: string) {
+  console.log('extCidMap', externalCidMap);
   try {
     carryPath = carryPath || convertToCidV1(dagCid);
     const tree = [];
@@ -584,7 +585,7 @@ export async function discoveryLs(dagCid: string, externalCidMap: ExternalCidMap
         result.size = link.Tsize;
       } else {
         let linkBlock = await client.block.get(linkCidObject, { timeout: INTERNAL_IPFS_TIMEOUT });
-        if (!linkBlock) linkBlock = await publicIpfs.block.get(cidObject, { timeout: INTERNAL_IPFS_TIMEOUT });
+        if (!linkBlock) linkBlock = await publicIpfs.block.get(cidObject, { timeout: EXTERNAL_IPFS_TIMEOUT });
         if (!linkBlock) throw new Error('Could not find block for cid: ' + dagCid);
         const { Data: linkData } = dagPb.decode(linkBlock);
         const unixFsLink = UnixFS.unmarshal(linkData);

--- a/desci-server/src/services/nodeManager.ts
+++ b/desci-server/src/services/nodeManager.ts
@@ -183,7 +183,7 @@ export const getAllCidsRequiredForPublish = async (
     nodeId,
     versionId,
   };
-  const dataBucketEntries = await generateDataReferences(nodeUuid, manifestCid, versionId);
+  const dataBucketEntries = await generateDataReferences({ nodeUuid, manifestCid, versionId });
 
   return [manifestEntry, ...dataBucketEntries];
 };

--- a/desci-server/src/utils/dataRefTools.ts
+++ b/desci-server/src/utils/dataRefTools.ts
@@ -28,7 +28,7 @@ async function extractExternalCidMapFromTreeUrl(workingTreeUrl: string) {
   if (res.status !== 200) throw new Error(`Failed to get working tree from ${workingTreeUrl}`);
 
   const { tree } = res.data;
-  const flatTree = recursiveFlattenTree(tree[0]);
+  const flatTree = recursiveFlattenTree(tree);
   const externalCidMap: ExternalCidMap = {};
   flatTree.forEach((entry) => {
     if (entry.external && entry.type === FileType.DIR) {

--- a/desci-server/src/utils/dataRefTools.ts
+++ b/desci-server/src/utils/dataRefTools.ts
@@ -55,9 +55,11 @@ export async function generateDataReferences(
   };
 
   const externalCidMap = await generateExternalCidMap(node.uuid);
-  let dataTree = recursiveFlattenTree(await getDirectoryTree(dataBucketCid, externalCidMap, true, false));
+  let dataTree;
   if (markExternals) {
     dataTree = recursiveFlattenTree(await discoveryLs(dataBucketCid, externalCidMap));
+  } else {
+    dataTree = recursiveFlattenTree(await getDirectoryTree(dataBucketCid, externalCidMap, true, false));
   }
   const manifestPathsToDbTypes = generateManifestPathsToDbTypeMap(manifestEntry);
 

--- a/desci-server/test/integration/data.test.ts
+++ b/desci-server/test/integration/data.test.ts
@@ -107,11 +107,11 @@ describe('Data Controllers', () => {
         expect(res.body).to.have.property('manifestCid');
       });
       it('should have created all necessary data references', async () => {
-        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences(
-          node.uuid!,
-          res.body.manifestCid,
-          false,
-        );
+        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences({
+          nodeUuid: node.uuid!,
+          manifestCid: res.body.manifestCid,
+          publicRefs: false,
+        });
         const correctRefs = missingRefs.length === 0 && unusedRefs.length === 0 && Object.keys(diffRefs).length === 0;
         expect(correctRefs).to.equal(true);
       });
@@ -204,11 +204,11 @@ describe('Data Controllers', () => {
         expect(res.body).to.have.property('manifestCid');
       });
       it('should have created all necessary data references', async () => {
-        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences(
-          node.uuid!,
-          res.body.manifestCid,
-          false,
-        );
+        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences({
+          nodeUuid: node.uuid!,
+          manifestCid: res.body.manifestCid,
+          publicRefs: false,
+        });
         const correctRefs = missingRefs.length === 0 && unusedRefs.length === 0 && Object.keys(diffRefs).length === 0;
         expect(correctRefs).to.equal(true);
       });
@@ -262,11 +262,11 @@ describe('Data Controllers', () => {
         expect(res.body).to.have.property('manifestCid');
       });
       it('should have created all necessary data references', async () => {
-        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences(
-          node.uuid!,
-          res.body.manifestCid,
-          false,
-        );
+        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences({
+          nodeUuid: node.uuid!,
+          manifestCid: res.body.manifestCid,
+          publicRefs: false,
+        });
         const correctRefs = missingRefs.length === 0 && unusedRefs.length === 0 && Object.keys(diffRefs).length === 0;
         expect(correctRefs).to.equal(true);
       });
@@ -332,7 +332,7 @@ describe('Data Controllers', () => {
 
         await prisma.dataReference.create({ data: manifestEntry });
         await prisma.privateShare.create({ data: { shareId: privShareUuid, nodeUUID: node.uuid! } });
-        await validateAndHealDataRefs(node.uuid!, manifestCid, false);
+        await validateAndHealDataRefs({ nodeUuid: node.uuid!, manifestCid, publicRefs: false });
 
         dotlessUuid = node.uuid!.substring(0, node.uuid!.length - 1);
       });
@@ -423,7 +423,8 @@ describe('Data Controllers', () => {
         };
 
         await prisma.dataReference.create({ data: manifestEntry });
-        await validateAndHealDataRefs(node.uuid!, manifestCid, false);
+        await validateAndHealDataRefs({ nodeUuid: node.uuid!, manifestCid, publicRefs: false });
+
         res = await request(app)
           .post(`/v1/data/delete`)
           .set('authorization', authHeaderVal)
@@ -456,11 +457,11 @@ describe('Data Controllers', () => {
         expect(res.statusCode).to.not.equal(200);
       });
       it('should remove deleted content data references', async () => {
-        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences(
-          node.uuid!,
-          res.body.manifestCid,
-          false,
-        );
+        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences({
+          nodeUuid: node.uuid!,
+          manifestCid: res.body.manifestCid,
+          publicRefs: false,
+        });
         const correctRefs = missingRefs.length === 0 && unusedRefs.length === 0 && Object.keys(diffRefs).length === 0;
         expect(correctRefs).to.equal(true);
       });
@@ -534,7 +535,7 @@ describe('Data Controllers', () => {
         };
 
         await prisma.dataReference.create({ data: manifestEntry });
-        await validateAndHealDataRefs(node.uuid!, manifestCid, false);
+        await validateAndHealDataRefs({ nodeUuid: node.uuid!, manifestCid, publicRefs: false });
         res = await request(app)
           .post(`/v1/data/rename`)
           .set('authorization', authHeaderVal)
@@ -579,11 +580,11 @@ describe('Data Controllers', () => {
         expect(res.statusCode).to.not.equal(200);
       });
       it('should rename all appropriate data references', async () => {
-        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences(
-          node.uuid!,
-          res.body.manifestCid,
-          false,
-        );
+        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences({
+          nodeUuid: node.uuid!,
+          manifestCid: res.body.manifestCid,
+          publicRefs: false,
+        });
         const correctRefs = missingRefs.length === 0 && unusedRefs.length === 0 && Object.keys(diffRefs).length === 0;
         expect(correctRefs).to.equal(true);
       });
@@ -678,7 +679,7 @@ describe('Data Controllers', () => {
         };
 
         await prisma.dataReference.create({ data: manifestEntry });
-        await validateAndHealDataRefs(node.uuid!, manifestCid, false);
+        await validateAndHealDataRefs({ nodeUuid: node.uuid!, manifestCid, publicRefs: false });
         res = await request(app)
           .post(`/v1/data/move`)
           .set('authorization', authHeaderVal)
@@ -720,11 +721,11 @@ describe('Data Controllers', () => {
         expect(res.statusCode).to.not.equal(200);
       });
       it('should modify all appropriate data references', async () => {
-        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences(
-          node.uuid!,
-          res.body.manifestCid,
-          false,
-        );
+        const { missingRefs, unusedRefs, diffRefs } = await validateDataReferences({
+          nodeUuid: node.uuid!,
+          manifestCid: res.body.manifestCid,
+          publicRefs: false,
+        });
         const correctRefs = missingRefs.length === 0 && unusedRefs.length === 0 && Object.keys(diffRefs).length === 0;
         expect(correctRefs).to.equal(true);
       });


### PR DESCRIPTION
Closes #107

## Description of the Problem / Feature
- There are two different environments where nodes are currently published; nodes prod, and nodes dev, both don't share the same dbs, when external data is linked in a node, it is required to be marked before generating trees, if we don't know a node contains external data then the tree generation will fail, public data references need to be backfilled on either prod/dev for them to be able to work interchangeably.
- The function to generate a external CID map, marking which data is external only utilized data refs, not public refs, this could lead to a potential issue of external data being deleted in a draft, and the tree not being able to be generated in previous published versions, or future versions.
## Explanation of the solution
- Fixed the backfilling script by adding an option to provide a working tree, this is the most time efficient way to be able to backfill on a different nodes env, especially where large data is involved.
- Fixed the external cid map generation function by making it able to generate an external cid map for a specific published version
