### PR TITLE
Tree improvements

### DIFF
--- a/desci-server/src/controllers/data/updateExternalCid.ts
+++ b/desci-server/src/controllers/data/updateExternalCid.ts
@@ -171,7 +171,7 @@ export const updateExternalCid = async (req: Request, res: Response<UpdateRespon
             externalCidMap[file.cid] = { size: file.size, directory: file.type === 'dir', path: file.path };
           }
         });
-        debugger;
+        // debugger;
         externalDagsToPin.push(extCid.cid);
       }
       uploaded.push({
@@ -400,7 +400,7 @@ export const updateExternalCid = async (req: Request, res: Response<UpdateRespon
           description: '[UPDATE DATASET E:2] FILES PINNED WITH DB ENTRY FAILURE (update v2)',
           cid: extDagCid,
           type: DataType.UNKNOWN,
-          size: extTypeAndSize.size || 0,
+          size: extTypeAndSize?.size || 0,
           nodeId: node.id,
           userId: owner.id,
           directory: extTypeAndSize.directory,

--- a/desci-server/src/utils/driveUtils.ts
+++ b/desci-server/src/utils/driveUtils.ts
@@ -32,9 +32,10 @@ export function fillDirSizes(tree, cidInfoMap) {
 
 // Fills in the access status of CIDs and dates
 export function fillCidInfo(tree, cidInfoMap) {
+  // debugger;
   const contains = [];
   tree.forEach((fd) => {
-    if (fd.type === 'dir') fd.contains = fillCidInfo(fd.contains, cidInfoMap);
+    if (fd.type === 'dir' && fd.contains?.length) fd.contains = fillCidInfo(fd.contains, cidInfoMap);
     fd.date = cidInfoMap[fd.cid]?.date || Date.now();
     fd.published = cidInfoMap[fd.cid]?.published;
     contains.push(fd);
@@ -126,6 +127,7 @@ export async function getTreeAndFill(
   ownerId?: number,
   published?: boolean,
 ) {
+  // debugger;
   const rootCid = manifest.components.find((c) => c.type === ResearchObjectComponentType.DATA_BUCKET).payload.cid;
   const externalCidMap = published
     ? await generateExternalCidMap(nodeUuid + '.', rootCid)
@@ -162,7 +164,7 @@ export async function getTreeAndFill(
   if (privEntries.length | pubEntries.length) {
     const pubCids: Record<string, boolean> = {};
     pubEntries.forEach((e) => (pubCids[e.cid] = true));
-
+    // debugger;
     // Build cidInfoMap
     privEntries.forEach((ref) => {
       if (pubCids[ref.cid]) return; // Skip if there's a pub entry


### PR DESCRIPTION
## Description of the Problem / Feature
- Bug where empty dirs were being passed in a function that expected non empty dirs
- On resolution failure, failing CID isn't logged
## Explanation of the solution
- Fixed empty dir bug
- Improved logging to know which CID failed to resolve

