### PR TITLE
Contributor API adjustments

### DIFF
--- a/desci-server/src/controllers/users/search.ts
+++ b/desci-server/src/controllers/users/search.ts
@@ -3,8 +3,9 @@ import { Request, Response } from 'express';
 
 import { prisma } from '../../client.js';
 import { logger as parentLogger } from '../../logger.js';
+import { orcidRegex } from '../../utils.js';
 
-export type SearchProfilesRequest = Request<never, never, never, { name: string }> & {
+export type SearchProfilesRequest = Request<never, never, never, { name?: string; orcid?: string }> & {
   user: User; // added by auth middleware
 };
 
@@ -20,18 +21,28 @@ export type UserProfile = { name: string; id: number; orcid?: string };
 
 export const searchProfiles = async (req: SearchProfilesRequest, res: Response<SearchProfilesResBody>) => {
   const user = req.user;
-  const { name } = req.query;
+  const { name, orcid } = req.query;
   const logger = parentLogger.child({
     module: 'Users::searchProfiles',
     body: req.body,
     userId: user.id,
     name,
+    orcid,
+    queryType: orcid ? 'orcid' : 'name',
   });
 
-  if (name.toString().length < 2) return res.status(400).json({ error: 'Name query must be at least 2 characters' });
+  if (orcid && orcidRegex.test(orcid) === false)
+    return res
+      .status(400)
+      .json({ error: 'Invalid orcid id, orcid must follow either 123456780000 or 1234-4567-8000-0000 format.' });
+
+  if (name.toString().length < 2 && !orcid)
+    return res.status(400).json({ error: 'Name query must be at least 2 characters' });
 
   try {
-    const profiles = await prisma.user.findMany({ where: { name: { contains: name as string, mode: 'insensitive' } } });
+    const profiles = orcid
+      ? await prisma.user.findMany({ where: { orcid: orcid } })
+      : await prisma.user.findMany({ where: { name: { contains: name as string, mode: 'insensitive' } } });
 
     if (profiles) {
       const profilesReturn: UserProfile[] = profiles.map((profile) => ({

--- a/desci-server/src/utils.ts
+++ b/desci-server/src/utils.ts
@@ -236,3 +236,10 @@ export function omitKeys(obj: Record<string, any>, filterList: string[]): Record
     .filter((key) => !filterList.includes(key))
     .reduce((newObj, key) => ({ ...newObj, [key]: obj[key] }), {});
 }
+
+/**
+ * Accepts either 16 digits or 4 groups of 4 digits separated by hyphens.
+ * e.g. 0000-0000-0000-0000
+ * or 0000000000000000
+ */
+export const orcidRegex: RegExp = /^\d{4}-?\d{4}-?\d{4}-?\d{3}[\dX]$/;


### PR DESCRIPTION


## Description of the Problem / Feature
- Nodes profiles found via search didn't return a users orcid if they've set it up
- Can't search nodes profiles via orcid
## Explanation of the solution
- User profile search now returns orcids if the user has one setup, this helps in prefilling contributor orcid info if a user has  linked nodes profile.
- Expanded search api for nodes profiles to also accept an orcid id, accepting either 16 digits or 4 digits * 4 separated by hyphens.

