### PR TITLE
Contributor API changes

### DIFF
--- a/desci-server/src/controllers/nodes/contributions/create.ts
+++ b/desci-server/src/controllers/nodes/contributions/create.ts
@@ -74,7 +74,10 @@ export const addContributor = async (req: AddContributorRequest, res: Response<A
     }
 
     if (user.id !== contributorAdded.userId && email) {
-      logger.info({ contributorId, recipient: email }, 'Firing off contributor invite email');
+      logger.info(
+        { contributorId, recipient: email },
+        'Firing off contributor invite email for newly invited contributor',
+      );
       // Generate a share code for the contributor if it's the node owner themselves
       const shareCode = await contributorService.generatePrivShareCodeForContribution(contributorAdded, node);
 

--- a/desci-server/src/controllers/nodes/contributions/update.ts
+++ b/desci-server/src/controllers/nodes/contributions/update.ts
@@ -81,6 +81,7 @@ export const updateContributor = async (req: UpdateContributorRequest, res: Resp
       // Future:
       if (currentEmail !== email && email !== user.email) {
         // If email was changed, send a new email.
+        logger.info({ contributorId, recipient: email }, 'Firing off contributor invite email for updated contributor');
 
         const shareCode = await contributorService.generatePrivShareCodeForContribution(contributorUpdated, node);
         // Fire off an email -> make it count as a friend referral


### PR DESCRIPTION
## Description of the Problem / Feature
- Contributor invites that weren't issued using a users email didn't receive emails, even if they've a nodes profile.
- Same issue for updates
## Explanation of the solution
- Improved, if a contributor is invited via their userId or ORCID and they have a nodes profile, they now receive an invite to the email under their nodes profile.
