### PR TITLE
Ceramic prod deployment

### DIFF
--- a/ceramic-k8s/ceramic_deployment_dev.yaml
+++ b/ceramic-k8s/ceramic_deployment_dev.yaml
@@ -48,26 +48,19 @@ spec:
               cpu: "0.6"
               memory: 4Gi
           # # restart pod after failureThreshold*periodSeconds total seconds
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: server-api
-          #   failureThreshold: 80
-          #   periodSeconds: 3
-          # # temporarily stop sending traffic to pod after failureThreshold*periodSeconds total seconds
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: server-api
-          #   failureThreshold: 3
-          #   periodSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /api/v0/node/healthcheck
+              port: http-api
+            failureThreshold: 10
+            periodSeconds: 5
           # # wait for pod to start for failureThreshold*periodSeconds total seconds
-          # startupProbe:
-          #   httpGet:
-          #     path: /
-          #     port: server-api
-          #   failureThreshold: 200
-          #   periodSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /api/v0/node/healthcheck
+              port: http-api
+            failureThreshold: 60
+            periodSeconds: 1
 
       serviceAccountName: "vault-auth"
 ---

--- a/ceramic-k8s/ceramic_deployment_prod.yaml
+++ b/ceramic-k8s/ceramic_deployment_prod.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: js-ceramic-prod
+  labels:
+    App: JsCeramicProd
+spec:
+  replicas: 1
+  revisionHistoryLimit: 8
+  selector:
+    matchLabels:
+      App: JsCeramicProd
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/agent-inject-status: "update"
+        vault.hashicorp.com/role: app-vault-reader
+        vault.hashicorp.com/agent-inject-secret-config: secrets/desci-server/production/db
+        vault.hashicorp.com/agent-inject-template-config: |
+          {{- with secret "secrets/desci-server/production/db" -}}
+          echo "{\"anchor\":{\"auth-method\":\"did\",\"ethereum-rpc-url\":\"{{ .Data.ceramic_rpc }}\"},\"node\":{\"privateSeedUrl\":\"inplace:ed25519#{{ .Data.ceramic_cas_pkey }}\"},\"http-api\":{\"cors-allowed-origins\":[\".*\"],\"admin-dids\":[\"did:key:z6MktbKJrMnhVJ37QFTo12911ycm2juKDUzWHDVETu9s5a9T\"]},\"ipfs\":{\"mode\":\"remote\",\"host\":\"http://public-ceramic-ipfs-prod-service-internal.default.svc.cluster.local:5001\"},\"logger\":{\"log-level\":0},\"metrics\":{\"metrics-exporter-enabled\":false,\"metrics-port\":9090},\"network\":{\"name\":\"mainnet\"},\"state-store\":{\"mode\":\"fs\",\"local-directory\":\"/root/.ceramic/statestore\"},\"indexing\":{\"db\":\"{{ .Data.ceramic_url }}\",\"allow-queries-before-historical-sync\":true,\"models\":[]}}" > daemon.config.json
+          export NODE_ENV=production
+          echo "envset"; 
+          {{- end -}}
+      labels:
+        App: JsCeramicProd
+    spec:
+      containers:
+        - image: ceramicnetwork/js-ceramic:5.3.0
+          name: js-ceramic-prod
+          command: ["/bin/bash", "-c"]
+          args:
+            - echo "SOURCING ENV"; source /vault/secrets/config; ./packages/cli/bin/ceramic.js daemon --config daemon.config.json;
+          ports:
+            - containerPort: 7007
+              name: http-api
+          resources:
+            limits:
+              cpu: "0.7"
+              memory: 4Gi
+            requests:
+              cpu: "0.6"
+              memory: 4Gi
+          # # restart pod after failureThreshold*periodSeconds total seconds
+          livenessProbe:
+            httpGet:
+              path: /api/v0/node/healthcheck
+              port: http-api
+            failureThreshold: 10
+            periodSeconds: 5
+          # # wait for pod to start for failureThreshold*periodSeconds total seconds
+          startupProbe:
+            httpGet:
+              path: /api/v0/node/healthcheck
+              port: http-api
+            failureThreshold: 60
+            periodSeconds: 1
+
+      serviceAccountName: "vault-auth"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ceramic-prod-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - host: ceramic-prod.desci.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: public-js-ceramic-prod-service
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: public-js-ceramic-prod-service
+  labels:
+    App: JsCeramicProd
+spec:
+  type: LoadBalancer
+  selector:
+    App: JsCeramicProd
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: 7007


### PR DESCRIPTION
## Description of the Problem / Feature
The dev node only talks to the Clay testnet, for production we need one using the Ceramic mainnet.

## Explanation of the solution
Add a deployment spec for the production node

## Instructions on making this work
Part from the config that follows below, note these things:
1. Needs a companion IPFS node (the URL `public-ceramic-ipfs-prod-service-internal` used in config below does not yet exist)
2. A new, empty persistent disk for the `state-store`

The node config vault secrets require some tweaking in `/desci-server/production/db` compared to `/desci-server/dev/db`:
1. `.Data.ceramic_rpc` needs to be set to an Ethereum **mainnet** endpoint
2. `.Data.ceramic_cas_pkey` needs to be set to a new secret (sent to @hubsmoke in TG)
4. `.Data.ceramic_url` needs to point to a new, empty database marked for ceramic mainnet

There is the full config for reference:
```json
{
  "anchor": {
    "auth-method": "did",
    "ethereum-rpc-url": "{{ .Data.ceramic_rpc }}"
  },
  "node": {
    "privateSeedUrl": "inplace:ed25519#{{ .Data.ceramic_cas_pkey }}"
  },
  "http-api": {
    "cors-allowed-origins": [
      ".*"
    ],
    "admin-dids": [
      "did:key:z6MktbKJrMnhVJ37QFTo12911ycm2juKDUzWHDVETu9s5a9T"
    ]
  },
  "ipfs": {
    "mode": "remote",
    "host": "http://public-ceramic-ipfs-prod-service-internal.default.svc.cluster.local:5001"
  },
  "logger": {
    "log-level": 0
  },
  "metrics": {
    "metrics-exporter-enabled": false,
    "metrics-port": 9090
  },
  "network": {
    "name": "mainnet"
  },
  "state-store": {
    "mode": "fs",
    "local-directory": "/root/.ceramic/statestore"
  },
  "indexing": {
    "db": "{{ .Data.ceramic_url }}",
    "allow-queries-before-historical-sync": true,
    "models": []
  }
}
```