### PR TITLE
Prevent resolution of soft deleted nodes

### DIFF
--- a/desci-server/src/controllers/nodes/list.ts
+++ b/desci-server/src/controllers/nodes/list.ts
@@ -63,7 +63,7 @@ export const list = async (req: Request, res: Response, next: NextFunction) => {
       },
       where: {
         ownerId: owner.id,
-        // isDeleted: false,
+        isDeleted: false,
       },
       orderBy: { updatedAt: 'desc' },
     });

--- a/desci-server/src/controllers/nodes/share.ts
+++ b/desci-server/src/controllers/nodes/share.ts
@@ -11,6 +11,7 @@ export const createPrivateShare = async (req: Request, res: Response, next: Next
     where: {
       uuid: uuid + '.',
       ownerId: owner.id,
+      isDeleted: false,
     },
   });
 
@@ -43,6 +44,7 @@ export const getPrivateShare = async (req: Request, res: Response, next: NextFun
       where: {
         uuid: uuid + '.',
         ownerId: owner.id,
+        isDeleted: false,
       },
     });
 

--- a/desci-server/src/controllers/nodes/show.ts
+++ b/desci-server/src/controllers/nodes/show.ts
@@ -90,6 +90,7 @@ export const show = async (req: Request, res: Response, next: NextFunction) => {
       where: {
         uuid: uuid + '.',
         ownerId,
+        isDeleted: false,
       },
     });
 


### PR DESCRIPTION
## Description of the Problem / Feature
- Soft deleted nodes could still be resolved
## Explanation of the solution
- Prevented deleted nodes from being resolved in most common routes
