### PR TITLE
Contributor api verification fix

### DIFF
--- a/desci-server/src/services/Contributors.ts
+++ b/desci-server/src/services/Contributors.ts
@@ -226,7 +226,7 @@ class ContributorService {
     const contribution = await prisma.nodeContribution.findUnique({ where: { contributorId } });
     if (!contribution) throw Error('Invalid contributorId');
 
-    const contributionPointsToUser = contribution.email === user.email || contribution.orcid === user.orcid;
+    const contributionPointsToUser = contribution.email === user.email || contribution.orcid === user.orcid || contribution.userId === user.id;
     if (!contributionPointsToUser) throw Error('Unauthorized to verify contribution');
 
     const userHasOrcidValidated = user.orcid !== undefined && user.orcid !== null;


### PR DESCRIPTION
Contributors are only able to verify if they were invited via orcid/email, fixed to enable also verifying if added directly via nodes profile (userId)