### PR TITLE
Clone node script

### DIFF
--- a/desci-server/src/scripts/dataRefDoctor.ts
+++ b/desci-server/src/scripts/dataRefDoctor.ts
@@ -24,12 +24,12 @@ Usage Guidelines:
 Operation Types [validate, heal, validateAll, healAll]
 
 Usage Examples:
-validate:     OPERATION=validate NODE_UUID=noDeUuiD. MANIFEST_CID=bafkabc123 PUBLIC_REFS=true npm run script:fix-data-refs
-heal:         OPERATION=heal NODE_UUID=noDeUuiD. MANIFEST_CID=bafkabc123 PUBLIC_REFS=true npm run script:fix-data-refs
-validateAll:  OPERATION=validateAll PUBLIC_REFS=true npm run script:fix-data-refs
-healAll:      OPERATION=healAll PUBLIC_REFS=true npm run script:fix-data-refs
-fillPublic:   OPERATION=fillPublic USER_EMAIL=noreply@desci.com NODE_UUID=noDeUuiD. npm run script:fix-data-refs
-fillPublic:   OPERATION=clonePrivateNode NODE_UUID=noDeUuiD. NEW_NODE_UUID=nEwnoDeUuiD2. npm run script:fix-data-refs
+validate:         OPERATION=validate NODE_UUID=noDeUuiD. MANIFEST_CID=bafkabc123 PUBLIC_REFS=true npm run script:fix-data-refs
+heal:             OPERATION=heal NODE_UUID=noDeUuiD. MANIFEST_CID=bafkabc123 PUBLIC_REFS=true npm run script:fix-data-refs
+validateAll:      OPERATION=validateAll PUBLIC_REFS=true npm run script:fix-data-refs
+healAll:          OPERATION=healAll PUBLIC_REFS=true npm run script:fix-data-refs
+fillPublic:       OPERATION=fillPublic USER_EMAIL=noreply@desci.com NODE_UUID=noDeUuiD. npm run script:fix-data-refs
+clonePrivateNode: OPERATION=clonePrivateNode NODE_UUID=noDeUuiD. NEW_NODE_UUID=nEwnoDeUuiD2. npm run script:fix-data-refs
 
 Heal external flag in refs:
 healAll:      OPERATION=healAll PUBLIC_REFS=true MARK_EXTERNALS=true npm run script:fix-data-refs


### PR DESCRIPTION
## Description of the Problem / Feature
Cloning a node is useful for testing purposes, at the moment no functionality like so exists.
## Explanation of the solution
Added a script to clone draft mode nodes.
## Instructions on making this work
Create a fresh empty node, copy its UUID and run the script
`OPERATION=clonePrivateNode NODE_UUID=noDeUuiD. NEW_NODE_UUID=nEwnoDeUuiD2. npm run script:fix-data-refs`
