### PR TITLE
nodes-lib: declarative endpoint definitions

### DIFF
--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/src/api.ts
+++ b/nodes-lib/src/api.ts
@@ -25,37 +25,37 @@ import type { NodeIDs } from "@desci-labs/desci-codex-lib/dist/src/types.js";
 import { publish } from "./publish.js";
 import type { ResearchObjectDocument } from "./automerge.js";
 import { randomUUID } from "crypto";
-import { NODES_API_URL, NODES_API_KEY } from "./config.js";
+import { NODES_API_KEY } from "./config.js";
 import { makeRequest } from "./routes.js";
 
 export const ENDPOINTS = {
   deleteData: {
     method: "post",
-    route: `${NODES_API_URL}/v1/data/delete`,
+    route: `/v1/data/delete`,
     _payloadT: <DeleteDataParams>{},
     _responseT: <DeleteDataResponse>{},
   },
   uploadFiles: {
     method: "post",
-    route: `${NODES_API_URL}/v1/data/update`,
+    route: `/v1/data/update`,
     _payloadT: <UploadParams>{},
     _responseT: <UploadFilesResponse>{},
   },
   uploadExternal: {
     method: "post",
-    route: `${NODES_API_URL}/v1/data/update`,
+    route: `/v1/data/update`,
     _payloadT: <UploadPdfFromUrlParams | UploadGithubRepoFromUrlParams>{},
     _responseT: <UploadFilesResponse>{},
   },
   createFolder: {
     method: "post",
-    route: `${NODES_API_URL}/v1/data/update`,
+    route: `/v1/data/update`,
     _payloadT: <CreateFolderParams>{},
     _responseT: <CreateFolderResponse>{},
   },
   updateExternalCid: {
     method: "post",
-    route: `${NODES_API_URL}/v1/data/updateExternalCid`,
+    route: `/v1/data/updateExternalCid`,
     _payloadT: <AddExternalTreeParams>{},
     _responseT: <UploadFilesResponse>{},
   },
@@ -64,72 +64,72 @@ export const ENDPOINTS = {
   */
   retrieveTree: {
     method: "get",
-    route: `${NODES_API_URL}/v1/data/retrieveTree`,
+    route: `/v1/data/retrieveTree`,
     _payloadT: undefined,
     _responseT: <RetrieveResponse>{},
   },
   moveData: {
     method: "post",
-    route: `${NODES_API_URL}/v1/data/move`,
+    route: `/v1/data/move`,
     _payloadT: <MoveDataParams>{},
     _responseT: <MoveDataResponse>{},
   },
   createDraft: {
     method: "post",
-    route: `${NODES_API_URL}/v1/nodes/createDraft`,
+    route: `/v1/nodes/createDraft`,
     _payloadT: <CreateDraftParams>{},
     _responseT: <CreateDraftResponse>{},
   },
     /** Append `/[uuid]` */
   deleteDraft: {
     method: "delete",
-    route: `${NODES_API_URL}/v1/nodes`,
+    route: `/v1/nodes`,
     _payloadT: undefined,
     _responseT: undefined,
   },
   /** Append `/[uuid] `*/
   showNode: {
     method: "get",
-    route: `${NODES_API_URL}/v1/nodes/objects`,
+    route: `/v1/nodes/objects`,
     _payloadT: undefined,
     _responseT: <NodeResponse>{},
   },
   listNodes: {
     method: "get",
-    route: `${NODES_API_URL}/v1/nodes/`,
+    route: `/v1/nodes/`,
     _payloadT: undefined,
     _responseT: <{ nodes: ListedNode[] }>{},
   },
   prepublish: {
     method: "post",
-    route: `${NODES_API_URL}/v1/nodes/prepublish`,
+    route: `/v1/nodes/prepublish`,
     _payloadT: <{ uuid: string }>{},
     _responseT: <PrepublishResponse>{},
   },
   publish: {
     method: "post",
-    route: `${NODES_API_URL}/v1/nodes/publish`,
+    route: `/v1/nodes/publish`,
     _payloadT: <PublishParams>{},
     _responseT: <PublishResponse>{},
   },
   /** Append `/[uuid]` */
   getDocument: {
     method: "get",
-    route: `${NODES_API_URL}/v1/nodes/documents`,
+    route: `/v1/nodes/documents`,
     _payloadT: undefined,
     _responseT: <ManifestDocumentResponse>{},
   },
   /** Append `/[uuid]/actions` */
   changeDocument: {
     method: "post",
-    route: `${NODES_API_URL}/v1/nodes/documents`,
+    route: `/v1/nodes/documents`,
     _payloadT: <ChangeManifestParams>{},
     _responseT: <ManifestDocumentResponse>{},
   },
   /** Append `/[uuid] `*/
   dpidHistory: {
     method: "get",
-    route: `${NODES_API_URL}/v1/pub/versions`,
+    route: `/v1/pub/versions`,
     _payloadT: undefined,
     _responseT: <IndexedNode>{},
   },

--- a/nodes-lib/src/publish.ts
+++ b/nodes-lib/src/publish.ts
@@ -33,7 +33,7 @@ export const publish = async (
   try {
     // If the dPID is new, skip checking for history to potentially backfill
     const publishHistory = preexistingDpid
-      ? await getDpidHistory(uuid)
+      ? (await getDpidHistory(uuid)).versions
       : [];
     ceramicIDs = await codexPublish(chainPubResponse.prepubResult, publishHistory);
   } catch (e) {

--- a/nodes-lib/src/routes.ts
+++ b/nodes-lib/src/routes.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosResponse } from "axios";
+import { ENDPOINTS } from "./api.js";
+
+/**
+ * This function looks like all types are unions, but when called with
+ * the parameter `endpoint`, the specific type of that will constrain all
+ * variables in the function. Hence, it looks weird here but is nice and
+ * clear when called.
+ *
+ * It accepts an entry from the `ENDPOINTS` const object, uses that to validate
+ * the shape of the payload and type the response from the server.
+*/
+export async function makeRequest<
+  /** Any single entry in ENDPOINTS, is inferred by argument `endpoint` */
+  T extends typeof ENDPOINTS[keyof typeof ENDPOINTS]
+>(
+  endpoint: T,
+  headers: Record<string, string>,
+  payload: T["_payloadT"],
+  routeTail?: string,
+): Promise<T["_responseT"]> {
+  let res: AxiosResponse<T["_responseT"]>;
+  // post is the only method that takes a data payload
+  if ( endpoint.method === "post") {
+   res = await axios[endpoint.method]<typeof endpoint._responseT>(
+      endpoint.route + (routeTail ?? ""),
+      payload,
+      { headers },
+    );
+  } else {
+   res = await axios[endpoint.method]<typeof endpoint._responseT>(
+      endpoint.route + (routeTail ?? ""),
+      { headers },
+    );
+  };
+  return res.data;
+};

--- a/nodes-lib/src/routes.ts
+++ b/nodes-lib/src/routes.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { ENDPOINTS } from "./api.js";
-
+import { NODES_API_URL as API } from "./config.js";
 /**
  * This function looks like all types are unions, but when called with
  * the parameter `endpoint`, the specific type of that will constrain all
@@ -19,17 +19,18 @@ export async function makeRequest<
   payload: T["_payloadT"],
   routeTail?: string,
 ): Promise<T["_responseT"]> {
+  const url = API + endpoint.route + (routeTail ?? "");
   let res: AxiosResponse<T["_responseT"]>;
   // post is the only method that takes a data payload
   if ( endpoint.method === "post") {
    res = await axios[endpoint.method]<typeof endpoint._responseT>(
-      endpoint.route + (routeTail ?? ""),
+      url,
       payload,
       { headers },
     );
   } else {
    res = await axios[endpoint.method]<typeof endpoint._responseT>(
-      endpoint.route + (routeTail ?? ""),
+      url,
       { headers },
     );
   };


### PR DESCRIPTION
It was very easy to screw up an endpoint call by using the wrong method, missing some parameter, etc. Implemented more declarative endpoint registry which specs the method, payload, and response which is quiiite neat.