### PR TITLE
Fix/automerge data crashes

### DIFF
--- a/desci-server/src/controllers/data/delete.ts
+++ b/desci-server/src/controllers/data/delete.ts
@@ -102,13 +102,13 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
     /*
      ** Delete components in Manifest, update DAG cids in manifest
      */
-    const componentDeletionIds = latestManifest.components
+    const pathsToDelete = latestManifest.components
       .filter((c) => c.payload?.path?.startsWith(path + '/') || c.payload?.path === path)
-      .map((c) => c.id);
+      .map((c) => (c.payload?.path as string) || '');
 
     const updatedManifest = await deleteComponentsFromManifest({
       node,
-      componentIds: componentDeletionIds,
+      pathsToDelete,
     });
 
     const { persistedManifestCid } = await persistManifest({ manifest: updatedManifest, node, userId: owner.id });
@@ -130,16 +130,17 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
 
 interface UpdatingManifestParams {
   node: Node;
-  componentIds: string[];
+  pathsToDelete: string[];
 }
 
-export async function deleteComponentsFromManifest({ node, componentIds }: UpdatingManifestParams) {
-  let updatedManifest: ResearchObjectV1;
+export async function deleteComponentsFromManifest({ node, pathsToDelete }: UpdatingManifestParams) {
+  // let updatedManifest: ResearchObjectV1;
   const manifestUpdater = getNodeManifestUpdater(node);
-  parentLogger.info({ componentIds }, `deleteComponentsFromManifest:`);
-  for (const componentId of componentIds) {
-    updatedManifest = await manifestUpdater({ type: 'Delete Component', componentId });
-    parentLogger.info({ componentId, updatedManifest }, `Deleted ${componentId}:`);
-  }
+  parentLogger.info({ pathsToDelete }, `deleteComponentsFromManifest:`);
+  const updatedManifest = await manifestUpdater({ type: 'Delete Components', pathsToDelete });
+  // for (const path of pathsToDelete) {
+  //   updatedManifest = await manifestUpdater({ type: 'Delete Component', componentId });
+  //   parentLogger.info({ pathsToDelete, updatedManifest }, `Deleted ${componentId}:`);
+  // }
   return updatedManifest;
 }

--- a/desci-server/src/controllers/data/move.ts
+++ b/desci-server/src/controllers/data/move.ts
@@ -102,12 +102,6 @@ export const moveData = async (req: Request, res: Response<MoveResponse | ErrorR
     /*
      ** Updates old paths in the manifest component payloads to the new ones, updates the data bucket root CID and any DAG CIDs changed along the way
      */
-    // const updatedManifest = updateComponentPathsInManifest({
-    //   manifest: latestManifest,
-    //   oldPath: oldPath,
-    //   newPath: newPath,
-    // });
-    // [AUTOMERGE] Delegate to repo service
     const dispatchChange = getNodeManifestUpdater(node);
     const updatedManifest = await dispatchChange({ type: 'Rename Component Path', oldPath, newPath });
 

--- a/desci-server/src/controllers/data/rename.ts
+++ b/desci-server/src/controllers/data/rename.ts
@@ -68,7 +68,13 @@ export const renameData = async (req: Request, res: Response<RenameResponse | Er
      */
 
     const dispatchChange = getNodeManifestUpdater(node);
-    let updatedManifest = await dispatchChange({ type: 'Rename Component Path', oldPath: path, newPath });
+    let updatedManifest = latestManifest;
+    try {
+      updatedManifest = await dispatchChange({ type: 'Rename Component Path', oldPath: path, newPath });
+    } catch (err) {
+      logger.error({ err }, 'Source: Rename Component Path');
+      return res.status(400).json({ error: 'failed' });
+    }
 
     // Get all entries that need to be updated
     const entriesToUpdate = await prisma.draftNodeTree.findMany({
@@ -97,7 +103,11 @@ export const renameData = async (req: Request, res: Response<RenameResponse | Er
       // const componentIndex = updatedManifest.components.findIndex((c) => c.payload.path === newPath);
       const { fileName } = separateFileNameAndExtension(newName);
       // updatedManifest.components[componentIndex].name = fileName;
-      updatedManifest = await dispatchChange({ type: 'Rename Component', path: newPath, fileName });
+      try {
+        updatedManifest = await dispatchChange({ type: 'Rename Component', path: newPath, fileName });
+      } catch (err) {
+        logger.error({ err }, 'Source: Rename Component');
+      }
     }
 
     /*

--- a/desci-server/src/services/data/processing.ts
+++ b/desci-server/src/services/data/processing.ts
@@ -639,35 +639,40 @@ export async function assignTypeMapInManifest(
   contextPath: DrivePath,
   contextPathNewCid: string,
 ): Promise<ResearchObjectV1> {
-  const manifestUpdater = getNodeManifestUpdater(node);
-  let updatedManifest: ResearchObjectV1;
-  const componentIndex = manifest.components.findIndex((c) => c.payload.path === contextPath);
-  // Check if the component already exists, update its type map
-  if (componentIndex !== -1) {
-    const prevComponent = manifest.components[componentIndex];
-    updatedManifest = await manifestUpdater({
-      type: 'Assign Component Type',
-      component: prevComponent,
-      componentTypeMap: compTypeMap,
-      componentIndex,
-    });
-  } else {
-    // If doesn't exist, create the component and assign its type map
-    const compName = contextPath.split('/').pop();
-    const component = {
-      id: v4(),
-      name: compName,
-      type: compTypeMap,
-      payload: {
-        ...urlOrCid(contextPathNewCid, ResearchObjectComponentType.DATA),
-        path: contextPath,
-      },
-    };
-    try {
+  try {
+    const manifestUpdater = getNodeManifestUpdater(node);
+    let updatedManifest: ResearchObjectV1;
+    const componentIndex = manifest.components.findIndex((c) => c.payload.path === contextPath);
+    // Check if the component already exists, update its type map
+    if (componentIndex !== -1) {
+      const prevComponent = manifest.components[componentIndex];
+      updatedManifest = await manifestUpdater({
+        type: 'Assign Component Type',
+        component: prevComponent,
+        componentTypeMap: compTypeMap,
+        componentIndex,
+      });
+    } else {
+      // If doesn't exist, create the component and assign its type map
+      const compName = contextPath.split('/').pop();
+      const component = {
+        id: v4(),
+        name: compName,
+        type: compTypeMap,
+        payload: {
+          ...urlOrCid(contextPathNewCid, ResearchObjectComponentType.DATA),
+          path: contextPath,
+        },
+      };
+      // try {
       updatedManifest = await manifestUpdater({ type: 'Add Component', component });
-    } catch (e) {
-      console.log('[ERROR assignTypeMapInManifest]', e);
+      // } catch (e) {
+      //   console.log('[ERROR assignTypeMapInManifest]', e);
+      // }
     }
+    return updatedManifest;
+  } catch (err) {
+    logger.error(err, 'Error Caught in assignTypeMapInManifest');
+    return manifest;
   }
-  return updatedManifest;
 }

--- a/desci-server/src/services/manifestRepo.ts
+++ b/desci-server/src/services/manifestRepo.ts
@@ -89,6 +89,7 @@ export function assertNever(value: never) {
 export type ManifestActions =
   | { type: 'Add Component'; component: ResearchObjectV1Component }
   | { type: 'Delete Component'; componentId: string }
+  | { type: 'Delete Components'; pathsToDelete: string[] }
   | { type: 'Rename Component'; path: string; fileName: string }
   | { type: 'Rename Component Path'; oldPath: string; newPath: string }
   | {
@@ -145,6 +146,24 @@ export const getNodeManifestUpdater = (node: Node) => {
           handle.change(
             (document) => {
               document.manifest.components.splice(deleteIdx, 1);
+            },
+            { time: Date.now(), message: action.type },
+          );
+        }
+        break;
+      case 'Delete Components':
+        const componentEntries = latestDocument.manifest.components
+          .map((c) => (action.pathsToDelete.includes(c.payload?.path) ? c.payload?.path : null))
+          .filter(Boolean) as string[];
+        if (componentEntries.length > 0) {
+          logger.info({ action, componentEntries }, `DocumentUpdater::Delete Components`);
+          handle.change(
+            (document) => {
+              for (const path of componentEntries) {
+                const deleteIdx = document.manifest.components.findIndex((c) => c.payload?.path === path);
+                logger.info({ path, deleteIdx }, `DocumentUpdater::Delete`);
+                if (deleteIdx !== -1) document.manifest.components.splice(deleteIdx, 1);
+              }
             },
             { time: Date.now(), message: action.type },
           );


### PR DESCRIPTION
## Description of the Problem / Feature
- Data operations fail due to automerge Range Error

## Explanation of the solution
- Handle and log crashes, prevent errors from propagating to api requests
- Fail early if database update depends on automerge crash 
