### PR TITLE
Add Ceramic node in dev cluster

### DIFF
--- a/.ceramicDev.config.json
+++ b/.ceramicDev.config.json
@@ -1,0 +1,35 @@
+{
+  "anchor": { },
+  "http-api": {
+    "cors-allowed-origins": [
+      ".*"
+    ],
+    "admin-dids": [
+      "did:key:z6MktbKJrMnhVJ37QFTo12911ycm2juKDUzWHDVETu9s5a9T"
+    ]
+  },
+  "ipfs": {
+    "mode": "remote",
+    "host": "http://host.docker.internal:5001"
+  },
+  "logger": {
+    "log-level": 2
+  },
+  "metrics": {
+    "metrics-exporter-enabled": false,
+    "metrics-port": 9090
+  },
+  "network": {
+    "name": "inmemory"
+  },
+  "node": {},
+  "state-store": {
+    "mode": "fs",
+    "local-directory": "/root/.ceramic/statestore"
+  },
+  "indexing": {
+    "db": "postgres://walter:white@db_postgres:5432/postgres",
+    "allow-queries-before-historical-sync": true,
+    "models": []
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,6 @@ MEDIA_SECRET_KEY=supersecret
 ORCID_API_DOMAIN=https://api.sandbox.orcid.org
 ORCID_CLIENT_ID=
 ORCID_CLIENT_SECRET=
+
+# Ceramic publish feature toggle
+TOGGLE_CERAMIC= #1

--- a/.env.example
+++ b/.env.example
@@ -90,5 +90,7 @@ ORCID_API_DOMAIN=https://api.sandbox.orcid.org
 ORCID_CLIENT_ID=
 ORCID_CLIENT_SECRET=
 
-# Ceramic publish feature toggle
-TOGGLE_CERAMIC= #1
+# Ceramic publish feature toggle, set to 1 for active
+TOGGLE_CERAMIC=
+# If above is set, clone `@desci-labs/desci-codex` and put the path to it here
+CODEX_REPO_PATH=

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ This starts:
 4. expedition explorer for local dev (http://localhost:3001)
 5. graph index pointing to latest deployed contract (http://localhost:8080)
 6. Local IPFS node (private, swarm key enabled) (http://localhost:5001 or http://localhost:8089)
+7. Local Ceramic node, run `bootstrapCeramic.sh` to initialize (http://localhost:7007)
+
+**Note:** The Ceramic publish functionality needs to be activated by setting the corresponding environment variable, see `.env.example` for instructions.
 
 **Note:** nodes-media (http://localhost:5454, responsible for DOI / PDF downloads, and for media transcoding) is disabled in the dev cluster by default, but can be uncommented in `docker-compose.dev.yml` for local development
 <br>

--- a/bootstrapCeramic.sh
+++ b/bootstrapCeramic.sh
@@ -1,0 +1,60 @@
+#! /usr/bin/env bash
+
+# This script will try to find the `desci-codex` repo and run the
+# model deployments. This yields a runtime definition file, which is
+# necessary to instantiate the composeDB client used for publishing.
+#
+# This needs to be re-run when local-data is cleaned, as the models will
+# get new streamIDs, and hence the runtime definition file is changed.
+#
+# There is no damage trying to run this multiple times in a row; it's
+# idempotent.
+
+CTX="[bootstrapCeramic.sh]"
+
+set -euo pipefail
+trap catch ERR
+catch() {
+  echo "$CTX script failed"
+  exit 1
+}
+
+# Assert running from repo root
+if [[ ! -f .env ]]; then
+  echo "$CTX Must run from repo root, aborting!"
+  exit 1
+fi
+
+# Assert desci-codex repo available
+CODEX_REPO_PATH=$(grep "CODEX_REPO_PATH" .env | cut -d"=" -f2)
+if [[ -z "$CODEX_REPO_PATH" ]]; then
+  echo "$CTX CODEX_REPO_PATH not set in .env, aborting!"
+  exit 1
+else
+  echo "$CTX Found codex repo path: $CODEX_REPO_PATH"
+fi
+
+# Assert ceramic service is running
+RUNNING_SERVICES=$(docker compose --project-name desci ps --services)
+if ! grep -q ceramic <<<"$RUNNING_SERVICES"; then
+  echo "$CTX the ceramic compose service doesn't seem to be running, aborting!"
+  exit 1
+fi
+
+# Setup desci-codex and deploy composites
+pushd "$CODEX_REPO_PATH"
+if [[ ! -d "node_modules" ]]; then
+  echo "$CTX installing deps desci-codex..."
+  npm ci
+fi
+
+echo "$CTX deploying composites..."
+npm run --workspace packages/composedb deployComposites
+popd
+
+echo "$CTX composites deployed! Copying composite runtime definition to local-data/ceramic..."
+cp \
+  "$CODEX_REPO_PATH/packages/composedb/src/__generated__/definition.js" \
+  local-data/ceramic/definition.js
+
+echo "$CTX Done! Re-run this script if local state is cleaned."

--- a/desci-contracts/scripts/seed.sh
+++ b/desci-contracts/scripts/seed.sh
@@ -28,7 +28,7 @@ check() {
   done
 
   echo "[seed:$CONTRACT_NAME] deployment found, killing ganache..."
-  ps aux | grep ganache-cli | grep -v grep | awk '{print $2}' | xargs -r -t kill || echo "[seed:$CONTRACT_NAME] ganache not running"
+  pkill -f "npm exec ganache" || echo "[seed:$CONTRACT_NAME] ganache not running"
   echo "[seed:$CONTRACT_NAME] ganache killed"
 }
 

--- a/desci-server/prisma/migrations/20240110092031_add_ceramic_streamid_to_node/migration.sql
+++ b/desci-server/prisma/migrations/20240110092031_add_ceramic_streamid_to_node/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Node" ADD COLUMN     "ceramicStream" TEXT;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Node {
   deletedAt           DateTime?
   UploadJobs          UploadJobs[]
   DraftNodeTree       DraftNodeTree[]
+  ceramicStream       String?
 
   @@index([ownerId])
   @@index([uuid])

--- a/desci-server/src/controllers/nodes/prepublish.ts
+++ b/desci-server/src/controllers/nodes/prepublish.ts
@@ -17,6 +17,7 @@ export interface PrepublishSuccessResponse {
   updatedManifestCid: string;
   updatedManifest: ResearchObjectV1;
   version?: NodeVersion;
+  ceramicStream?: string;
 }
 
 export interface PrepublishErrorResponse {
@@ -38,6 +39,7 @@ export const prepublish = async (req: RequestWithNode, res: Response<PrepublishR
     body: req.body,
     uuid,
     user: (req as any).user,
+    ceramicStream: node.ceramicStream,
   });
   if (!uuid) {
     return res.status(400).json({ ok: false, error: 'UUID is required.' });
@@ -87,6 +89,7 @@ export const prepublish = async (req: RequestWithNode, res: Response<PrepublishR
       updatedManifestCid: persistedManifestCid,
       updatedManifest: updatedManifest,
       version: nodeVersion,
+      ceramicStream: node.ceramicStream,
     });
   } catch (err) {
     logger.error({ err }, '[prepublish::prepublish] node-pre-publish-err');

--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -11,13 +11,13 @@ import {
   getAllCidsRequiredForPublish,
   createPublicDataRefs,
   createDataMirrorJobs,
+  setCeramicStream,
 } from '../../services/nodeManager.js';
-import { validateAndHealDataRefs } from '../../utils/dataRefTools.js';
 import { discordNotify } from '../../utils/discordUtils.js';
 
 // call node publish service and add job to queue
-export const publish = async (req: Request, res: Response, next: NextFunction) => {
-  const { uuid, cid, manifest, transactionId, nodeVersionId } = req.body;
+export const publish = async (req: Request, res: Response, _next: NextFunction) => {
+  const { uuid, cid, manifest, transactionId, nodeVersionId, ceramicStream } = req.body;
   // debugger;
   const email = (req as any).user.email;
   const logger = parentLogger.child({
@@ -92,6 +92,16 @@ export const publish = async (req: Request, res: Response, next: NextFunction) =
         transactionId,
       },
     });
+
+    if (process.env.TOGGLE_CERAMIC === "1") {
+      if (ceramicStream) {
+        logger.trace(`[ceramic] setting streamID on node`);
+        await setCeramicStream(uuid, ceramicStream);
+      } else {
+        // Likely feature toggle is active in backend, but not in frontend
+        logger.warn(`[ceramic] wanted to set streamID for ${node.uuid} but request did not contain one`)
+      }
+    };
 
     logger.trace(`[publish::publish] nodeUuid=${node.uuid}, manifestCid=${cid}, transaction=${transactionId}`);
 
@@ -187,16 +197,9 @@ export const publish = async (req: Request, res: Response, next: NextFunction) =
     );
 
     // trigger ipfs storage upload, but don't wait for it to finish, will happen async
-    publishResearchObject(publicDataReferences).then(handleMirrorSuccess).catch(handleMirrorFail);
-    // Disabled bandaid fix, shouldn't be necessary if publish step handled correctly on frontend.
-    // .finally(async () => {
-    //   await validateAndHealDataRefs({
-    //     nodeUuid: node.uuid!,
-    //     manifestCid: cid,
-    //     publicRefs: true,
-    //     markExternals: true,
-    //   });
-    // });
+    publishResearchObject(publicDataReferences)
+      .then(handleMirrorSuccess)
+      .catch(handleMirrorFail);
 
     /**
      * Save the cover art for this Node for later sharing: PDF -> JPG for this version

--- a/desci-server/src/services/nodeManager.ts
+++ b/desci-server/src/services/nodeManager.ts
@@ -54,6 +54,20 @@ export const createNodeDraftBlank = async (
   return nodeCopy;
 };
 
+export const setCeramicStream = async (uuid: string, ceramicStream: string) => {
+  logger.debug({ fn: 'setCeramicStream', uuid, ceramicStream}, 'node::setCeramicStream');
+  uuid = uuid.endsWith(".") ? uuid : uuid + ".";
+  return await prisma.node.update({
+
+    data: {
+      ceramicStream,
+    },
+    where: {
+      uuid,
+    }
+  });
+};
+
 export const createPublicDataRefs = async (
   data: Prisma.PublicDataReferenceCreateManyInput[],
   userId: number | undefined,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -132,13 +132,22 @@ services:
       # EXPERIMENTAL_SUBGRAPH_VERSION_SWITCHING_MODE: synced
 
   ipfs:
-    image: ipfs/go-ipfs:v0.13.0
+    image: ipfs/kubo:v0.24.0
     container_name: "ipfs"
     environment:
       IPFS_SWARM_KEY: "/key/swarm/psk/1.0.0/\n/base16/\n9d002c50635a479d29dcc0ccb49d862952a0dcc52baddd253167adcd496c8d04"
     ports:
       - "5001:5001"
       - "8089:8080"
+    command:
+      # These are defaults from the go-ipfs dockerfile CMD
+      - "daemon"
+      - "--migrate=true"
+      - "--agent-version-suffix=docker"
+      # This is necessary before ceramic ships Recon, the new tip gossip protocol
+      - "--enable-pubsub-experiment"
+    extra_hosts:
+      - host.docker.internal:host-gateway
     volumes:
       - ./local-data/ipfs:/data/ipfs
     healthcheck:
@@ -156,6 +165,25 @@ services:
     volumes:
       - ./local-data/redis:/data
 
+  ceramic:
+    image: ceramicnetwork/js-ceramic:3.2.0
+    container_name: ceramic
+    ports:
+      - "7007:7007"
+    environment:
+      NODE_ENV: production
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - ./local-data/ceramic/statestore:/root/.ceramic/statestore
+      - ./.ceramicDev.config.json:/root/.ceramic/daemon.config.json
+    depends_on:
+      ipfs:
+        condition:
+          service_healthy
+      db_postgres:
+        condition:
+          service_healthy
 
   # desci_nodes_backend_test:
   #   container_name: 'be_test_boilerplate'


### PR DESCRIPTION
## Description of the Problem / Feature
Adds a Ceramic node to the local dev cluster, supporting a feature toggled publishing flow in nodes-web-v2.

## Explanation of the solution
- New docker compose service called `ceramic`. It uses the same dev postgres database as the rest.
- Necessary version bump of kubo
- Prisma migration to keep track of streamIDs along with the node UUID.
- Changes to `publish` and `prepublish` to keep track of the above

## Instructions on making this work
- Should be fully backward compatible :crossed_fingers: 
- To opt in, set the corresponding environment variable as demonstrated in `.env.example`.
- Finally, run `bootstrapCeramic.sh`, which will deploy models from [@desci-labs/desci-codex](https://github.com/desci-labs/desci-codex). This is a bit annoying, because it needs to run when the cluster is already up, making it hard to integrate into the make scripts :monocle_face: 

Resolves #175 together with https://github.com/desci-labs/nodes-web-v2/pull/583