### PR TITLE
Email hotfix

### DIFF
--- a/desci-server/src/templates/emails/MagicCode.tsx
+++ b/desci-server/src/templates/emails/MagicCode.tsx
@@ -31,7 +31,7 @@ export const MagicCodeEmail = ({ magicCode }: MagicCodeEmailProps) => (
             Your magic code is ready!
           </Heading>
           <Section className="mx-auto w-fit my-5 bg-opacity-90 backdrop-blur-xl rounded-md px-14 py-3" align="center">
-            <Text className="text-lg text-center tracking-[0.3em]">{magicCode}420420</Text>
+            <Text className="text-lg text-center tracking-[0.3em]  text-primary-hover">{magicCode}</Text>
           </Section>
         </Container>
       </Body>


### PR DESCRIPTION
## Description of the Problem / Feature
- Placeholders were left in magic code email by mistake
## Explanation of the solution
- Removed placeholders
