### PR TITLE
Dev Cookie fixes

### DIFF
--- a/desci-server/src/controllers/auth/magic.ts
+++ b/desci-server/src/controllers/auth/magic.ts
@@ -46,7 +46,7 @@ export const magic = async (req: Request, res: Response, next: NextFunction) => 
         res.cookie('auth', token, {
           maxAge: oneDay,
           httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
+          // secure: process.env.NODE_ENV === 'production', // unsafe, but only used for local dev
           domain: 'localhost', // unsafe
           sameSite: 'strict',
         });

--- a/desci-server/src/controllers/auth/magic.ts
+++ b/desci-server/src/controllers/auth/magic.ts
@@ -40,7 +40,7 @@ export const magic = async (req: Request, res: Response, next: NextFunction) => 
         sameSite: 'strict',
       });
 
-      if (dev === 'true') {
+      if (dev === 'true' && process.env.SERVER_URL === 'https://nodes-api-dev.desci.com') {
         // insecure cookie for local dev, should only be used for testing
         logger.info({ fn: 'magic', email: req.body.email }, `insecure dev cookie set`);
         res.cookie('auth', token, {


### PR DESCRIPTION
## Description of the Problem / Feature
- Dev cookie available on prod
- Dev cookie doesn't save in a localhost with tls disabled frontend environment
## Explanation of the solution
- Restrict the dev cookie to only be usable in the dev testing API backend
- Secure flag disabled for the dev cookie
