### PR TITLE
Orcid authtoken refresh

### DIFF
--- a/desci-server/src/controllers/attestations/verification.ts
+++ b/desci-server/src/controllers/attestations/verification.ts
@@ -48,6 +48,19 @@ export const removeVerification = async (
     return new SuccessMessageResponse().send(res);
   } else {
     await attestationService.removeVerification(verification.id, user.id);
+
+    const claim = await attestationService.findClaimById(verification.nodeAttestationId);
+
+    const attestation = await attestationService.findAttestationById(claim.attestationId);
+
+    if (attestation.protected) {
+      /**
+       * Update ORCID Profile
+       */
+      const node = await prisma.node.findFirst({ where: { uuid: ensureUuidEndsWithDot(claim.nodeUuid) } });
+      const owner = await prisma.user.findFirst({ where: { id: node.ownerId } });
+      if (owner.orcid) await orcidApiService.postWorkRecord(node.uuid, owner.orcid);
+    }
     return new SuccessMessageResponse().send(res);
   }
 };

--- a/desci-server/src/services/user.ts
+++ b/desci-server/src/services/user.ts
@@ -239,8 +239,19 @@ export async function setOrcidForUser(
         },
       });
       logger.trace({ fn: 'setOrcidForUser' }, 'updated user');
-      const authTokenInsert = await client.authToken.create({
-        data: {
+      const exists = await client.authToken.findFirst({ where: { userId, source: AuthTokenSource.ORCID } });
+      await client.authToken.upsert({
+        where: {
+          id: exists.id,
+        },
+        create: {
+          accessToken: auth.accessToken,
+          refreshToken: auth.refreshToken,
+          expiresIn: auth.expiresIn,
+          userId,
+          source: AuthTokenSource.ORCID,
+        },
+        update: {
           accessToken: auth.accessToken,
           refreshToken: auth.refreshToken,
           expiresIn: auth.expiresIn,


### PR DESCRIPTION
fixes:
- prevent storing duplicate orcid  authToken for same user
- update orcid work record after protected claim is unverified
- add feature to refresh and update orcid authToken before use in orcid service