### PR TITLE
Expand metadata for dirs

### DIFF
--- a/desci-models/src/trees/treeTools.ts
+++ b/desci-models/src/trees/treeTools.ts
@@ -14,6 +14,7 @@ import {
   DrivePath,
   FileDir,
   FileType,
+  NODE_KEEP_FILE,
   RecursiveLsResult,
   VirtualDriveArgs,
 } from "./treeTypes";
@@ -134,6 +135,11 @@ export function convertIpfsTreeToDriveObjectTree(
 export function aggregateContainedComponents(dirDrive: DriveObject) {
   return dirDrive?.contains?.reduce(
     (acc: ContainsComponents, fd: DriveObject) => {
+      if (
+        (fd.type === FileType.FILE && fd.name === ".DS_Store") ||
+        fd.name === NODE_KEEP_FILE
+      )
+        return acc;
       if (fd.type === FileType.DIR && fd.containsComponents)
         acc = addObjectValues(acc, fd.containsComponents);
       const key = fd.componentType as ResearchObjectComponentType;
@@ -142,7 +148,6 @@ export function aggregateContainedComponents(dirDrive: DriveObject) {
       } else {
         acc[key] = 1;
       }
-      // }
       return acc;
     },
     {} as ContainsComponents

--- a/desci-models/src/trees/treeTypes.ts
+++ b/desci-models/src/trees/treeTypes.ts
@@ -18,11 +18,16 @@ export interface DriveObject {
   cid: string;
   type: FileType;
   contains?: Array<DriveObject> | null;
+  containsComponents?: ContainsComponents;
   parent?: DriveObject | FileDir | null;
   path?: string;
   starred?: boolean;
   external?: boolean;
 }
+
+export type ContainsComponents = {
+  [key in ResearchObjectComponentType]?: number;
+};
 
 export type DriveMetadata = CommonComponentPayload & DataComponentMetadata;
 

--- a/desci-models/src/trees/treeTypes.ts
+++ b/desci-models/src/trees/treeTypes.ts
@@ -25,6 +25,8 @@ export interface DriveObject {
   external?: boolean;
 }
 
+export const NODE_KEEP_FILE = ".nodeKeep";
+
 export type ContainsComponents = {
   [key in ResearchObjectComponentType]?: number;
 };


### PR DESCRIPTION
Closes #98

## Description of the Problem / Feature
- Lack of information of a directories contents without potential manual deep traversal of that dir.
## Explanation of the solution
- Expanded the tree generation API to include a property on dirs that reflects the contained components within them, and their aggregate counts.
