### PR TITLE
nodes-lib token ownership check & DIDSession support

### DIFF
--- a/nodes-lib/package-lock.json
+++ b/nodes-lib/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.5-rc9",
       "license": "MIT",
       "dependencies": {
-        "@desci-labs/desci-codex-lib": "^1.1.7-rc0",
+        "@desci-labs/desci-codex-lib": "^1.1.7",
         "@desci-labs/desci-contracts": "^0.2.3-rc3",
         "@desci-labs/desci-models": "^0.2.3-rc1",
         "@didtools/cacao": "^3.0.1",
@@ -27,7 +27,6 @@
       "devDependencies": {
         "@types/mime-types": "^2.1.4",
         "@types/node": "^20.11.5",
-        "dids": "^5.0.2",
         "typedoc": "^0.25.8",
         "typescript": "^5.3.3",
         "vitest": "^1.2.1",
@@ -988,25 +987,25 @@
       }
     },
     "node_modules/@desci-labs/desci-codex-composedb": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-composedb/-/desci-codex-composedb-2.0.0.tgz",
-      "integrity": "sha512-OygjqzwJ4jjHuKg+MDfJmil7+67mhdO6041usZAbdT5iLoQB9Jl4XSJo/l/GXrHRwmbW/LbXcEij+Aa0abLlOw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-composedb/-/desci-codex-composedb-2.0.1.tgz",
+      "integrity": "sha512-ahtxnsX/bQ52X2fPgRZisx7cdhX7b2nEj+d+PY0q33+qDzVHPeAd6Gi3Er2h9djX6bDRmH5X5kpr46v/XTOPMg==",
       "dependencies": {
         "@composedb/types": "^0.7.1"
       }
     },
     "node_modules/@desci-labs/desci-codex-lib": {
-      "version": "1.1.7-rc0",
-      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-lib/-/desci-codex-lib-1.1.7-rc0.tgz",
-      "integrity": "sha512-IFz3ApgI3Ya8RtRtaUknT3Gh8UPF1fkGvnkzXktTUo/T32UxUR2x+e00NheBfeXuaek6LQzogBOMooVDBKmscA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-lib/-/desci-codex-lib-1.1.7.tgz",
+      "integrity": "sha512-Z06qpACxorVPn4tp35XHro2KTqvp0rVoaMkxwGssVM+4DqeuV3jEudyrSIZTc0A2BJ2SuqMYC9WtBdbq6/Py1w==",
       "dependencies": {
         "@composedb/client": "^0.7.1",
-        "@desci-labs/desci-codex-composedb": "^2.0.0",
+        "@desci-labs/desci-codex-composedb": "^2.0.1",
         "dids": "^5.0.2",
         "gql-query-builder": "^3.8.0",
         "graphql": "^16.8.0",
-        "key-did-provider-ed25519": "^3.0.2",
-        "key-did-resolver": "^3.0.0",
+        "key-did-provider-ed25519": "^4.0.2",
+        "key-did-resolver": "^4.0.0",
         "uint8arrays": "^4.0.6"
       }
     },
@@ -4341,14 +4340,6 @@
       "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
       "integrity": "sha512-ddkU+dFIuEIW8lE7ZwdIAf2UPoM90eaprg5m3YXAVVTmKlqV/9BX4A2M8BOK2yOq6/VgZFVhK6QAxJebhlbhzw=="
     },
-    "node_modules/bigint-mod-arith": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.3.1.tgz",
-      "integrity": "sha512-pX/cYW3dCa87Jrzv6DAr8ivbbJRzEX5yGhdt8IutnX/PCIXfpx+mabWNK/M8qqh+zQ0J3thftUBHW0ByuUlG0w==",
-      "engines": {
-        "node": ">=10.4.0"
-      }
-    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -5173,36 +5164,6 @@
         "key-did-provider-ed25519": "^4.0.2",
         "key-did-resolver": "^4.0.0",
         "uint8arrays": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/did-session/node_modules/key-did-provider-ed25519": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-4.0.2.tgz",
-      "integrity": "sha512-bnnRGuuUtylKGMVmgXVSoGccBg87roFi6xy5dQmTgNqnCmrxBBUatYoVimcnA+SGCFqi2qk6B9dD10Ed4rTZPg==",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "did-jwt": "^7.4.7",
-        "dids": "^5.0.2",
-        "fast-json-stable-stringify": "^2.1.0",
-        "rpc-utils": "^0.6.2",
-        "uint8arrays": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/did-session/node_modules/key-did-resolver": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-4.0.0.tgz",
-      "integrity": "sha512-+U2nd/0rjO4Yqe2hnHBD7ygcLRfT43Oje9IIjv1BlBi0lopwxZpIFQ7GekguOHK02r+JGdl8mpJVNHs5lvXVOA==",
-      "dependencies": {
-        "@noble/curves": "^1.2.0",
-        "multiformats": "^13.0.0",
-        "uint8arrays": "^5.0.1",
-        "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=14.14"
@@ -6818,160 +6779,49 @@
       }
     },
     "node_modules/key-did-provider-ed25519": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-3.0.2.tgz",
