### PR TITLE
Bug fix: Diff controller failing to return on diffless size

### DIFF
--- a/desci-server/src/controllers/data/diff.ts
+++ b/desci-server/src/controllers/data/diff.ts
@@ -114,11 +114,16 @@ export const diffData = async (req: Request, res: Response<DiffResponse | ErrorR
     componentsDiff,
   };
 
-  if (treeDiff && sizeDiff && componentsDiff) {
+  const hasDiffs = treeDiff && (sizeDiff !== null || sizeDiff !== undefined) && componentsDiff;
+
+  if (hasDiffs) {
     await setToCache(cacheKey, diffs);
     return res.status(200).json(diffs);
   }
 
-  logger.error({ treeDiff, manifestA, manifestB, dataBucketCidA, dataBucketCidB }, 'Failed to diff trees');
+  logger.error(
+    { diffsSuccessfullyGenerated: hasDiffs, manifestCidA, manifestCidB, dataBucketCidA, dataBucketCidB },
+    'Failed to diff trees',
+  );
   return res.status(400).json({ error: 'Failed to diff trees' });
 };


### PR DESCRIPTION
## Description of the Problem / Feature
- Bug where a 0 size diff prevented the controller from returning
- Cluttered logging for fail condition
## Explanation of the solution
- Fixed check on size diff
- Improved logging output to be less cluttered and show more relevant info for debugging
