### PR TITLE
nodes-lib: support staging environment with dev contracts

### DIFF
--- a/nodes-lib/README.md
+++ b/nodes-lib/README.md
@@ -78,7 +78,7 @@ By default, the library defaults to interacting with the nodes dev environment. 
 - dPID registration transactions will be done against a testing contract
 - Ceramic publishing is done on the Clay testnet
 
-Configure your intended environment by calling the `setConfig` function. If you're not doing something very avant-garde, you can likely just pass a standard config instance like `NODESLIB_CONFIGS.local`. Otherwise, build up your own config object.
+Configure your intended environment by calling the `setNodesLibConfig` function. If you're not doing something very avant-garde, you can likely just pass a standard config instance like `NODESLIB_CONFIGS.local`. Otherwise, build up your own config object.
 
 Note that your API key must be set manually by calling `setApiKey`, find more information in the Authentication section.
 

--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/src/config/chain.ts
+++ b/nodes-lib/src/config/chain.ts
@@ -6,6 +6,7 @@ export type NodesContract =
   | tc.ResearchObject
   | tc.ResearchObjectV2
   | tc.DpidRegistry;
+
 export type ContractConnector<T extends NodesContract> =
   (signerOrProvider: Signer | providers.Provider) => T;
 
@@ -28,7 +29,7 @@ export const CHAIN_CONFIGS = {
   local: {
     chainId: "1337",
     rpcUrl: "http://localhost:8545",
-    researchObjectConnector: signerOrProvider => tc.ResearchObject__factory.connect(
+    researchObjectConnector: signerOrProvider => tc.ResearchObjectV2__factory.connect(
       contracts.localRoInfo.proxies.at(0)!.address,
       signerOrProvider
     ),
@@ -39,7 +40,19 @@ export const CHAIN_CONFIGS = {
   },
   dev: {
     chainId: "11155111",
-    rpcUrl: "https://eth-sepolia.g.alchemy.com/v2/demo",
+    rpcUrl: "https://reverse-proxy-dev.desci.com/rpc_sepolia",
+    researchObjectConnector: signerOrProvider => tc.ResearchObjectV2__factory.connect(
+      contracts.devRoInfo.proxies.at(0)!.address,
+      signerOrProvider
+    ),
+    dpidRegistryConnector: signerOrProvider => tc.DpidRegistry__factory.connect(
+      contracts.devDpidInfo.proxies.at(0)!.address,
+      signerOrProvider
+    ),
+  },
+  staging: {
+    chainId: "11155111",
+    rpcUrl: "https://reverse-proxy-staging.desci.com/rpc_sepolia",
     researchObjectConnector: signerOrProvider => tc.ResearchObjectV2__factory.connect(
       contracts.devRoInfo.proxies.at(0)!.address,
       signerOrProvider
@@ -51,7 +64,7 @@ export const CHAIN_CONFIGS = {
   },
   prod: {
     chainId: "11155111",
-    rpcUrl: "https://eth-sepolia.g.alchemy.com/v2/demo",
+    rpcUrl: "https://reverse-proxy-prod.desci.com/rpc_sepolia",
     researchObjectConnector: signerOrProvider => tc.ResearchObjectV2__factory.connect(
       contracts.prodRoInfo.proxies.at(0)!.address,
       signerOrProvider

--- a/nodes-lib/src/config/index.ts
+++ b/nodes-lib/src/config/index.ts
@@ -4,6 +4,7 @@ import { CHAIN_CONFIGS, ChainConfig } from "./chain.js";
 export type NodesEnv =
   | "local"
   | "dev"
+  | "staging"
   | "prod";
 
 export type Config = {
@@ -25,6 +26,12 @@ export const NODESLIB_CONFIGS = {
     apiKey: undefined,
     ceramicNodeUrl: "https://ceramic-dev.desci.com",
     chainConfig: CHAIN_CONFIGS.dev,
+  },
+  staging: {
+    apiUrl: "https://nodes-api-staging.desci.com",
+    apiKey: undefined,
+    ceramicNodeUrl: "https://ceramic-dev.desci.com",
+    chainConfig: CHAIN_CONFIGS.dev, // also using the dev sepolia contracts
   },
   prod: {
     apiUrl: "https://nodes-api.desci.com",


### PR DESCRIPTION
## Description of the Problem / Feature
Wasn't possible to use staging API's

## Explanation of the solution
Add `staging` config, re-using chain config from `dev`

## Instructions on making this work
Updating to `nodes-lib@0.0.6` and using `setNodesLibConfig(NODESLIB_CONFIGS.staging)` will activate this configuration.