-      "integrity": "sha512-4Yw0CeO1hKRaUsh9NIz4tn4Ysr09CdoJItyT0vHjd5iedJ+FvVt7pTbNr7IY0/+8mWvYslutAK5LFrwu5agpsA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-4.0.2.tgz",
+      "integrity": "sha512-bnnRGuuUtylKGMVmgXVSoGccBg87roFi6xy5dQmTgNqnCmrxBBUatYoVimcnA+SGCFqi2qk6B9dD10Ed4rTZPg==",
       "dependencies": {
-        "@noble/curves": "^1.1.0",
-        "did-jwt": "^7.2.0",
-        "dids": "^4.0.4",
+        "@noble/curves": "^1.3.0",
+        "did-jwt": "^7.4.7",
+        "dids": "^5.0.2",
         "fast-json-stable-stringify": "^2.1.0",
         "rpc-utils": "^0.6.2",
-        "uint8arrays": "^4.0.3"
+        "uint8arrays": "^5.0.1"
       },
       "engines": {
         "node": ">=14.14"
       }
     },
-    "node_modules/key-did-provider-ed25519/node_modules/@didtools/cacao": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
-      "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+    "node_modules/key-did-provider-ed25519/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
       "dependencies": {
-        "@didtools/codecs": "^1.0.1",
-        "@didtools/siwx": "1.0.0",
-        "@ipld/dag-cbor": "^9.0.1",
-        "caip": "^1.1.0",
-        "multiformats": "^11.0.2",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/@didtools/codecs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@didtools/codecs/-/codecs-1.0.1.tgz",
-      "integrity": "sha512-6PYXOCX7mwVWUcudKQ3eW5LtI8v5esozazbf2q2F01PE+LoeEvTytvgU9FEspj4pATpq3hPx1eenX2uLirDJ8w==",
-      "dependencies": {
-        "codeco": "^1.1.0",
-        "multiformats": "^11.0.1",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/@didtools/pkh-ethereum": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@didtools/pkh-ethereum/-/pkh-ethereum-0.4.1.tgz",
-      "integrity": "sha512-oE5bbyTauJ/WddaWnDK7bWns2E2LG4Ut33ICEcEQdlMoXM0902/vnGm8+6QE/yuLOyAllgf7DnDKvERF5IY6uQ==",
-      "dependencies": {
-        "@didtools/cacao": "^2.1.0",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "@stablelib/random": "^1.0.2",
-        "caip": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/@didtools/siwx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@didtools/siwx/-/siwx-1.0.0.tgz",
-      "integrity": "sha512-b7sPDTNHdySoJ+Rp2p06x3rg1iTxI4yPTTA3PrPh40xcvFJ0K/YhdIb/Rzff13t92arcJ+VYGFhqtJorauV91g==",
-      "dependencies": {
-        "codeco": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/cborg": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
-      "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==",
-      "bin": {
-        "cborg": "cli.js"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/dag-jose-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-3.0.0.tgz",
-      "integrity": "sha512-gu+XutOTy3kD8fDcA1SMjZ2U0mUOb/hxoRVZaMCizXN7Ssbc5dKOzeXQ4GquV4BdQzs3w5Y7irOpn2plFPIJfg==",
-      "dependencies": {
-        "@ipld/dag-cbor": "^7.0.1",
-        "multiformats": "^11.0.1"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/dag-jose-utils/node_modules/@ipld/dag-cbor": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
-      "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/dag-jose-utils/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/dids": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/dids/-/dids-4.0.4.tgz",
-      "integrity": "sha512-PKxQP0QFqgeMe0dbL7LCRdPJVhZU2ejj8RWCfJ6vro3a+o5o32cWNM1X6YXpdIWq6G5fTJw9KO2dHj2ZzYDc7w==",
-      "dependencies": {
-        "@didtools/cacao": "^2.1.0",
-        "@didtools/codecs": "^1.0.1",
-        "@didtools/pkh-ethereum": "^0.4.1",
-        "@stablelib/random": "^1.0.1",
-        "codeco": "^1.1.0",
-        "dag-jose-utils": "^3.0.0",
-        "did-jwt": "^7.2.0",
-        "did-resolver": "^4.1.0",
-        "multiformats": "^11.0.2",
-        "rpc-utils": "^0.6.1",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/key-did-provider-ed25519/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/key-did-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-3.0.0.tgz",
-      "integrity": "sha512-IyEq64AdS6lUwtn3YSvGpu7KAGA2x5+fjRCUIa8+ccSLmWrODV/ICM5aa6hHV/19EPWef8/e322r9sQJJ6/3qA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-4.0.0.tgz",
+      "integrity": "sha512-+U2nd/0rjO4Yqe2hnHBD7ygcLRfT43Oje9IIjv1BlBi0lopwxZpIFQ7GekguOHK02r+JGdl8mpJVNHs5lvXVOA==",
       "dependencies": {
-        "@stablelib/ed25519": "^1.0.2",
-        "bigint-mod-arith": "^3.1.0",
-        "multiformats": "^11.0.1",
-        "nist-weierstrauss": "^1.6.1",
-        "uint8arrays": "^4.0.3",
+        "@noble/curves": "^1.2.0",
+        "multiformats": "^13.0.0",
+        "uint8arrays": "^5.0.1",
         "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=14.14"
       }
     },
-    "node_modules/key-did-resolver/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+    "node_modules/key-did-resolver/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/knex": {
@@ -7895,28 +7745,6 @@
       "optional": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nist-weierstrauss": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/nist-weierstrauss/-/nist-weierstrauss-1.6.1.tgz",
-      "integrity": "sha512-FpjCOnPV/s3ZVIkeldCVSml2K4lruabPbBgoEitpCK1JL0KTVoWb56CFTU6rZn5i6VqAjdwcOp0FDwJACPmeFA==",
-      "dependencies": {
-        "multiformats": "^9.6.5",
-        "uint8arrays": "^2.1.4"
-      }
-    },
-    "node_modules/nist-weierstrauss/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
-    "node_modules/nist-weierstrauss/node_modules/uint8arrays": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-      "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
       }
     },
     "node_modules/node-abi": {
@@ -10989,25 +10817,25 @@
       }
     },
     "@desci-labs/desci-codex-composedb": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-composedb/-/desci-codex-composedb-2.0.0.tgz",
-      "integrity": "sha512-OygjqzwJ4jjHuKg+MDfJmil7+67mhdO6041usZAbdT5iLoQB9Jl4XSJo/l/GXrHRwmbW/LbXcEij+Aa0abLlOw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-composedb/-/desci-codex-composedb-2.0.1.tgz",
+      "integrity": "sha512-ahtxnsX/bQ52X2fPgRZisx7cdhX7b2nEj+d+PY0q33+qDzVHPeAd6Gi3Er2h9djX6bDRmH5X5kpr46v/XTOPMg==",
       "requires": {
         "@composedb/types": "^0.7.1"
       }
     },
     "@desci-labs/desci-codex-lib": {
-      "version": "1.1.7-rc0",
-      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-lib/-/desci-codex-lib-1.1.7-rc0.tgz",
-      "integrity": "sha512-IFz3ApgI3Ya8RtRtaUknT3Gh8UPF1fkGvnkzXktTUo/T32UxUR2x+e00NheBfeXuaek6LQzogBOMooVDBKmscA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@desci-labs/desci-codex-lib/-/desci-codex-lib-1.1.7.tgz",
+      "integrity": "sha512-Z06qpACxorVPn4tp35XHro2KTqvp0rVoaMkxwGssVM+4DqeuV3jEudyrSIZTc0A2BJ2SuqMYC9WtBdbq6/Py1w==",
       "requires": {
         "@composedb/client": "^0.7.1",
-        "@desci-labs/desci-codex-composedb": "^2.0.0",
+        "@desci-labs/desci-codex-composedb": "^2.0.1",
         "dids": "^5.0.2",
         "gql-query-builder": "^3.8.0",
         "graphql": "^16.8.0",
-        "key-did-provider-ed25519": "^3.0.2",
-        "key-did-resolver": "^3.0.0",
+        "key-did-provider-ed25519": "^4.0.2",
+        "key-did-resolver": "^4.0.0",
         "uint8arrays": "^4.0.6"
       }
     },
@@ -13331,11 +13159,6 @@
       "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
       "integrity": "sha512-ddkU+dFIuEIW8lE7ZwdIAf2UPoM90eaprg5m3YXAVVTmKlqV/9BX4A2M8BOK2yOq6/VgZFVhK6QAxJebhlbhzw=="
     },
