### PR TITLE
Automerge Drive Clock

### DIFF
--- a/desci-server/src/controllers/data/delete.ts
+++ b/desci-server/src/controllers/data/delete.ts
@@ -106,6 +106,7 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
       .filter((c) => c.payload?.path?.startsWith(path + '/') || c.payload?.path === path)
       .map((c) => c.id);
 
+    debugger;
     const updatedManifest = await deleteComponentsFromManifest({
       node,
       componentIds: componentDeletionIds,

--- a/desci-server/src/controllers/data/delete.ts
+++ b/desci-server/src/controllers/data/delete.ts
@@ -4,7 +4,8 @@ import { Request, Response } from 'express';
 
 import { prisma } from '../../client.js';
 import { logger as parentLogger } from '../../logger.js';
-import { getLatestManifestFromNode, getNodeManifestUpdater } from '../../services/manifestRepo.js';
+import { getLatestDriveTime } from '../../services/draftTrees.js';
+import { NodeUuid, getLatestManifestFromNode, getNodeManifestUpdater } from '../../services/manifestRepo.js';
 
 import { ErrorResponse } from './update.js';
 import { persistManifest } from './utils.js';
@@ -41,6 +42,7 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
   }
 
   const latestManifest = await getLatestManifestFromNode(node);
+  const dispatchChange = getNodeManifestUpdater(node);
 
   try {
     /**
@@ -117,6 +119,12 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
       throw Error(`[DATA::DELETE]Failed to persist manifest: ${updatedManifest}, node: ${node}, userId: ${owner.id}`);
 
     logger.info(`DATA::Delete Success, path: `, path, ' deleted');
+
+    /**
+     * Update drive clock on automerge document
+     */
+    const latestDriveClock = await getLatestDriveTime(node.uuid as NodeUuid);
+    await dispatchChange({ type: 'Set Drive Clock', time: latestDriveClock });
 
     return res.status(200).json({
       manifest: updatedManifest,

--- a/desci-server/src/controllers/data/move.ts
+++ b/desci-server/src/controllers/data/move.ts
@@ -164,8 +164,7 @@ export const moveData = async (req: Request, res: Response<MoveResponse | ErrorR
      * Update drive clock on automerge document
      */
     const latestDriveClock = await getLatestDriveTime(node.uuid as NodeUuid);
-    const manifestUpdater = getNodeManifestUpdater(node);
-    await manifestUpdater({ type: 'Set Drive Clock', time: latestDriveClock });
+    await dispatchChange({ type: 'Set Drive Clock', time: latestDriveClock });
 
     return res.status(200).json({
       manifest: updatedManifest,

--- a/desci-server/src/controllers/data/rename.ts
+++ b/desci-server/src/controllers/data/rename.ts
@@ -152,8 +152,7 @@ export const renameData = async (req: Request, res: Response<RenameResponse | Er
      * Update drive clock on automerge document
      */
     const latestDriveClock = await getLatestDriveTime(node.uuid as NodeUuid);
-    const manifestUpdater = getNodeManifestUpdater(node);
-    await manifestUpdater({ type: 'Set Drive Clock', time: latestDriveClock });
+    await dispatchChange({ type: 'Set Drive Clock', time: latestDriveClock });
 
     return res.status(200).json({
       manifest: updatedManifest,

--- a/desci-server/src/controllers/nodes/documents.ts
+++ b/desci-server/src/controllers/nodes/documents.ts
@@ -39,6 +39,7 @@ export const getNodeDocument = async function (req: RequestWithNode, response: R
       handle.change((document) => {
         document.manifest = manifest;
         document.uuid = uuid;
+        document.driveClock = Date.now().toString();
       });
       handle.docSync();
       const document = await handle.doc();

--- a/desci-server/src/controllers/nodes/prepublish.ts
+++ b/desci-server/src/controllers/nodes/prepublish.ts
@@ -5,7 +5,8 @@ import { Response } from 'express';
 import { prisma } from '../../client.js';
 import { logger as parentLogger } from '../../logger.js';
 import { RequestWithNode } from '../../middleware/authorisation.js';
-import { getManifestFromNode, updateManifestDataBucket } from '../../services/data/processing.js';
+import { updateManifestDataBucket } from '../../services/data/processing.js';
+import { NodeUuid, getDraftManifestFromUuid } from '../../services/manifestRepo.js';
 import { prepareDataRefsForDagSkeleton } from '../../utils/dataRefTools.js';
 import { dagifyAndAddDbTreeToIpfs } from '../../utils/draftTreeUtils.js';
 import { persistManifest } from '../data/utils.js';
@@ -53,7 +54,7 @@ export const prepublish = async (req: RequestWithNode, res: Response<PrepublishR
       return res.status(403).json({ ok: false, error: 'Failed' });
     }
 
-    const { manifest, manifestCid } = await getManifestFromNode(node);
+    const manifest = await getDraftManifestFromUuid(node.uuid as NodeUuid);
 
     /**
      * Dagify and add DAGs to IPFS (No Files Pinned yet, just the folder structure added to IPFS (NOT PINNED!))

--- a/desci-server/src/services/data/processing.ts
+++ b/desci-server/src/services/data/processing.ts
@@ -165,7 +165,7 @@ export async function processS3DataToIpfs({
      */
     const latestDriveClock = await getLatestDriveTime(node.uuid as NodeUuid);
     const manifestUpdater = getNodeManifestUpdater(node);
-    const updatedDocument = await manifestUpdater({ type: 'Set Drive Clock', time: latestDriveClock });
+    await manifestUpdater({ type: 'Set Drive Clock', time: latestDriveClock });
 
     const tree = await getTreeAndFill(updatedManifest, node.uuid, user.id);
 
@@ -253,6 +253,13 @@ export async function processNewFolder({
     });
 
     const ltsManifest = await getLatestManifestFromNode(ltsNode);
+
+    /**
+     * Update drive clock on automerge document
+     */
+    const latestDriveClock = await getLatestDriveTime(node.uuid as NodeUuid);
+    const manifestUpdater = getNodeManifestUpdater(node);
+    await manifestUpdater({ type: 'Set Drive Clock', time: latestDriveClock });
 
     const tree = await getTreeAndFill(ltsManifest, node.uuid, user.id);
 

--- a/desci-server/src/services/data/processing.ts
+++ b/desci-server/src/services/data/processing.ts
@@ -257,6 +257,7 @@ export async function processNewFolder({
     /**
      * Update drive clock on automerge document
      */
+    debugger;
     const latestDriveClock = await getLatestDriveTime(node.uuid as NodeUuid);
     const manifestUpdater = getNodeManifestUpdater(node);
     await manifestUpdater({ type: 'Set Drive Clock', time: latestDriveClock });

--- a/desci-server/src/services/manifestRepo.ts
+++ b/desci-server/src/services/manifestRepo.ts
@@ -101,7 +101,8 @@ export type ManifestActions =
       component: ResearchObjectV1Component;
       componentIndex: number;
       componentTypeMap: ResearchObjectComponentTypeMap;
-    };
+    }
+  | { type: 'Set Drive Clock'; time: string };
 
 export const getNodeManifestUpdater = (node: Node) => {
   // const backendRepo = server.repo;
@@ -187,6 +188,23 @@ export const getNodeManifestUpdater = (node: Node) => {
           { time: Date.now(), message: action.type },
         );
         break;
+      case 'Set Drive Clock':
+        handle.change(
+          (document) => {
+            if (document.driveClock && document.driveClock === action.time) return; // Don't update if already the latest
+            document.driveClock = action.time;
+          },
+          { time: Date.now(), message: action.type },
+        );
+        break;
+      // case 'Remove Drive Clock':
+      //   handle.change(
+      //     (document) => {
+      //       delete document.driveClock;
+      //     },
+      //     { time: Date.now(), message: action.type },
+      //   );
+      //   break;
       default:
         assertNever(action);
     }

--- a/desci-server/src/services/manifestRepo.ts
+++ b/desci-server/src/services/manifestRepo.ts
@@ -32,6 +32,7 @@ export const createManifestDocument = async function ({ node, manifest }: { node
     (d) => {
       d.manifest = manifest;
       d.uuid = uuid;
+      d.driveClock = Date.now().toString();
     },
     { message: 'Init Document', time: Date.now() },
   );

--- a/desci-server/src/types/documents.ts
+++ b/desci-server/src/types/documents.ts
@@ -3,4 +3,5 @@ import { ResearchObjectV1 } from '@desci-labs/desci-models';
 export interface ResearchObjectDocument {
   manifest: ResearchObjectV1;
   uuid: string;
+  driveClock?: string;
 }


### PR DESCRIPTION
## Description of the Problem / Feature
- With the draft data tree changes, we can no longer rely on a data bucket CID to know if the file tree has changed.
## Explanation of the solution
- Add a drive clock to the automerge document that reflects the last updated item in the nodes draft tree.
- WIP Still needs all instances covered where a draft tree change may occur
