### PR TITLE
nodelib: hotfix issue with absolute path conversion

### DIFF
--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/src/api.ts
+++ b/nodes-lib/src/api.ts
@@ -958,11 +958,15 @@ const getHeaders = (isFormData: boolean = false) => {
 */
 export const makeAbsolutePath = (path: string) => {
   // Sensible definitions of root
-  if (!path || path === "root" || path === "root/") return "root";
+  const ROOT_ALIASES = [ "root", "root/", "/" ];
+  if (!path || ROOT_ALIASES.includes(path)) return "root";
+
   // Support unix-style absolute paths
   if (path.startsWith("/")) return `root${path}`;
+
   // What endpoints actually expect
   if (path.startsWith("root/")) return path;
+
   // Just add root to other paths
   return `root/${path}`;
 };


### PR DESCRIPTION
My waterproof path conversion missed the humble `/` as a definition for drive root. Hence, it fell through and set `root/` which broke stuff :)