### PR TITLE
feat: implement async publishing using simple task queue on progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,13 @@ IPFS_READ_ONLY_GATEWAY_SERVER=http://host.docker.internal:8089/ipfs # Used to pr
 
 # SET TO 1 to run communities seed script
 RUN=1
+
+
+## Configure RPC nodes (open an issue/ping us to access DeSci Labs' nodes)
+ETHEREUM_RPC_URL=http://host.docker.internal:8545
+
+# Use this for Goerli testnet
+# ETHEREUM_RPC_URL=https://eth-goerli.g.alchemy.com/v2/demo
+
+# Use this for Sepolia testnet
+# ETHEREUM_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/demo

--- a/desci-server/kubernetes/deployment.yaml
+++ b/desci-server/kubernetes/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           export REPO_SERVICE_SECRET_KEY={{ .Data.REPO_SERVICE_SECRET_KEY }}
           export ISOLATED_MEDIA_SERVER_URL={{ .Data.ISOLATED_MEDIA_SERVER_URL }}
           export IPFS_READ_ONLY_GATEWAY_SERVER_URL={{ .Data.IPFS_READ_ONLY_GATEWAY_SERVER_URL }}
+          export ETHEREUM_RPC_URL={{ .Data.ETHEREUM_RPC_URL }}
           export DEBUG_TEST=0;
           echo "appfinish";
           {{- end -}}

--- a/desci-server/kubernetes/deployment_dev.yaml
+++ b/desci-server/kubernetes/deployment_dev.yaml
@@ -76,6 +76,7 @@ spec:
           export REPO_SERVICE_SECRET_KEY={{ .Data.REPO_SERVICE_SECRET_KEY }}
           export ISOLATED_MEDIA_SERVER_URL={{ .Data.ISOLATED_MEDIA_SERVER_URL }}
           export IPFS_READ_ONLY_GATEWAY_SERVER_URL={{ .Data.IPFS_READ_ONLY_GATEWAY_SERVER_URL }}
+          export ETHEREUM_RPC_URL={{ .Data.ETHEREUM_RPC_URL }}
           export DEBUG_TEST=0;
           echo "appfinish";
           {{- end -}}

