### PR TITLE
Memory fix for repo data uploads

### DIFF
--- a/desci-server/src/controllers/data/update.ts
+++ b/desci-server/src/controllers/data/update.ts
@@ -132,6 +132,8 @@ export const update = async (req: Request, res: Response<UpdateResponse | ErrorR
       .status(400)
       .json({ error: 'Choose between one of the following; files, new folder, externalUrl or externalCids' });
 
+  debugger;
+
   /*
    ** External URL setup, currnetly used for Github Code Repositories & external PDFs
    */
@@ -274,7 +276,9 @@ export const update = async (req: Request, res: Response<UpdateResponse | ErrorR
   if (zipPath.length > 0) {
     const outputPath = zipPath.replace('.zip', '');
     logger.debug({ outputPath }, 'Starting unzipping to output directory');
+    console.log('[STREAMDBG start3 pre-unzip] mem: ', process.memoryUsage());
     await extractZipFileAndCleanup(zipPath, outputPath);
+    console.log('[STREAMDBG end3 unzip-finish] mem: ', process.memoryUsage());
     logger.debug({ outputPath }, 'extraction complete, starting pinning');
     const pinResult = await addDirToIpfs(outputPath);
 

--- a/desci-server/src/controllers/data/update.ts
+++ b/desci-server/src/controllers/data/update.ts
@@ -132,7 +132,7 @@ export const update = async (req: Request, res: Response<UpdateResponse | ErrorR
       .status(400)
       .json({ error: 'Choose between one of the following; files, new folder, externalUrl or externalCids' });
 
-  debugger;
+  // debugger;
 
   /*
    ** External URL setup, currnetly used for Github Code Repositories & external PDFs
@@ -276,9 +276,7 @@ export const update = async (req: Request, res: Response<UpdateResponse | ErrorR
   if (zipPath.length > 0) {
     const outputPath = zipPath.replace('.zip', '');
     logger.debug({ outputPath }, 'Starting unzipping to output directory');
-    console.log('[STREAMDBG start3 pre-unzip] mem: ', process.memoryUsage());
     await extractZipFileAndCleanup(zipPath, outputPath);
-    console.log('[STREAMDBG end3 unzip-finish] mem: ', process.memoryUsage());
     logger.debug({ outputPath }, 'extraction complete, starting pinning');
     const pinResult = await addDirToIpfs(outputPath);
 

--- a/desci-server/src/services/ipfs.ts
+++ b/desci-server/src/services/ipfs.ts
@@ -1004,21 +1004,6 @@ export interface ZipToDagAndPinResult {
   totalSize: number;
 }
 
-// Adds a directory to IPFS and deletes the directory after, returning the root CID
-// export async function addDirToIpfs(directoryPath: string): Promise<IpfsPinnedResult[]> {
-//   // Add all files in the directory to IPFS using globSource
-//   const files = [];
-
-//   const source = globSource(directoryPath, '**/*', { hidden: true });
-//   for await (const file of client.addAll(source, { cidVersion: 1 })) {
-//     files.push({ path: file.path, cid: file.cid.toString(), size: file.size });
-//   }
-//   const totalFiles = files.length;
-//   const rootDag = files[totalFiles - 1];
-//   logger.info({ fn: 'addDirToIpfs', rootDag, totalFiles }, 'Files added to IPFS:');
-//   return files;
-// }
-
 export async function addDirToIpfs(directoryPath: string): Promise<IpfsPinnedResult[]> {
   const files = [];
 

--- a/desci-server/src/utils.ts
+++ b/desci-server/src/utils.ts
@@ -93,7 +93,7 @@ export async function zipUrlToStream(url: string): Promise<Readable> {
 export async function calculateTotalZipUncompressedSize(zipPath: string): Promise<number> {
   return new Promise((resolve, reject) => {
     let totalSize = 0;
-
+    console.log('[STREAMDBG start2] mem: ', process.memoryUsage());
     yauzl.open(zipPath, { lazyEntries: true }, (err, zipfile) => {
       if (err) reject(err);
 
@@ -109,6 +109,7 @@ export async function calculateTotalZipUncompressedSize(zipPath: string): Promis
       zipfile.on('end', () => {
         resolve(totalSize);
         zipfile.close();
+        console.log('[STREAMDBG end2] mem: ', process.memoryUsage());
       });
 
       zipfile.on('error', (err) => {
@@ -178,6 +179,7 @@ export async function extractZipFileAndCleanup(zipFilePath: string, outputDirect
 
 export async function saveZipStreamToDisk(zipStream: Readable, outputPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
+    console.log('[STREAMDBG start1] mem: ', process.memoryUsage());
     // Create a writable stream to the output file
     const fileStream = fs.createWriteStream(outputPath);
 
@@ -187,6 +189,7 @@ export async function saveZipStreamToDisk(zipStream: Readable, outputPath: strin
     fileStream.on('error', reject);
 
     fileStream.on('finish', resolve);
+    console.log('[STREAMDBG end1] mem: ', process.memoryUsage());
   });
 }
 

--- a/desci-server/src/utils.ts
+++ b/desci-server/src/utils.ts
@@ -93,7 +93,6 @@ export async function zipUrlToStream(url: string): Promise<Readable> {
 export async function calculateTotalZipUncompressedSize(zipPath: string): Promise<number> {
   return new Promise((resolve, reject) => {
     let totalSize = 0;
-    console.log('[STREAMDBG start2] mem: ', process.memoryUsage());
     yauzl.open(zipPath, { lazyEntries: true }, (err, zipfile) => {
       if (err) reject(err);
 
@@ -109,7 +108,6 @@ export async function calculateTotalZipUncompressedSize(zipPath: string): Promis
       zipfile.on('end', () => {
         resolve(totalSize);
         zipfile.close();
-        console.log('[STREAMDBG end2] mem: ', process.memoryUsage());
       });
 
       zipfile.on('error', (err) => {
@@ -179,7 +177,6 @@ export async function extractZipFileAndCleanup(zipFilePath: string, outputDirect
 
 export async function saveZipStreamToDisk(zipStream: Readable, outputPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    console.log('[STREAMDBG start1] mem: ', process.memoryUsage());
     // Create a writable stream to the output file
     const fileStream = fs.createWriteStream(outputPath);
 
@@ -189,7 +186,6 @@ export async function saveZipStreamToDisk(zipStream: Readable, outputPath: strin
     fileStream.on('error', reject);
 
     fileStream.on('finish', resolve);
-    console.log('[STREAMDBG end1] mem: ', process.memoryUsage());
   });
 }
 


### PR DESCRIPTION
## Description of the Problem / Feature
- Leak in stream data flow causing OOM issues when adding repos
## Explanation of the solution
- One point in the repo upload flow was pushing all file contents into a buffer, should be fixed.
## Instructions on making this work
Needs live testing

