### PR TITLE
update drive storage space default

### DIFF
--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -16,6 +16,7 @@
     "script:fix-data-refs": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/dataRefDoctor.ts",
     "script:active-users": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/activeUsers.ts",
     "script:invalidate-redis-cache": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/invalidate-redis-cache.ts",
+    "script:increase-base-drive-storage": "debug=* NODE_PATH=./src ts-node-dev ./src/scripts/increase-base-drive-storage.ts",
     "build": "rimraf dist && tsc && yarn copy-files",
     "copy-files": "copyfiles -u 1 src/**/*.cjs dist/",
     "generate": "npx prisma generate",

--- a/desci-server/prisma/migrations/20231108232618_default_drive_gb/migration.sql
+++ b/desci-server/prisma/migrations/20231108232618_default_drive_gb/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "currentDriveStorageLimitGb" SET DEFAULT 100,
+ALTER COLUMN "maxDriveStorageLimitGb" SET DEFAULT 500;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -162,8 +162,8 @@ model User {
   CidPruneList               CidPruneList[]
   PublicDataReference        PublicDataReference[]
   FriendReferral             FriendReferral[]
-  currentDriveStorageLimitGb Int                   @default(5)
-  maxDriveStorageLimitGb     Int                   @default(250)
+  currentDriveStorageLimitGb Int                   @default(100)
+  maxDriveStorageLimitGb     Int                   @default(500)
   userOrganizations          UserOrganizations[]
 
   @@index([orcid])

--- a/desci-server/src/scripts/increase-base-drive-storage.ts
+++ b/desci-server/src/scripts/increase-base-drive-storage.ts
@@ -1,0 +1,60 @@
+import dotenv from 'dotenv';
+
+import prisma from 'client';
+dotenv.config({ path: '../.env' });
+
+export const increaseBaseDriveStoragePreview = async (targetDriveStorageGb: number, shouldApply: boolean) => {
+  const userCount = prisma.user.aggregate({
+    // prisma count aggregation
+    // https://www.prisma.io/docs/concepts/components/prisma-client/aggregation#count
+    _count: {
+      id: true,
+    },
+    where: {
+      currentDriveStorageLimitGb: {
+        lt: targetDriveStorageGb,
+      },
+    },
+  });
+
+  // get total users
+  const totalUserCount = await prisma.user.count();
+
+  const userStorageCount = prisma.$queryRaw`select count(1), "currentDriveStorageLimitGb" from "User" group by "currentDriveStorageLimitGb"`;
+
+  console.log(
+    `[increasesBaseDriveStorage] Affected users found: ${(await userCount)._count.id}/${totalUserCount} (${
+      Math.floor(((await userCount)._count.id / totalUserCount) * 10000) / 100
+    }%)`,
+  );
+
+  console.log(await userStorageCount);
+
+  if (shouldApply) {
+    // update users
+    const users = await prisma.user.updateMany({
+      where: {
+        currentDriveStorageLimitGb: {
+          lt: targetDriveStorageGb,
+        },
+      },
+      data: {
+        currentDriveStorageLimitGb: targetDriveStorageGb,
+      },
+    });
+    console.log(`[increasesBaseDriveStorage] Updated ${users.count} users`);
+  } else {
+    console.log(
+      `[increasesBaseDriveStorage] run with \`npm run script:increase-base-drive-storage ${targetDriveStorageGb} apply\` to apply changes`,
+    );
+  }
+};
+
+// get first arg
+const targetDriveStorageGb = parseInt(process.argv[2]);
+const shouldApply = process.argv[3] === 'apply';
+console.log(process.argv);
+console.log(`[increasesBaseDriveStorage] Target drive storage: ${targetDriveStorageGb} GB`);
+increaseBaseDriveStoragePreview(targetDriveStorageGb, shouldApply)
+  .then((result) => console.log('Done running script', result))
+  .catch((err) => console.log('Error running script ', err));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "nodes",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description of the Problem / Feature
- upgrade users to default 100gb storage

## Explanation of the solution
- update user table defaults
- add script to upgrade users under a target amount of gb storage

## Instructions on making this work
run migrations to set default to 100gb
run `npm run script:increase-base-drive-storage 100` to upgrade all existing users to 100gb
