### PR TITLE
Contributor api change

### DIFF
--- a/desci-server/src/routes/v1/nodes.ts
+++ b/desci-server/src/routes/v1/nodes.ts
@@ -67,11 +67,11 @@ router.get('/cover/:uuid/:version', [], getCoverImage);
 router.get('/documents/:uuid', [ensureUser, ensureNodeAccess], getNodeDocument);
 router.post('/documents/:uuid/actions', [ensureUser, ensureNodeAccess], dispatchDocumentChange);
 router.get('/thumbnails/:uuid/:manifestCid?', [attachUser], thumbnails);
+router.post('/contributions/node/:uuid', [attachUser], getNodeContributions);
 router.post('/contributions/:uuid', [ensureUser, ensureWriteNodeAccess], addContributor);
 router.patch('/contributions/:uuid', [ensureUser, ensureWriteNodeAccess], updateContributor);
 router.delete('/contributions/:uuid', [ensureUser, ensureWriteNodeAccess], deleteContributor);
 router.get('/contributions/user/:userId', [], getUserContributions);
-router.get('/contributions/node/:uuid', [attachUser], getNodeContributions);
 router.patch('/contributions/verify', [ensureUser], verifyContribution);
 
 router.delete('/:uuid', [ensureUser], deleteNode);


### PR DESCRIPTION
## Description of the Problem / Feature
Compatibility issues when trying to send up a JSON body in a GET request in browsers prevent it from being sent up to the server
## Explanation of the solution
Changed the affected route to a post, moved it up to not collide with the other post endpoint for adding contributors.