-    "bigint-mod-arith": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.3.1.tgz",
-      "integrity": "sha512-pX/cYW3dCa87Jrzv6DAr8ivbbJRzEX5yGhdt8IutnX/PCIXfpx+mabWNK/M8qqh+zQ0J3thftUBHW0ByuUlG0w=="
-    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -14018,30 +13841,6 @@
         "uint8arrays": "^5.0.1"
       },
       "dependencies": {
-        "key-did-provider-ed25519": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-4.0.2.tgz",
-          "integrity": "sha512-bnnRGuuUtylKGMVmgXVSoGccBg87roFi6xy5dQmTgNqnCmrxBBUatYoVimcnA+SGCFqi2qk6B9dD10Ed4rTZPg==",
-          "requires": {
-            "@noble/curves": "^1.3.0",
-            "did-jwt": "^7.4.7",
-            "dids": "^5.0.2",
-            "fast-json-stable-stringify": "^2.1.0",
-            "rpc-utils": "^0.6.2",
-            "uint8arrays": "^5.0.1"
-          }
-        },
-        "key-did-resolver": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-4.0.0.tgz",
-          "integrity": "sha512-+U2nd/0rjO4Yqe2hnHBD7ygcLRfT43Oje9IIjv1BlBi0lopwxZpIFQ7GekguOHK02r+JGdl8mpJVNHs5lvXVOA==",
-          "requires": {
-            "@noble/curves": "^1.2.0",
-            "multiformats": "^13.0.0",
-            "uint8arrays": "^5.0.1",
-            "varint": "^6.0.0"
-          }
-        },
         "uint8arrays": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
