### PR TITLE
Added redis cache invalidation script

### DIFF
--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -15,6 +15,7 @@
     "script:fill-research-fields": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/fill-research-fields.ts",
     "script:fix-data-refs": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/dataRefDoctor.ts",
     "script:active-users": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/activeUsers.ts",
+    "script:invalidate-redis-cache": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/invalidate-redis-cache.ts",
     "build": "rimraf dist && tsc && yarn copy-files",
     "copy-files": "copyfiles -u 1 src/**/*.cjs dist/",
     "generate": "npx prisma generate",

--- a/desci-server/src/scripts/invalidate-redis-cache.ts
+++ b/desci-server/src/scripts/invalidate-redis-cache.ts
@@ -1,0 +1,101 @@
+import { ResearchObjectComponentType } from '@desci-labs/desci-models';
+import axios from 'axios';
+
+import { cleanupManifestUrl } from 'controllers/nodes';
+import parentLogger from 'logger';
+import redisClient from 'redisClient';
+import { getIndexedResearchObjects } from 'theGraph';
+import { hexToCid } from 'utils';
+
+const logger = parentLogger.child({ module: 'SCRIPTS::invalidateRedisKeys' });
+/* 
+
+Usage Examples:
+invalidateByUuid:     OPERATION=invalidateByUuid NODE_UUID=noDeUuiD. npm run script:invalidate-redis-cache
+
+*/
+
+main();
+function main() {
+  const { operation, nodeUuid } = getOperationEnvs();
+
+  switch (operation) {
+    case 'invalidateByUuid':
+      if (!nodeUuid) return logger.error('Missing NODE_UUID or MANIFEST_CID');
+      invalidateByUuid({ nodeUuid });
+      break;
+    default:
+      logger.error('Invalid operation, valid operations include: invalidateByUuid');
+      return;
+  }
+}
+
+function getOperationEnvs() {
+  return {
+    operation: process.env.OPERATION || null,
+    nodeUuid: process.env.NODE_UUID || null,
+  };
+}
+
+async function invalidateByUuid({ nodeUuid }: { nodeUuid: string }) {
+  // Find all published versions of the node
+  if (!nodeUuid.endsWith('.')) nodeUuid += '.';
+  const { researchObjects } = await getIndexedResearchObjects([nodeUuid]);
+  if (!researchObjects.length)
+    logger.error(`[FillPublic] Failed to resolve any public nodes with the uuid: ${nodeUuid}`);
+
+  // Find every manifest CID and root CID for each node, and iterate a deleteKey run over each
+  const indexedNode = researchObjects[0];
+
+  const totalVersionsIndexed = indexedNode.versions.length || 0;
+  try {
+    for (let nodeVersIdx = 0; nodeVersIdx < totalVersionsIndexed; nodeVersIdx++) {
+      logger.info(
+        `[invalidateByUuid] Deleting keys for indexed version: ${nodeVersIdx}, with txHash: ${indexedNode.versions[nodeVersIdx]?.id}`,
+      );
+      const hexCid = indexedNode.versions[nodeVersIdx]?.cid || indexedNode.recentCid;
+      const manifestCid = hexToCid(hexCid);
+      const manifestUrl = cleanupManifestUrl(manifestCid);
+      const manifest = await (await axios.get(manifestUrl)).data;
+      if (!manifest)
+        return logger.error(
+          { manifestUrl, manifestCid },
+          `[invalidateByUuid] Failed to retrieve manifest from ipfs cid: ${manifestCid}`,
+        );
+      const dataBucketCid = manifest.components.find((c) => c.type === ResearchObjectComponentType.DATA_BUCKET)?.payload
+        .cid;
+
+      await deleteKeys(`*${manifestCid}*`);
+      await deleteKeys(`*${dataBucketCid}*`);
+    }
+  } catch (e) {
+    logger.error(
+      {
+        err: e,
+        nodeUuid,
+        totalVersionsIndexed,
+        indexedNode,
+      },
+      `[invalidateByUuid] Failed to invalidate cache keys for node: ${nodeUuid}, error`,
+    );
+  }
+}
+
+async function deleteKeys(pattern: string) {
+  let cursor = 0;
+
+  do {
+    // Scan the Redis keyspace
+    const res = await redisClient.scan(cursor, { MATCH: pattern as string, COUNT: 500 });
+    cursor = res.cursor || 0;
+    const keys = res.keys || [];
+
+    // Delete the keys
+    if (keys?.length > 0) {
+      logger.info({ keys }, `Found ${keys.length} keys, deleting...`);
+      await Promise.all(keys.map(async (key) => await redisClient.del(key)));
+    }
+  } while (cursor !== 0);
+
+  logger.info({ pattern }, `All matching keys deleted.`);
+}


### PR DESCRIPTION
## Description of the Problem / Feature
No easy way to invalidate all cached keys related to a given node uuid
## Explanation of the solution
Added a script to invalidate all cache keys for published nodes by their uuid
## Instructions on making this work
Run the following in desci-server whilst it's running:
OPERATION=invalidateByUuid NODE_UUID=nOdEUuiD npm run script:invalidate-redis-cache
