### PR TITLE
Adjust invite emails

### DIFF
--- a/desci-server/src/templates/emails/ContributorInvite.tsx
+++ b/desci-server/src/templates/emails/ContributorInvite.tsx
@@ -38,8 +38,9 @@ export const ContributorInvite = ({
   newUser,
 }: ContributorInviteEmailProps) => {
   if (nodeUuid?.endsWith('.') || nodeUuid?.endsWith('=')) nodeUuid = nodeUuid.slice(0, -1);
+  inviter = inviter || 'A user';
   const privShareUrl = `${DAPP_URL}/node/${nodeUuid}?shareId=${privShareCode}`;
-  const contributorUrl = `${DAPP_URL}/node/${nodeUuid}/contributors/${contributorId}?shareId=${privShareCode}`;
+  const contributorUrl = `${DAPP_URL}/node/${nodeUuid}/contributors/${contributorId}?shareId=${privShareCode}&src=inv`;
   return (
     <MainLayout>
       <Html>


### PR DESCRIPTION
## Description of the Problem / Feature
- Contributor link adjusted to include 'src' coming from an invite, to enable frontend improvements for un-authed users who click on their individual contribution links received in their emails.
- Added a sensible default for invites sent from a profile without a profile name assigned yet, to prevent it being blank.
