### PR TITLE
Add global description to RO models

### DIFF
--- a/desci-models/src/ResearchObject.ts
+++ b/desci-models/src/ResearchObject.ts
@@ -18,6 +18,7 @@ export interface IpldUrl {
 export interface ResearchObjectV1 extends ResearchObject {
   version: "desci-nodes-0.1.0" | "desci-nodes-0.2.0" | 1;
   title?: string;
+  description?: string;
   defaultLicense?: string;
   coverImage?: string | IpldUrl;
   components: ResearchObjectV1Component[];
@@ -269,12 +270,15 @@ export enum ResearchObjectV1AuthorRole {
 
 /**
  * Maps FileExtensions => ResearchObjectComponentTypes
- * @example { 
+ * @example {
  *   '.py': ResearchObjectComponentType.CODE,
  *    '.ipynb': ResearchObjectComponentType.CODE,
  *    '.csv': ResearchObjectComponentType.DATA,
  *    '.pdf': ResearchObjectComponentType.PDF
  * }
  */
-export type ResearchObjectComponentTypeMap = Record<FileExtension, ResearchObjectComponentType>
+export type ResearchObjectComponentTypeMap = Record<
+  FileExtension,
+  ResearchObjectComponentType
+>;
 export type FileExtension = string;


### PR DESCRIPTION
## Description of the Problem / Feature
- No field on the manifest for a global node description
## Explanation of the solution
- Added a description string field on the manifest to be used as an overall node description/summary, this will serve as a stopgap until we get the block editor refined, this field may then be migrated to either a string or IPLD uri
