### PR TITLE
Fix node title using automerge document change hooks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,24 @@
 {
-    "explorer.compactFolders": false,
-    "files.exclude": {
-        "**/node_modules/**": false
-    },
-    "yaml.schemas": {
-        "https://gitpod.io/schemas/gitpod-schema.json": "file:///workspace/desci-nodes/.gitpod.yml"
-    },
-    "solidity.defaultCompiler": "localFile",
-    "tailwindCSS.includeLanguages": {
-        "typescript": "javascript", // if you are using typescript
-        "typescriptreact": "javascript" // if you are using typescript with react
-    },
-    "editor.quickSuggestions": {
-        "strings": true // forces VS Code to trigger completions when editing "string" content
-    },
-    "tailwindCSS.experimental.classRegex": [
-        "tw`([^`]*)", // tw`...`
-        "tw\\.[^`]+`([^`]*)`", // tw.xxx<xxx>`...`
-        "tw\\(.*?\\).*?`([^`]*)" // tw(Component)<xxx>`...`
-    ]
+  "explorer.compactFolders": false,
+  "files.exclude": {
+    "**/node_modules/**": false
+  },
+  "yaml.schemas": {
+    "https://gitpod.io/schemas/gitpod-schema.json": "file:///workspace/desci-nodes/.gitpod.yml"
+  },
+  "solidity.defaultCompiler": "localFile",
+  "tailwindCSS.includeLanguages": {
+    "typescript": "javascript", // if you are using typescript
+    "typescriptreact": "javascript" // if you are using typescript with react
+  },
+  "editor.quickSuggestions": {
+    "strings": true // forces VS Code to trigger completions when editing "string" content
+  },
+  "tailwindCSS.experimental.classRegex": [
+    "tw`([^`]*)", // tw`...`
+    "tw\\.[^`]+`([^`]*)`", // tw.xxx<xxx>`...`
+    "tw\\(.*?\\).*?`([^`]*)" // tw(Component)<xxx>`...`
+  ],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
 }

--- a/desci-server/src/controllers/auth/magic.ts
+++ b/desci-server/src/controllers/auth/magic.ts
@@ -33,7 +33,7 @@ export const magic = async (req: Request, res: Response, next: NextFunction) => 
       where: {
         email: {
           equals: email,
-          mode: 'insensitive'
+          mode: 'insensitive',
         },
       },
     });

--- a/desci-server/src/controllers/nodes/draftUpdate.ts
+++ b/desci-server/src/controllers/nodes/draftUpdate.ts
@@ -71,6 +71,13 @@ export const draftUpdate = async (req: Request, res: Response, next: NextFunctio
 
     const uri = `${hash}`;
 
+    logger.info(
+      {
+        updatedMeta,
+      },
+      `Updating node ${node.uuid}`,
+    );
+
     await prisma.node.update({
       where: {
         id: node.id,

--- a/desci-server/src/lib/PostgresStorageAdapter.ts
+++ b/desci-server/src/lib/PostgresStorageAdapter.ts
@@ -30,7 +30,7 @@ export class PostgresStorageAdapter extends StorageAdapter {
 
   async save(keyArray: StorageKey, binary: Uint8Array): Promise<void> {
     const key = getKey(keyArray);
-    logger.info({ action: 'Save', key }, 'PostgresStorageAdapter::Save');
+    logger.trace({ action: 'Save', key }, 'PostgresStorageAdapter::Save');
     this.cache[key] = binary;
 
     try {


### PR DESCRIPTION
## Description of the Problem / Feature
- after switching to auto merge, node titles don't update right away

## Explanation of the solution
- we cache titles in database to avoid fetching document data, create a document change handler that updates the database after a title change