### PR TITLE
reverse-proxy: add support for washing secrets in response bodies

### DIFF
--- a/reverse-proxy/README.md
+++ b/reverse-proxy/README.md
@@ -15,6 +15,12 @@ So, in general, the pattern is `PROXY_MAPPING_[redirect key]=[redirect target]`.
 | `/example`      | https://example.com      |
 | `/example/cats` | https://example.com/cats |
 
+
+## Washing responses
+Some targets (looking at you, Alchemy) return the URL secrets in the response body. Since this is target-dependent, you need to add detection code in `getSensitiveStrings` if this applies to a new proxy target.
+
+The request interceptor automatically washes all response bodies that goes back to the client by replacing instances of all these sensitive strings with `[redacted]`.
+
 ## Running
 Run in development mode:
 ```shell

--- a/reverse-proxy/src/util.ts
+++ b/reverse-proxy/src/util.ts
@@ -1,0 +1,38 @@
+export type Mapping = Record<string, string>;
+
+/**
+ * Build a route mapping from envvars prefixed `PROXY_MAPPING_`
+*/
+export const buildMappingFromEnv = (): Mapping => Object.fromEntries(
+  Object.entries(process.env as { [s:string]: string } )
+  .filter(([k, _]) => k.startsWith("PROXY_MAPPING_"))
+  .map(([k, v]) => [k.replace("PROXY_MAPPING_", ""), v])
+  .map(([k, v]) => ["/" + k.toLowerCase(), v])
+);
+
+/**
+ * Find sensitive strings in mapped URL's
+*/
+export const getSensitiveStrings = (mapping: Mapping) => {
+  const urls = Object.values(mapping);
+
+  const alchemyTokens = urls
+    .filter(url => url.includes("alchemy.com"))
+    /* 32-char alphanum token with dashes and underscores */
+    .map(url => url.match(/[a-zA-Z0-9_-]{32}/))
+    /* Remove potential null match for tokenless url */
+    .flatMap(maybeMatch => maybeMatch ? [maybeMatch] : [])
+    /* Get the match from RexExpMatchArray */
+    .map(matchArr => matchArr[0]);
+
+  return alchemyTokens;
+};
+
+export const redactSensitive = (
+  sensitiveStrings: string[],
+  dirty: string
+): string =>
+  sensitiveStrings.reduce(
+    (acc, nextSecret) => acc.replaceAll(nextSecret, "[redacted]"),
+    dirty, // initial accumulator
+  );


### PR DESCRIPTION
Alchemy returns the URL secret back in the response lol, so this PR adds support for extracting secret material from mapped URLs and automatically replaces instances in the body with `[redacted]` :detective: 