@@ -15321,135 +15120,46 @@
       }
     },
     "key-did-provider-ed25519": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-3.0.2.tgz",
-      "integrity": "sha512-4Yw0CeO1hKRaUsh9NIz4tn4Ysr09CdoJItyT0vHjd5iedJ+FvVt7pTbNr7IY0/+8mWvYslutAK5LFrwu5agpsA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-4.0.2.tgz",
+      "integrity": "sha512-bnnRGuuUtylKGMVmgXVSoGccBg87roFi6xy5dQmTgNqnCmrxBBUatYoVimcnA+SGCFqi2qk6B9dD10Ed4rTZPg==",
       "requires": {
-        "@noble/curves": "^1.1.0",
-        "did-jwt": "^7.2.0",
-        "dids": "^4.0.4",
+        "@noble/curves": "^1.3.0",
+        "did-jwt": "^7.4.7",
+        "dids": "^5.0.2",
         "fast-json-stable-stringify": "^2.1.0",
         "rpc-utils": "^0.6.2",
-        "uint8arrays": "^4.0.3"
+        "uint8arrays": "^5.0.1"
       },
       "dependencies": {
-        "@didtools/cacao": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@didtools/cacao/-/cacao-2.1.0.tgz",
-          "integrity": "sha512-35gopj+mOmAlA3nHoHiYMvNMXJtbJDJnVpIlCf/Wf/+/x+uG9aIQefXfF35D6JuaTCZ0apabjpT2umL5h3EXcw==",
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
           "requires": {
-            "@didtools/codecs": "^1.0.1",
-            "@didtools/siwx": "1.0.0",
-            "@ipld/dag-cbor": "^9.0.1",
-            "caip": "^1.1.0",
-            "multiformats": "^11.0.2",
-            "uint8arrays": "^4.0.3"
+            "multiformats": "^13.0.0"
           }
-        },
-        "@didtools/codecs": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@didtools/codecs/-/codecs-1.0.1.tgz",
-          "integrity": "sha512-6PYXOCX7mwVWUcudKQ3eW5LtI8v5esozazbf2q2F01PE+LoeEvTytvgU9FEspj4pATpq3hPx1eenX2uLirDJ8w==",
-          "requires": {
-            "codeco": "^1.1.0",
-            "multiformats": "^11.0.1",
-            "uint8arrays": "^4.0.3"
-          }
-        },
-        "@didtools/pkh-ethereum": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@didtools/pkh-ethereum/-/pkh-ethereum-0.4.1.tgz",
-          "integrity": "sha512-oE5bbyTauJ/WddaWnDK7bWns2E2LG4Ut33ICEcEQdlMoXM0902/vnGm8+6QE/yuLOyAllgf7DnDKvERF5IY6uQ==",
-          "requires": {
-            "@didtools/cacao": "^2.1.0",
-            "@noble/curves": "^1.1.0",
-            "@noble/hashes": "^1.3.1",
-            "@stablelib/random": "^1.0.2",
-            "caip": "^1.1.0"
-          }
-        },
-        "@didtools/siwx": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@didtools/siwx/-/siwx-1.0.0.tgz",
-          "integrity": "sha512-b7sPDTNHdySoJ+Rp2p06x3rg1iTxI4yPTTA3PrPh40xcvFJ0K/YhdIb/Rzff13t92arcJ+VYGFhqtJorauV91g==",
-          "requires": {
-            "codeco": "^1.1.0"
-          }
-        },
-        "cborg": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
-          "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug=="
-        },
-        "dag-jose-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-3.0.0.tgz",
-          "integrity": "sha512-gu+XutOTy3kD8fDcA1SMjZ2U0mUOb/hxoRVZaMCizXN7Ssbc5dKOzeXQ4GquV4BdQzs3w5Y7irOpn2plFPIJfg==",
-          "requires": {
-            "@ipld/dag-cbor": "^7.0.1",
-            "multiformats": "^11.0.1"
-          },
-          "dependencies": {
-            "@ipld/dag-cbor": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
-              "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
-              "requires": {
-                "cborg": "^1.6.0",
-                "multiformats": "^9.5.4"
-              },
-              "dependencies": {
-                "multiformats": {
-                  "version": "9.9.0",
-                  "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-                  "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-                }
-              }
-            }
-          }
-        },
-        "dids": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/dids/-/dids-4.0.4.tgz",
-          "integrity": "sha512-PKxQP0QFqgeMe0dbL7LCRdPJVhZU2ejj8RWCfJ6vro3a+o5o32cWNM1X6YXpdIWq6G5fTJw9KO2dHj2ZzYDc7w==",
-          "requires": {
-            "@didtools/cacao": "^2.1.0",
-            "@didtools/codecs": "^1.0.1",
-            "@didtools/pkh-ethereum": "^0.4.1",
-            "@stablelib/random": "^1.0.1",
-            "codeco": "^1.1.0",
-            "dag-jose-utils": "^3.0.0",
-            "did-jwt": "^7.2.0",
-            "did-resolver": "^4.1.0",
-            "multiformats": "^11.0.2",
-            "rpc-utils": "^0.6.1",
-            "uint8arrays": "^4.0.3"
-          }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
         }
       }
     },
     "key-did-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-3.0.0.tgz",