--- a/desci-server/prisma/migrations/20240229065702_add_publish_worker_table/migration.sql
+++ b/desci-server/prisma/migrations/20240229065702_add_publish_worker_table/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "PublishTaskQueueStatus" AS ENUM ('WAITING', 'PENDING', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "PublishTaskQueue" (
+    "id" SERIAL NOT NULL,
+    "ceramicStream" TEXT NOT NULL,
+    "cid" TEXT NOT NULL,
+    "dpid" TEXT,
+    "userId" INTEGER NOT NULL,
+    "transactionId" TEXT NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "status" "PublishTaskQueueStatus" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PublishTaskQueue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PublishTaskQueue_transactionId_key" ON "PublishTaskQueue"("transactionId");
+
+-- AddForeignKey
+ALTER TABLE "PublishTaskQueue" ADD CONSTRAINT "PublishTaskQueue_uuid_fkey" FOREIGN KEY ("uuid") REFERENCES "Node"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PublishTaskQueue" ADD CONSTRAINT "PublishTaskQueue_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/desci-server/prisma/migrations/20240229071713_add_publish_node_action_type/migration.sql
+++ b/desci-server/prisma/migrations/20240229071713_add_publish_node_action_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ActionType" ADD VALUE 'PUBLISH_NODE';

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Node {
   ceramicStream       String?
   NodeAttestation     NodeAttestation[]
   NodeThumbnails      NodeThumbnails[]
+  PublishTaskQueue    PublishTaskQueue[]
 
   @@index([ownerId])
   @@index([uuid])
@@ -182,6 +183,7 @@ model User {
   NodeAttestationVerification NodeAttestationVerification[]
   NodeAttestationReaction     NodeAttestationReaction[]
   ApiKey                      ApiKey[]
+  PublishTaskQueue            PublishTaskQueue[]
 
   @@index([orcid])
   @@index([walletAddress])
@@ -589,23 +591,23 @@ model NodeFeedItemEndorsement {
 
 // an organization that endorses work and has members
 model DesciCommunity {
-  id              Int                       @id @default(autoincrement())
-  createdAt       DateTime                  @default(now())
-  updatedAt       DateTime                  @updatedAt
-  name            String                    @unique
-  slug            String?                   @unique
-  image_url       String?
-  subtitle        String? // short description
-  description     String
-  keywords        String[]
-  memberString    String[] // string list of member names
-  links           String[] // string list of links
-  hidden          Boolean                   @default(false)
-  members         User[]
-  endorsements    NodeFeedItemEndorsement[]
-  CommunityMember CommunityMember[]
-  Attestation     Attestation[]
-  NodeAttestation NodeAttestation[]
+  id                        Int                         @id @default(autoincrement())
+  createdAt                 DateTime                    @default(now())
+  updatedAt                 DateTime                    @updatedAt
+  name                      String                      @unique
+  slug                      String?                     @unique
+  image_url                 String?
+  subtitle                  String? // short description
+  description               String
+  keywords                  String[]
+  memberString              String[] // string list of member names
+  links                     String[] // string list of links
+  hidden                    Boolean                     @default(false)
+  members                   User[]
+  endorsements              NodeFeedItemEndorsement[]
+  CommunityMember           CommunityMember[]
+  Attestation               Attestation[]
+  NodeAttestation           NodeAttestation[]
   AttestationTemplate       AttestationTemplate[]
   CommunityEntryAttestation CommunityEntryAttestation[]
 }
@@ -740,6 +742,21 @@ model NodeAttestationVerification {
   @@unique([nodeAttestationId, userId])
 }
 
+model PublishTaskQueue {
+  id            Int                    @id @default(autoincrement())
+  ceramicStream String
+  cid           String
+  dpid          String?
+  userId        Int
+  transactionId String                 @unique
+  uuid          String
+  status        PublishTaskQueueStatus
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
+  node Node @relation(fields: [uuid], references: [uuid])
+  user User @relation(fields: [userId], references: [id])
+}
+
 enum CommunityMembershipRole {
   ADMIN
   MEMBER
@@ -781,6 +798,7 @@ enum ActionType {
   RETRIEVE_URL_FAIL
   RETREIVE_URL_SUCCESS
   USER_TERMS_CONSENT
+  PUBLISH_NODE
   PUBLISH_NODE_CID_SUCCESS
   PUBLISH_NODE_CID_FAIL
   PUBLISH_NODE_RESEARCH_OBJECT_SUCCESS
@@ -820,6 +838,12 @@ enum PublishState {
   WAITING
   PENDING
   SUCCESS
+  FAILED
+}
+
+enum PublishTaskQueueStatus {
+  WAITING
+  PENDING
   FAILED
 }
 

--- a/desci-server/src/server.ts
+++ b/desci-server/src/server.ts
@@ -28,6 +28,7 @@ import { NotFoundError } from './internal.js';
 import { logger } from './logger.js';
 import { ensureUserIfPresent } from './middleware/ensureUserIfPresent.js';
 import { errorHandler } from './middleware/errorHandler.js';
+import { runWorkerUntilStopped } from './workers/publish.js';
 
 const __filename = fileURLToPath(import.meta.url);
 // const __dirname = path.dirname(__filename);
@@ -112,6 +113,9 @@ class AppServer {
       this.#readyResolvers.forEach((resolve) => resolve(true));
       console.log(`Server running on port ${this.port}`);
     });
+
+    // init publish worker
+    this.#initWorker();
   }
 
   get httpServer() {
@@ -205,6 +209,10 @@ class AppServer {
     } else {
       logger.info('[DeSci Nodes] Telemetry disabled');
     }
+  }
+
+  async #initWorker() {
+    await runWorkerUntilStopped();
   }
 }
 

--- a/desci-server/src/services/interactionLog.ts
+++ b/desci-server/src/services/interactionLog.ts
@@ -13,6 +13,13 @@ export const saveInteraction = async (req: Request, action: ActionType, data: an
   });
 };
 
+export const saveInteractionWithoutReq = async (action: ActionType, data: any, userId?: number) => {
+  logger.info({ fn: 'saveInteractionController' }, 'interactionLog::saveInteraction');
+  return await prisma.interactionLog.create({
+    data: { userId, rep: 0, action, extra: JSON.stringify(data) },
+  });
+};
+
 export const getUserConsent = async (userId?: number) => {
   logger.info({ fn: 'getUserConsent', userId }, 'interactionLog::getUserConsent');
   return await prisma.interactionLog.findFirst({

--- a/desci-server/src/theGraph.ts
+++ b/desci-server/src/theGraph.ts
@@ -9,6 +9,7 @@ import { decodeBase64UrlSafeToHex } from './utils.js';
 
 export const getIndexedResearchObjects = async (urlSafe64s: string[]) => {
   const hex = urlSafe64s.map(decodeBase64UrlSafeToHex).map((h) => `0x${h}`);
+  logger.info({ hex, urlSafe64s }, 'getIndexedResearchObjects');
   const q = `{
     researchObjects(where: { id_in: ["${hex.join('","')}"]}) {
       id, id10, recentCid, owner, versions(orderBy: time, orderDirection: desc) {

--- a/desci-server/src/workers/publish.ts
+++ b/desci-server/src/workers/publish.ts
@@ -1,0 +1,101 @@
+import { PublishTaskQueueStatus } from '@prisma/client';
+import { ethers } from 'ethers';
+
+import { prisma } from '../client.js';
+import { publishHandler } from '../controllers/nodes/publish.js';
+import { logger as parentLogger } from '../logger.js';
+
+enum ProcessOutcome {
+  EmptyQueue,
+  TaskCompleted,
+  Error,
+}
+
+const ETHEREUM_RPC_URL = process.env.ETHEREUM_RPC_URL || 'http://host.docker.internal:8545';
+
+if (!ETHEREUM_RPC_URL) throw new Error('Env var` ETHEREUM_RPC_URL` not set');
+
+const logger = parentLogger.child({ module: 'PUBLISH WORKER ' });
+
+const checkTransaction = async (transactionId: string, uuid: string) => {
+  const provider = ethers.getDefaultProvider(ETHEREUM_RPC_URL);
+  logger.info(
+    {
+      uuid,
+      transactionId,
+      ETHEREUM_RPC_URL,
+    },
+    'TX::check transaction',
+  );
+
+  console.log('NETWORK', await provider.getNetwork());
+  const tx = await provider.getTransactionReceipt(transactionId);
+  console.log('TX::Receipt', { tx });
+  return tx?.status;
+};
+
+async function processPublishQueue() {
+  const task = await dequeueTask();
+
+  if (!task) return ProcessOutcome.EmptyQueue;
+
+  try {
+    const txStatus = await checkTransaction(task.transactionId, task.uuid);
+    if (txStatus === 1) {
+      // todo: dispatch publish task
+      publishHandler(task)
+        .then((published) => {
+          logger.info({ task, published }, 'PUBLISH SUCCESS');
+        })
+        .catch((err) => {
+          logger.info({ task, err }, 'PUBLISH FAILED');
+        });
+      // todo: dequeue task
+      await prisma.publishTaskQueue.delete({ where: { id: task.id } });
+    } else if (txStatus === 0) {
+      await prisma.publishTaskQueue.update({ where: { id: task.id }, data: { status: PublishTaskQueueStatus.FAILED } });
+      logger.info({ txStatus }, 'PUBLISH TX Receipt');
+    } else {
+      await prisma.publishTaskQueue.update({
+        where: { id: task.id },
+        data: { status: PublishTaskQueueStatus.PENDING },
+      });
+      logger.info({ txStatus }, 'PUBLISH TX Might be stuck');
+    }
+    return ProcessOutcome.TaskCompleted;
+  } catch (err) {
+    logger.error({ err }, 'ProcessPublishQueue::ERROR');
+    return ProcessOutcome.Error;
+  }
+}
+
+const dequeueTask = async () => {
+  let task = await prisma.publishTaskQueue.findFirst({ where: { status: PublishTaskQueueStatus.WAITING } });
+  if (!task) {
+    task = await prisma.publishTaskQueue.findFirst({ where: { status: PublishTaskQueueStatus.PENDING } });
+  }
+  return task;
+};
+
+const delay = async (timeMs: number) => {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+};
+
+export async function runWorkerUntilStopped() {
+  while (true) {
+    const outcome = await processPublishQueue();
+    console.log('Processed Queue', outcome);
+    switch (outcome) {
+      case ProcessOutcome.EmptyQueue:
+        await delay(10000);
+        break;
+      case ProcessOutcome.Error:
+        await delay(1000);
+        break;
+      case ProcessOutcome.TaskCompleted:
+        break;
+      default:
+        logger.error({ outcome }, 'UNREACHABLE CODE REACHED, CHECK IMMEDIATELY');
+    }
+  }
+}


### PR DESCRIPTION
# Note this update includes DB migrations

## Description of the Problem / Feature
- Implement simple task queue using postgress
- Implement worker to process task queue and trigger publish depending on transaction status
- Separate `/publish` from `publishTaskProcessor`

## Instructions on making this work
UPDATE .env to add correct `ETHEREUM_RPC_URL` value
