### PR TITLE
Fix case bug for component type detection

### DIFF
--- a/desci-server/src/services/data/processing.ts
+++ b/desci-server/src/services/data/processing.ts
@@ -717,7 +717,7 @@ export function constructComponentTypeMapFromFiles(files: any[]): ResearchObject
   files.forEach((f) => {
     const path = f.originalname ?? f.path;
     const extension = extractExtension(path);
-    const cType = EXTENSION_MAP[extension] ?? DEFAULT_COMPONENT_TYPE;
+    const cType = EXTENSION_MAP[extension?.toLowerCase()] ?? DEFAULT_COMPONENT_TYPE;
     componentTypeMap[extension] = cType;
   });
   return componentTypeMap;


### PR DESCRIPTION
## Description of the Problem / Feature
- Upper case extensions weren't being recognized
## Explanation of the solution
- Parsed all extensions to lower case before checking the type map
