### PR TITLE
Bug-fix: Fix diff pruning

### DIFF
--- a/desci-server/src/utils/diffUtils.ts
+++ b/desci-server/src/utils/diffUtils.ts
@@ -35,12 +35,13 @@ export function diffTrees(treeA: DriveObject[], treeB: DriveObject[], options: D
   }, {});
 
   const prune = (category) => {
+    const treeMap = category === 'removed' ? treeBMap : treeAMap;
     if (
       options.pruneThreshold &&
       diff[category].count > options.pruneThreshold &&
       options.onThresholdExceeded?.onlyDirectories
     ) {
-      diff[category].entries = diff[category].entries.filter((path) => treeAMap[path]?.type === FileType.DIR);
+      diff[category].entries = diff[category].entries.filter((path) => treeMap[path]?.type === FileType.DIR);
     }
   };
 


### PR DESCRIPTION
## Description of the Problem / Feature
- When 'removed' diff entries are pruned, it results in an empty result.
## Explanation of the solution
- Wrong map was being used to prune removed entries, fixed.