-      "integrity": "sha512-IyEq64AdS6lUwtn3YSvGpu7KAGA2x5+fjRCUIa8+ccSLmWrODV/ICM5aa6hHV/19EPWef8/e322r9sQJJ6/3qA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-4.0.0.tgz",
+      "integrity": "sha512-+U2nd/0rjO4Yqe2hnHBD7ygcLRfT43Oje9IIjv1BlBi0lopwxZpIFQ7GekguOHK02r+JGdl8mpJVNHs5lvXVOA==",
       "requires": {
-        "@stablelib/ed25519": "^1.0.2",
-        "bigint-mod-arith": "^3.1.0",
-        "multiformats": "^11.0.1",
-        "nist-weierstrauss": "^1.6.1",
-        "uint8arrays": "^4.0.3",
+        "@noble/curves": "^1.2.0",
+        "multiformats": "^13.0.0",
+        "uint8arrays": "^5.0.1",
         "varint": "^6.0.0"
       },
       "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        "uint8arrays": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+          "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+          "requires": {
+            "multiformats": "^13.0.0"
+          }
         }
       }
     },
@@ -16145,30 +15855,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "optional": true
-    },
-    "nist-weierstrauss": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/nist-weierstrauss/-/nist-weierstrauss-1.6.1.tgz",
-      "integrity": "sha512-FpjCOnPV/s3ZVIkeldCVSml2K4lruabPbBgoEitpCK1JL0KTVoWb56CFTU6rZn5i6VqAjdwcOp0FDwJACPmeFA==",
-      "requires": {
-        "multiformats": "^9.6.5",
-        "uint8arrays": "^2.1.4"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        },
-        "uint8arrays": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
-      }
     },
     "node-abi": {
       "version": "3.56.0",

--- a/nodes-lib/package-lock.json
+++ b/nodes-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.5-rc5",
+  "version": "0.0.5-rc9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@desci-labs/nodes-lib",
-      "version": "0.0.5-rc5",
+      "version": "0.0.5-rc9",
       "license": "MIT",
       "dependencies": {
         "@desci-labs/desci-codex-lib": "^1.1.7-rc0",
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@types/mime-types": "^2.1.4",
         "@types/node": "^20.11.5",
+        "dids": "^5.0.2",
         "typedoc": "^0.25.8",
         "typescript": "^5.3.3",
         "vitest": "^1.2.1",

--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.5-rc8",
+  "version": "0.0.5-rc9",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@types/mime-types": "^2.1.4",
     "@types/node": "^20.11.5",
+    "dids": "^5.0.2",
     "typedoc": "^0.25.8",
     "typescript": "^5.3.3",
     "vitest": "^1.2.1",

--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.5-rc9",
+  "version": "0.0.5",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {
@@ -26,7 +26,7 @@
     "docs": "typedoc src/index.ts"
   },
   "dependencies": {
-    "@desci-labs/desci-codex-lib": "^1.1.7-rc0",
+    "@desci-labs/desci-codex-lib": "^1.1.7",
     "@desci-labs/desci-contracts": "^0.2.3-rc3",
     "@desci-labs/desci-models": "^0.2.3-rc1",
     "@didtools/cacao": "^3.0.1",
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@types/mime-types": "^2.1.4",
     "@types/node": "^20.11.5",
-    "dids": "^5.0.2",
     "typedoc": "^0.25.8",
     "typescript": "^5.3.3",
     "vitest": "^1.2.1",

--- a/nodes-lib/src/api.ts
+++ b/nodes-lib/src/api.ts
@@ -28,6 +28,7 @@ import { randomUUID } from "crypto";
 import { getNodesLibInternalConfig } from "./config/index.js";
 import { makeRequest } from "./routes.js";
 import { Signer } from "ethers";
+import { type DID } from "dids";
 
 export const ENDPOINTS = {
   deleteData: {
@@ -338,9 +339,9 @@ export type PublishResponse = {
 export const publishDraftNode = async (
   uuid: string,
   signer: Signer,
-  skipCodex = false,
+  did?: DID,
 ): Promise<PublishResponse> => {
-  const publishResult = await publish(uuid, signer, skipCodex);
+  const publishResult = await publish(uuid, signer, did);
 
   const pubParams: PublishParams = {
     uuid,

--- a/nodes-lib/src/api.ts
+++ b/nodes-lib/src/api.ts
@@ -332,6 +332,8 @@ export type PublishResponse = {
  *
  * @param uuid - UUID of node to publish
  * @param signer - Signer to use for publish, if not set with env
+ * @throws (@link WrongOwnerError) if signer address isn't research object token owner
+ * @throws (@link DpidPublishError) if dPID couldnt be registered or updated
 */
 export const publishDraftNode = async (
   uuid: string,

--- a/nodes-lib/src/codex.ts
+++ b/nodes-lib/src/codex.ts
@@ -170,5 +170,5 @@ export const getRawState = async (
   streamID: string
 ) => {
   const ceramic = newCeramicClient(getNodesLibInternalConfig().ceramicNodeUrl);
-  return await streams.loadID(ceramic, streamID);
+  return await streams.loadID(ceramic, streams.StreamID.fromString(streamID));
 };

--- a/nodes-lib/src/codex.ts
+++ b/nodes-lib/src/codex.ts
@@ -7,6 +7,7 @@ import {
   queryResearchObject,
   resolveHistory,
   newCeramicClient,
+  streams,
 } from "@desci-labs/desci-codex-lib";
 import type { IndexedNodeVersion, PrepublishResponse } from "./api.js";
 import { convert0xHexToCid } from "./util/converting.js";
@@ -160,4 +161,14 @@ export const getCodexHistory = async (
 ) => {
   const ceramic = newCeramicClient(getNodesLibInternalConfig().ceramicNodeUrl);
   return await resolveHistory(ceramic, streamID);
+};
+
+/**
+ * Get the raw stream state for a streamID.
+*/
+export const getRawState = async (
+  streamID: string
+) => {
+  const ceramic = newCeramicClient(getNodesLibInternalConfig().ceramicNodeUrl);
+  return await streams.loadID(ceramic, streamID);
 };

--- a/nodes-lib/src/config/chain.ts
+++ b/nodes-lib/src/config/chain.ts
@@ -9,14 +9,24 @@ export type NodesContract =
 export type ContractConnector<T extends NodesContract> =
   (signerOrProvider: Signer | providers.Provider) => T;
 
+export type ChainID =
+  | "1337"
+  | "11155111";
+
 export type ChainConfig = {
+  /** Decimal chain ID */
+  chainId: ChainID,
+  /** RPC URL to use for communication */
   rpcUrl: string,
+  /** Given a signer or provider, create a contract instance */
   researchObjectConnector: ContractConnector<tc.ResearchObject | tc.ResearchObjectV2>,
+  /** Given a signer or provider, create a contract instance */
   dpidRegistryConnector: ContractConnector<tc.DpidRegistry>,
 };
 
 export const CHAIN_CONFIGS = {
   local: {
+    chainId: "1337",
     rpcUrl: "http://localhost:8545",
     researchObjectConnector: signerOrProvider => tc.ResearchObject__factory.connect(
       contracts.localRoInfo.proxies.at(0)!.address,
@@ -28,6 +38,7 @@ export const CHAIN_CONFIGS = {
     ),
   },
   dev: {
+    chainId: "11155111",
     rpcUrl: "https://eth-sepolia.g.alchemy.com/v2/demo",
     researchObjectConnector: signerOrProvider => tc.ResearchObjectV2__factory.connect(
       contracts.devRoInfo.proxies.at(0)!.address,
@@ -39,6 +50,7 @@ export const CHAIN_CONFIGS = {
     ),
   },
   prod: {
+    chainId: "11155111",
     rpcUrl: "https://eth-sepolia.g.alchemy.com/v2/demo",
     researchObjectConnector: signerOrProvider => tc.ResearchObjectV2__factory.connect(
       contracts.prodRoInfo.proxies.at(0)!.address,

--- a/nodes-lib/src/config/index.ts
+++ b/nodes-lib/src/config/index.ts
@@ -1,3 +1,4 @@
+import { getResources } from "@desci-labs/desci-codex-lib";
 import { CHAIN_CONFIGS, ChainConfig } from "./chain.js";
 
 export type NodesEnv =
@@ -76,3 +77,5 @@ export const setNodesLibConfig = (newConfig: Config): void => {
 export const getNodesLibInternalConfig = () => {
   return config as Required<Config>;
 };
+
+export { getResources };

--- a/nodes-lib/src/errors.ts
+++ b/nodes-lib/src/errors.ts
@@ -1,16 +1,14 @@
-
-
-export class BaseError<T extends string> extends Error {
-  name: T;
+class BaseError<Name extends string, Cause> extends Error {
+  name: Name;
   message: string;
-  cause: any;
+  cause: Cause;
 
   constructor({
     name, message, cause
   }: {
-    name: T,
+    name: Name,
     message: string,
-    cause?: any,
+    cause: Cause,
   }) {
     super();
     this.name = name;
@@ -19,4 +17,8 @@ export class BaseError<T extends string> extends Error {
   };
 };
 
-export class PublishError extends BaseError<"DPID_PUBLISH_ERROR"> {};
+export class DpidUpdateError extends BaseError<"DPID_UPDATE_ERROR", Error> {};
+export class DpidRegistrationError extends BaseError<"DPID_REGISTRATION_ERROR", Error> {};
+export class WrongOwnerError extends BaseError<
+  "WRONG_OWNER_ERROR", { expected: string, actual: string }
+> {};

--- a/nodes-lib/src/index.ts
+++ b/nodes-lib/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./api.js"
 export * from "./config/index.js";
+export * from "./errors.js";

--- a/nodes-lib/src/publish.ts
+++ b/nodes-lib/src/publish.ts
@@ -1,37 +1,24 @@
 import { type NodeIDs } from "@desci-labs/desci-codex-lib";
 import { getDpidHistory } from "./api.js";
-import { dpidPublish, hasDpid, type DpidPublishResult } from "./chain.js";
+import { dpidPublish, hasDpid } from "./chain.js";
 import { codexPublish } from "./codex.js";
-import { PublishError } from "./errors.js";
-import { Signer, providers } from "ethers";
+import { Signer } from "ethers";
 
 /**
  * The complete publish flow, including both the dPID registry and Codex.
+ *
+ * @throws (@link WrongOwnerError) if signer address isn't token owner
+ * @throws (@link DpidPublishError) if dPID couldnt be registered or updated
 */
 export const publish = async (
   uuid: string,
   provider: Signer,
   skipCodex: boolean = false,
 ) => {
-  let chainPubResponse: DpidPublishResult;
-  let preexistingDpid: boolean;
-    preexistingDpid = await hasDpid(uuid, provider);
-  try {
-    chainPubResponse = await dpidPublish(uuid, preexistingDpid, provider);
-  } catch (e) {
-    /**
-     * dPID registry operations failed. Since we can't know if the prepublish
-     * results will be the same next time around, skip doing ceramic publish
-     * to avoid historical drift.
-     */
-    const err = e as Error;
-    throw new PublishError({
-      name: "DPID_PUBLISH_ERROR",
-      message: "dPID registration failed",
-      cause: JSON.stringify(err, undefined, 2),
-    });
-  };
+  const preexistingDpid = await hasDpid(uuid, provider);
 
+  // Throws on ownership check or dpid publish/update failure
+  const chainPubResponse = await dpidPublish(uuid, preexistingDpid, provider);
   const dpidResult = {
     manifest: chainPubResponse.prepubResult.updatedManifest,
     cid: chainPubResponse.prepubResult.updatedManifestCid,

--- a/nodes-lib/src/publish.ts
+++ b/nodes-lib/src/publish.ts
@@ -3,31 +3,32 @@ import { getDpidHistory } from "./api.js";
 import { dpidPublish, hasDpid } from "./chain.js";
 import { codexPublish } from "./codex.js";
 import { Signer } from "ethers";
+import { type DID } from "dids";
 
 /**
  * The complete publish flow, including both the dPID registry and Codex.
+ * 
+ * @param uuid - Node to publish
+ * @param signer - Used to sign TXs for chain, and a SIWE CACAO for ceramic if did argument is not present
+ * @param did - An authenticated DID from a DIDSession, better UX as it has a signing capability already
  *
  * @throws (@link WrongOwnerError) if signer address isn't token owner
  * @throws (@link DpidPublishError) if dPID couldnt be registered or updated
 */
 export const publish = async (
   uuid: string,
-  provider: Signer,
-  skipCodex: boolean = false,
+  signer: Signer,
+  did?: DID,
 ) => {
-  const preexistingDpid = await hasDpid(uuid, provider);
+  const preexistingDpid = await hasDpid(uuid, signer);
 
   // Throws on ownership check or dpid publish/update failure
-  const chainPubResponse = await dpidPublish(uuid, preexistingDpid, provider);
+  const chainPubResponse = await dpidPublish(uuid, preexistingDpid, signer);
   const dpidResult = {
     manifest: chainPubResponse.prepubResult.updatedManifest,
     cid: chainPubResponse.prepubResult.updatedManifestCid,
     transactionId: chainPubResponse.reciept.transactionHash,
     ceramicIDs: undefined,
-  };
-
-  if (skipCodex) {
-    return dpidResult;
   };
 
   let ceramicIDs: NodeIDs | undefined;
@@ -36,7 +37,7 @@ export const publish = async (
     const publishHistory = preexistingDpid
       ? (await getDpidHistory(uuid)).versions
       : [];
-    ceramicIDs = await codexPublish(chainPubResponse.prepubResult, publishHistory, provider);
+    ceramicIDs = await codexPublish(chainPubResponse.prepubResult, publishHistory, did ?? signer);
   } catch (e) {
     const err = e as Error;
     console.log("Codex publish failed:", err);

--- a/nodes-lib/src/routes.ts
+++ b/nodes-lib/src/routes.ts
@@ -41,7 +41,8 @@ export async function makeRequest<
     withCredentials: true,
   };
 
-  if (window !== undefined && localStorage.getItem("auth")) {
+  // Can't check against undefined if variable doesn't exist
+  if (typeof window !== "undefined" && localStorage.getItem("auth")) {
     config.headers!.Authorization = `Bearer ${localStorage.getItem("auth")}`;
   };
 

--- a/nodes-lib/test/root.spec.ts
+++ b/nodes-lib/test/root.spec.ts
@@ -32,7 +32,7 @@ import {
 } from "@desci-labs/desci-models";
 import { authorizedSessionDidFromSigner, signerFromPkey } from "../src/util/signing.js";
 import { NODESLIB_CONFIGS, getNodesLibInternalConfig, setApiKey, setNodesLibConfig } from "../src/index.js";
-import { newComposeClient, getResources } from "@desci-labs/desci-codex-lib";
+import { getResources } from "@desci-labs/desci-codex-lib";
 
 // Pre-funded ganache account
 const TEST_PKEY = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";

--- a/nodes-lib/test/root.spec.ts
+++ b/nodes-lib/test/root.spec.ts
@@ -310,6 +310,15 @@ describe("nodes-lib", () => {
         expect(controller).toEqual(did.parent);
         expect(controller!.replace("did:pkh:eip155:1337:", "")).toEqual(signerAddress);
       });
+
+      test("can optionally derive DID from just a signer", async () => {
+        const { node } = await createBoilerplateNode();
+        const result = await publishDraftNode(node.uuid, testSigner);
+        const streamState = await getRawState(result.ceramicIDs!.streamID);
+        const controller = streamState.state.metadata.controllers.at(0);
+        const signerAddress = (await testSigner.getAddress()).toLowerCase();
+        expect(controller!.replace("did:pkh:eip155:1337:", "")).toEqual(signerAddress);
+      });
     });
 
     describe("node update", async () => {
@@ -346,7 +355,7 @@ describe("nodes-lib", () => {
       await dpidPublish(uuid, false, testSigner);
 
         // Allow graph node to index
-      await sleep(1_500);
+      await sleep(2_500);
 
       // make a regular publish
       const pubResult = await publishDraftNode(uuid, testSigner, did);

--- a/nodes-lib/test/root.spec.ts
+++ b/nodes-lib/test/root.spec.ts
@@ -15,7 +15,7 @@ import {
   removeContributor, addExternalCid, updateCoverImage,
 } from "../src/api.js";
 import axios from "axios";
-import { getCodexHistory, getPublishedFromCodex } from "../src/codex.js";
+import { getCodexHistory, getPublishedFromCodex, getRawState } from "../src/codex.js";
 import { dpidPublish } from "../src/chain.js";
 import { sleep } from "./util.js";
 import { convert0xHexToCid } from "../src/util/converting.js";
@@ -30,8 +30,9 @@ import {
   ResearchObjectComponentType,
   ResearchObjectComponentDataSubtype
 } from "@desci-labs/desci-models";
-import { signerFromPkey } from "../src/util/signing.js";
+import { authorizedSessionDidFromSigner, signerFromPkey } from "../src/util/signing.js";
 import { NODESLIB_CONFIGS, getNodesLibInternalConfig, setApiKey, setNodesLibConfig } from "../src/index.js";
+import { newComposeClient, getResources } from "@desci-labs/desci-codex-lib";
 
 // Pre-funded ganache account
 const TEST_PKEY = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -270,11 +271,12 @@ describe("nodes-lib", () => {
   describe("publishing ", async () => {
     let uuid: string;
     let publishResult: PublishResponse;
+    const did = await authorizedSessionDidFromSigner(testSigner, getResources());
 
     beforeAll(async () => {
       const { node } = await createBoilerplateNode();
       uuid = node.uuid;
-      publishResult = await publishDraftNode(uuid, testSigner);
+      publishResult = await publishDraftNode(uuid, testSigner, did);
     });
 
     describe("new node", async () => {
@@ -299,13 +301,22 @@ describe("nodes-lib", () => {
         const ceramicObject = await getPublishedFromCodex(publishResult.ceramicIDs!.streamID);
         expect(ceramicObject?.manifest).toEqual(publishResult.updatedManifestCid);
       });
+
+      test("has a CACAO from the passed DID", async () => {
+        const streamState = await getRawState(publishResult.ceramicIDs!.streamID);
+        const controller = streamState.state.metadata.controllers.at(0);
+        const signerAddress = (await testSigner.getAddress()).toLowerCase();
+
+        expect(controller).toEqual(did.parent);
+        expect(controller!.replace("did:pkh:eip155:1337:", "")).toEqual(signerAddress);
+      });
     });
 
     describe("node update", async () => {
       beforeAll(async () => {
         // async publish errors on re-publish before it finishes
         await sleep(5_000);
-        await publishDraftNode(uuid, testSigner);
+        await publishDraftNode(uuid, testSigner, did);
         // Allow graph node to index
         await sleep(1_500);
       });
@@ -338,7 +349,7 @@ describe("nodes-lib", () => {
       await sleep(1_500);
 
       // make a regular publish
-      const pubResult = await publishDraftNode(uuid, testSigner);
+      const pubResult = await publishDraftNode(uuid, testSigner, did);
 
         // Allow graph node to index
       await sleep(1_500);


### PR DESCRIPTION
This PR adds a new failure mode on publish, a special error for catching the case where signing address and RO token owner differs. This allows apps to react nicely before having to sign a TX which may fail with opaque errors instead.

Also adds capabilities for passing an (optional) `DIDSession` authorized DID to the `publishDraftNode` function, which avoids forcing a SIWE signature inside `nodes-lib` to authenticate for Ceramic. This triggers a second metamask window which we can now skip. (cc @shadrach-tayo )

There is also a getter for the resource ID's needed for the DID authorization, namely `getResources`. (cc @shadrach-tayo )