### PR TITLE
Local dev config change

### DIFF
--- a/desci-repo/nodemon.json
+++ b/desci-repo/nodemon.json
@@ -7,7 +7,6 @@
     "log/server.log"
   ],
   "verbose": true,
-  "exec": "node -r ts-node/register --inspect=0.0.0.0:9232",
-  "delay": 300,
-  "signal": "SIGTERM"
+  "exec": "npx kill-port 5484 9232; sleep 5; node -r ts-node/register --inspect=0.0.0.0:9232",
+  "delay": 300
 }


### PR DESCRIPTION
## Description of the Problem / Feature
- Revert the changes in the nodemon config for desci-repo, in case they're unnecessary and cause unexpected issues, desci-repo doesn't handle cleanup on signals, so it doesn't make a difference if the process gets SIGKILLed or  SIGTERMed, in the future if it handles termination signals then we can change it as necessary.
