### PR TITLE
Auth Cookies for SSR

### DIFF
--- a/desci-server/prisma/migrations/20230904170249_add_failed_attempts/migration.sql
+++ b/desci-server/prisma/migrations/20230904170249_add_failed_attempts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MagicLink" ADD COLUMN     "failedAttempts" INTEGER NOT NULL DEFAULT 0;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -240,12 +240,13 @@ model ChainTransaction {
 }
 
 model MagicLink {
-  id        Int      @id @default(autoincrement())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  expiresAt DateTime @default(dbgenerated("(now() + '01:00:00'::interval)"))
-  token     String
-  email     String
+  id             Int      @id @default(autoincrement())
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  expiresAt      DateTime @default(dbgenerated("(now() + '01:00:00'::interval)"))
+  failedAttempts Int      @default(0)
+  token          String
+  email          String
 }
 
 model OauthAccessToken {

--- a/desci-server/src/controllers/auth/magic.ts
+++ b/desci-server/src/controllers/auth/magic.ts
@@ -6,9 +6,10 @@ import logger from 'logger';
 import { magicLinkRedeem, sendMagicLink } from 'services/auth';
 import { saveInteraction } from 'services/interactionLog';
 
-const generateAccessToken = (payload) => {
+export const generateAccessToken = (payload) => {
   return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1y' });
 };
+
 const oneYear = 1000 * 60 * 60 * 24 * 365;
 export const magic = async (req: Request, res: Response, next: NextFunction) => {
   if (process.env.NODE_ENV === 'production') {

--- a/desci-server/src/controllers/auth/magic.ts
+++ b/desci-server/src/controllers/auth/magic.ts
@@ -34,10 +34,10 @@ export const magic = async (req: Request, res: Response, next: NextFunction) => 
         maxAge: oneYear,
         httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
         secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
+        sameSite: 'lax', // Desired for instant auth
       });
 
-      // Bearer token still returned for backwards compatability, should look to remove in the future.
+      // TODO: Bearer token still returned for backwards compatability, should look to remove in the future.
       res.send({ ok: true, user: { email: user.email, token } });
       saveInteraction(req, ActionType.USER_LOGIN, { userId: user.id }, user.id);
     } catch (err) {

--- a/desci-server/src/controllers/auth/magic.ts
+++ b/desci-server/src/controllers/auth/magic.ts
@@ -11,7 +11,12 @@ const generateAccessToken = (payload) => {
 };
 const oneYear = 1000 * 60 * 60 * 24 * 365;
 export const magic = async (req: Request, res: Response, next: NextFunction) => {
-  logger.info({ fn: 'magic', reqBody: req.body }, `magic link ${req.body}`);
+  if (process.env.NODE_ENV === 'production') {
+    logger.info({ fn: 'magic', email: req.body.email }, `magic link requested`);
+  } else {
+    logger.info({ fn: 'magic', reqBody: req.body }, `magic link ${req.body}`);
+  }
+
   const { email, code } = req.body;
   if (!code) {
     try {
@@ -24,6 +29,15 @@ export const magic = async (req: Request, res: Response, next: NextFunction) => 
     try {
       const user = await magicLinkRedeem(email, code);
       const token = generateAccessToken({ email: user.email });
+
+      res.cookie('auth', token, {
+        maxAge: oneYear,
+        httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+      });
+
+      // Bearer token still returned for backwards compatability, should look to remove in the future.
       res.send({ ok: true, user: { email: user.email, token } });
       saveInteraction(req, ActionType.USER_LOGIN, { userId: user.id }, user.id);
     } catch (err) {

--- a/desci-server/src/middleware/checkJwt.ts
+++ b/desci-server/src/middleware/checkJwt.ts
@@ -6,13 +6,21 @@ import { createJwtToken } from '../utils/createJwtToken';
 import { CustomError } from '../utils/response/custom-error/CustomError';
 
 export const checkJwt = (req: Request, res: Response, next: NextFunction) => {
-  const authHeader = req.get('Authorization');
-  if (!authHeader) {
-    const customError = new CustomError(400, 'General', 'Authorization header not provided');
-    return next(customError);
+  let token: string | undefined;
+
+  // Check if the token exists in the cookie
+  if (req.cookies && req.cookies.auth_token) {
+    token = req.cookies.auth_token;
+  } else {
+    // If not in the cookie, check the auth header
+    const authHeader = req.get('Authorization');
+    if (!authHeader) {
+      const customError = new CustomError(400, 'General', 'Authorization header not provided');
+      return next(customError);
+    }
+    token = authHeader.split(' ')[1];
   }
 
-  const token = authHeader.split(' ')[1];
   let jwtPayload: { [key: string]: any };
   try {
     jwtPayload = jwt.verify(token, process.env.JWT_SECRET as string) as { [key: string]: any };
@@ -26,7 +34,16 @@ export const checkJwt = (req: Request, res: Response, next: NextFunction) => {
   try {
     // Refresh and send a new token on every request
     const newToken = createJwtToken(jwtPayload as JwtPayload);
+
+    // TODO: Bearer token still returned for backwards compatability, should look to remove in the future.
     res.setHeader('token', `Bearer ${newToken}`);
+
+    res.cookie('auth_token', newToken, {
+      httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    });
+
     return next();
   } catch (err) {
     const customError = new CustomError(400, 'Raw', "Token can't be created", null, err);

--- a/desci-server/src/middleware/ensureUser.ts
+++ b/desci-server/src/middleware/ensureUser.ts
@@ -21,7 +21,7 @@ export const ensureUser = async (req: Request, res: Response, next: NextFunction
 
 export const retrieveUser = async (req: Request): Promise<User | null> => {
   let token: string | undefined;
-
+  // debugger;
   // Try to retrieve the token from the auth header
   const authHeader = req.headers['authorization'];
   if (authHeader) {

--- a/desci-server/src/middleware/ensureUser.ts
+++ b/desci-server/src/middleware/ensureUser.ts
@@ -19,29 +19,37 @@ export const ensureUser = async (req: Request, res: Response, next: NextFunction
   next();
 };
 
-export const retrieveUser = async (req: Request): Promise<User> => {
+export const retrieveUser = async (req: Request): Promise<User | null> => {
+  let token: string | undefined;
+
+  // Try to retrieve the token from the auth header
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  if (authHeader) {
+    token = authHeader.split(' ')[1];
+  }
+
+  // If auth token wasn't found in the header, try retrieve from cookies
+  if (!token && req.cookies) {
+    token = req.cookies['auth'];
+  }
 
   return new Promise(async (success, fail) => {
-    if (token == null) {
+    if (!token) {
       success(null);
-      return null;
+      return;
     }
+
     jwt.verify(token, process.env.JWT_SECRET as string, async (err: any, user: any) => {
       if (err) {
         // anonymous user
         logger.info({ module: 'retrieveUserMiddleware', authHeader, token }, 'anon request');
-        // console.log(err);
+        success(null);
+        return;
       }
 
-      if (err) {
-        success(null);
-        return null;
-      }
       if (!user) {
         success(null);
-        return null;
+        return;
       }
 
       const loggedInUserEmail = user.email as string;
@@ -53,7 +61,7 @@ export const retrieveUser = async (req: Request): Promise<User> => {
 
       if (!retrievedUser || !retrievedUser.id) {
         success(null);
-        return null;
+        return;
       }
 
       success(retrievedUser);

--- a/desci-server/src/services/auth.ts
+++ b/desci-server/src/services/auth.ts
@@ -33,6 +33,9 @@ const magicLinkRedeem = async (email: string, token: string): Promise<User> => {
     where: {
       email,
     },
+    orderBy: {
+      createdAt: 'desc',
+    },
   });
 
   if (!link) {

--- a/desci-server/test/integration/auth.test.ts
+++ b/desci-server/test/integration/auth.test.ts
@@ -1,9 +1,14 @@
 import 'mocha';
-import { User, MagicLink } from '@prisma/client';
+import { User } from '@prisma/client';
 import { expect } from 'chai';
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import supertest from 'supertest';
 
 import prisma from '../../src/client';
-import * as auth from '../../src/services/auth';
+import { generateAccessToken } from '../../src/controllers/auth/magic';
+import { ensureUser, retrieveUser } from '../../src/middleware/ensureUser';
+import { magicLinkRedeem, sendMagicLink } from '../../src/services/auth';
 import { expectThrowsAsync } from '../util';
 
 describe('Magic Link Authentication', () => {
@@ -27,21 +32,21 @@ describe('Magic Link Authentication', () => {
 
   describe('Magic Link Creation', () => {
     it('should create a magic link for an existing user', async () => {
-      const result = await auth.sendMagicLink(user.email);
+      const result = await sendMagicLink(user.email);
       expect(result).to.be.true;
     });
 
     describe('Magic Link Rate Limiting', () => {
       it('should not allow generating a magic link within 30 seconds of the last one', async () => {
-        await auth.sendMagicLink(user.email);
+        await sendMagicLink(user.email);
         await expectThrowsAsync(
-          () => auth.sendMagicLink(user.email),
+          () => sendMagicLink(user.email),
           'A magic link was recently generated. Please wait 30 seconds before requesting another.',
         );
       });
 
       it('should allow generating a magic link after 30 seconds of the last one', async () => {
-        await auth.sendMagicLink(user.email);
+        await sendMagicLink(user.email);
         const latestMagicLink = await prisma.magicLink.findFirst({
           where: {
             email: user.email,
@@ -56,7 +61,7 @@ describe('Magic Link Authentication', () => {
             data: { createdAt: new Date(Date.now() - 31 * 1000) }, // Set to 31 seconds ago
           });
         }
-        const result = await auth.sendMagicLink(user.email);
+        const result = await sendMagicLink(user.email);
         expect(result).to.be.true;
       });
     });
@@ -64,7 +69,7 @@ describe('Magic Link Authentication', () => {
 
   describe('Magic Link Redemption', () => {
     it('should redeem a valid magic link', async () => {
-      await auth.sendMagicLink(user.email);
+      await sendMagicLink(user.email);
       const magicLink = await prisma.magicLink.findFirst({
         where: {
           email: user.email,
@@ -73,12 +78,12 @@ describe('Magic Link Authentication', () => {
           createdAt: 'desc',
         },
       });
-      const redeemedUser = await auth.magicLinkRedeem(user.email, magicLink!.token);
+      const redeemedUser = await magicLinkRedeem(user.email, magicLink!.token);
       expect(redeemedUser.email).to.equal(user.email);
     });
 
     it('should not redeem an expired magic link', async () => {
-      await auth.sendMagicLink(user.email);
+      await sendMagicLink(user.email);
       const magicLink = await prisma.magicLink.findFirst({
         where: {
           email: user.email,
@@ -92,11 +97,11 @@ describe('Magic Link Authentication', () => {
         where: { id: magicLink!.id },
         data: { expiresAt: new Date('1980-01-01') },
       });
-      await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, magicLink!.token), 'Invalid token.');
+      await expectThrowsAsync(() => magicLinkRedeem(user.email, magicLink!.token), 'Invalid token.');
     });
 
     it('should not redeem a magic link more than once', async () => {
-      await auth.sendMagicLink(user.email);
+      await sendMagicLink(user.email);
       const magicLink = await prisma.magicLink.findFirst({
         where: {
           email: user.email,
@@ -105,12 +110,12 @@ describe('Magic Link Authentication', () => {
           createdAt: 'desc',
         },
       });
-      await auth.magicLinkRedeem(user.email, magicLink!.token);
-      await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, magicLink!.token), 'Invalid token.');
+      await magicLinkRedeem(user.email, magicLink!.token);
+      await expectThrowsAsync(() => magicLinkRedeem(user.email, magicLink!.token), 'Invalid token.');
     });
 
     it('should invalidate a magic link after 5 failed attempts', async () => {
-      await auth.sendMagicLink(user.email);
+      await sendMagicLink(user.email);
       const magicLink = await prisma.magicLink.findFirst({
         where: {
           email: user.email,
@@ -120,17 +125,88 @@ describe('Magic Link Authentication', () => {
         },
       });
       for (let i = 0; i < 5; i++) {
-        await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, 'invalidToken'), 'Invalid token.');
+        await expectThrowsAsync(() => magicLinkRedeem(user.email, 'invalidToken'), 'Invalid token.');
       }
       await expectThrowsAsync(
-        () => auth.magicLinkRedeem(user.email, magicLink!.token),
+        () => magicLinkRedeem(user.email, magicLink!.token),
         'Too many failed attempts. Token invalidated.',
       );
     });
 
     it('should not redeem a magic link with an invalid token', async () => {
-      await auth.sendMagicLink(user.email);
-      await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, 'invalidToken'), 'Invalid token.');
+      await sendMagicLink(user.email);
+      await expectThrowsAsync(() => magicLinkRedeem(user.email, 'invalidToken'), 'Invalid token.');
+    });
+  });
+});
+
+describe('Auth Middleware', () => {
+  let app: express.Express;
+  let mockUser: User;
+  let mockToken: string;
+  let request: supertest.SuperTest<supertest.Test>;
+
+  before(async () => {
+    await prisma.$queryRaw`TRUNCATE TABLE "User" CASCADE;`;
+
+    app = express();
+    app.use(cookieParser());
+
+    // Mock route that uses the auth middleware
+    app.get('/test', ensureUser, (req, res) => {
+      const user = (req as any).user;
+      res.send(user);
+    });
+
+    mockUser = await prisma.user.create({
+      data: {
+        email: 'test@desci.com',
+      },
+    });
+
+    mockToken = generateAccessToken({ email: mockUser.email });
+
+    request = supertest(app);
+  });
+
+  describe('retrieveUser', () => {
+    it('should retrieve user from auth header', async () => {
+      const response = await request.get('/test').set('authorization', `Bearer ${mockToken}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.email).to.equal(mockUser.email);
+    });
+
+    it('should retrieve user from cookies', async () => {
+      const response = await request.get('/test').set('Cookie', [`auth=${mockToken}`]);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.email).to.equal(mockUser.email);
+    });
+
+    it('should return 401 if no token is provided', async () => {
+      const response = await request.get('/test');
+      expect(response.status).to.equal(401);
+    });
+
+    it('should return 401 for invalid token', async () => {
+      const response = await request.get('/test').set('authorization', 'Bearer invalidToken');
+
+      expect(response.status).to.equal(401);
+    });
+  });
+
+  describe('ensureUser', () => {
+    it('should set req.user if user is retrieved', async () => {
+      const response = await request.get('/test').set('authorization', `Bearer ${mockToken}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.email).to.equal(mockUser.email);
+    });
+
+    it('should send 401 if no user is retrieved', async () => {
+      const response = await request.get('/test');
+      expect(response.status).to.equal(401);
     });
   });
 });

--- a/desci-server/test/integration/auth.test.ts
+++ b/desci-server/test/integration/auth.test.ts
@@ -1,0 +1,111 @@
+import 'mocha';
+import { User, MagicLink } from '@prisma/client';
+import { expect } from 'chai';
+
+import prisma from '../../src/client';
+import * as auth from '../../src/services/auth';
+import { expectThrowsAsync } from '../util';
+
+describe('Magic Link Authentication', () => {
+  let user: User;
+
+  before(async () => {});
+
+  after(async () => {});
+
+  beforeEach(async () => {
+    await prisma.$queryRaw`TRUNCATE TABLE "MagicLink" CASCADE;`;
+    await prisma.$queryRaw`TRUNCATE TABLE "User" CASCADE;`;
+    user = await prisma.user.create({
+      data: {
+        email: 'test@desci.com',
+      },
+    });
+  });
+
+  afterEach(async () => {});
+
+  describe('Magic Link Creation', () => {
+    it('should create a magic link for an existing user', async () => {
+      const result = await auth.sendMagicLink(user.email);
+      expect(result).to.be.true;
+    });
+
+    // it('should create a magic link for a new email', async () => {
+    //   const result = await auth.sendMagicLink('newuser@desci.com');
+    //   expect(result).to.be.true;
+    // });
+  });
+
+  describe('Magic Link Redemption', () => {
+    it('should redeem a valid magic link', async () => {
+      await auth.sendMagicLink(user.email);
+      const magicLink = await prisma.magicLink.findFirst({
+        where: {
+          email: user.email,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+      const redeemedUser = await auth.magicLinkRedeem(user.email, magicLink!.token);
+      expect(redeemedUser.email).to.equal(user.email);
+    });
+
+    it('should not redeem an expired magic link', async () => {
+      await auth.sendMagicLink(user.email);
+      const magicLink = await prisma.magicLink.findFirst({
+        where: {
+          email: user.email,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+
+      await prisma.magicLink.update({
+        where: { id: magicLink!.id },
+        data: { expiresAt: new Date('1980-01-01') },
+      });
+      await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, magicLink!.token), 'Invalid token.');
+    });
+
+    it('should not redeem a magic link more than once', async () => {
+      await auth.sendMagicLink(user.email);
+      const magicLink = await prisma.magicLink.findFirst({
+        where: {
+          email: user.email,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+      await auth.magicLinkRedeem(user.email, magicLink!.token);
+      await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, magicLink!.token), 'Invalid token.');
+    });
+
+    it('should invalidate a magic link after 5 failed attempts', async () => {
+      await auth.sendMagicLink(user.email);
+      const magicLink = await prisma.magicLink.findFirst({
+        where: {
+          email: user.email,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+      for (let i = 0; i < 5; i++) {
+        await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, 'invalidToken'), 'Invalid token.');
+      }
+      await expectThrowsAsync(
+        () => auth.magicLinkRedeem(user.email, magicLink!.token),
+        'Too many failed attempts. Token invalidated.',
+      );
+    });
+
+    it('should not redeem a magic link with an invalid token', async () => {
+      await auth.sendMagicLink(user.email);
+      await expectThrowsAsync(() => auth.magicLinkRedeem(user.email, 'invalidToken'), 'Invalid token.');
+    });
+  });
+});


### PR DESCRIPTION
## Description of the Problem / Feature
- For V2 that's using SSR the bearer token wouldn't be passed on first loads.
- Few vulnerabilities
## Explanation of the solution
- Added cookie auth
- Mitigated potential auth vulnerabilities
- Added tests to test a few core auth flows
## Instructions on making this work
**CONTAINS MIGRATIONS**
Extra considerations: 
- Consider using CSRF tokens since cookies are now valid
- httpOnly property enabled but still sending back bearer for backwards compatibility still gives exposure to auth XSS, consider removing bearer token header in the future
