### PR TITLE
Cover api fixes

### DIFF
--- a/desci-server/src/controllers/nodes/list.ts
+++ b/desci-server/src/controllers/nodes/list.ts
@@ -26,6 +26,7 @@ export const list = async (req: Request, res: Response, next: NextFunction) => {
       title: true,
       manifestUrl: true,
       cid: true,
+      NodeCover: true,
     },
     where: {
       ownerId: owner.id,
@@ -60,6 +61,7 @@ export const list = async (req: Request, res: Response, next: NextFunction) => {
         title: true,
         manifestUrl: true,
         cid: true,
+        NodeCover: true,
       },
       where: {
         ownerId: owner.id,


### PR DESCRIPTION
## Description of the Problem / Feature
- Collection API missing node cover data
- Automerge not updating node cover in the db
## Explanation of the solution
- Collection endpoint now also returns NodeCover data
- Automerge updates to the latest NodeCover in the db

