### PR TITLE
Cover image models

### DIFF
--- a/desci-models/src/ResearchObject.ts
+++ b/desci-models/src/ResearchObject.ts
@@ -19,7 +19,7 @@ export interface ResearchObjectV1 extends ResearchObject {
   version: "desci-nodes-0.1.0" | "desci-nodes-0.2.0" | 1;
   title?: string;
   defaultLicense?: string;
-  image?: string | IpldUrl;
+  coverImage?: string | IpldUrl;
   components: ResearchObjectV1Component[];
   validations?: ResearchObjectV1Validation[];
   attributes?: ResearchObjectV1Attributes[];
@@ -260,7 +260,7 @@ export interface ResearchObjectComponentAnnotation {
   id: string;
   authorId?: string;
   author?: ResearchObjectV1Author;
-};
+}
 
 export enum ResearchObjectV1AuthorRole {
   AUTHOR = "Author",


### PR DESCRIPTION
## Description of the Problem / Feature
- 'image' property in the manifest was confusing, it was never used either.
## Explanation of the solution
- Renamed to 'coverImage', before we start using it.

