### PR TITLE
Fix external CID import bug

### DIFF
--- a/desci-server/src/controllers/data/updateExternalCid.ts
+++ b/desci-server/src/controllers/data/updateExternalCid.ts
@@ -75,7 +75,7 @@ export const updateExternalCid = async (req: Request, res: Response<UpdateRespon
   // const isContextExternal = Object.values(externalCidMap).some((extDag) => neutralizePath(extDag.path) === contextPath);
 
   const cidTypesSizes: Record<string, GetExternalSizeAndTypeResult> = {};
-  if (externalCids && externalCids.length && componentType === ResearchObjectComponentType.DATA) {
+  if (externalCids && externalCids.length) {
     try {
       externalCids = externalCids.map((extCid) => ({ ...extCid, cid: convertToCidV1(extCid.cid) }));
       for (const extCid of externalCids) {


### PR DESCRIPTION
## Description of the Problem / Feature
- A check in the code to ensure external cids being imported were data components created a bug that caused a situation where external DAG's were pinned, though not added to the research object's DAG.
- No good reason to restrict external CIDs to be data only, no issue with allowing the component type to be flexible.
## Explanation of the solution
- Simply removing that single check alleviates all issues.