### PR TITLE
server: fix email logos

### DIFF
--- a/desci-server/src/templates/emails/BaseProvider.tsx
+++ b/desci-server/src/templates/emails/BaseProvider.tsx
@@ -1,7 +1,7 @@
 import { Tailwind } from '@react-email/components';
 import React from 'react';
 
-const BaseProvider = ({ children }: { children: JSX.Element }) => {
+export const BaseProvider = ({ children }: { children: JSX.Element }) => {
   return (
     <Tailwind
       config={{
@@ -19,5 +19,3 @@ const BaseProvider = ({ children }: { children: JSX.Element }) => {
     </Tailwind>
   );
 };
-
-export default BaseProvider;

--- a/desci-server/src/templates/emails/MagicCode.tsx
+++ b/desci-server/src/templates/emails/MagicCode.tsx
@@ -1,16 +1,12 @@
 import {
   Body,
   Container,
-  Column,
   Head,
   Heading,
   Html,
   Preview,
-  Row,
   Text,
-  Button,
   Section,
-  render,
 } from '@react-email/components';
 import * as React from 'react';
 
@@ -29,7 +25,7 @@ export const MagicCodeEmail = ({ magicCode, ip }: MagicCodeEmailProps) => (
   >
     <Html>
       <Head />
-      <Preview>Confirm your contribution</Preview>
+      <Preview>Confirm your identity</Preview>
       <Body style={main}>
         <Container style={container}>
           <Heading style={h1} className="text-center !text-black">

--- a/desci-server/src/templates/emails/MainLayout.tsx
+++ b/desci-server/src/templates/emails/MainLayout.tsx
@@ -1,27 +1,23 @@
-import { url } from 'inspector';
 
 import {
   Body,
   Container,
   Column,
   Head,
-  Heading,
   Html,
   Img,
   Link,
-  Preview,
   Row,
   Section,
   Text,
   Font,
 } from '@react-email/components';
 import React from 'react';
+import { BaseProvider } from './BaseProvider.js';
 
-import BaseProvider from './BaseProvider.js';
-
-export const emailAssetsBaseUrl = 'https://ipfs.desci.com/ipfs';
-const cubertBkg = 'bafkreih6yx7ywj7trvpp45vergrnytad7ezsku75tefyro4qrrcfrrmrt4';
-const labsLogo = 'bafkreifvb7tleo5jaidjjf6lfjxb5bpjbs2nswp47bi7zh3hxbpc6fjyf4';
+export const emailAssetsBaseUrl = 'https://pub.desci.com/ipfs';
+// const cubertBkg = 'bafkreih6yx7ywj7trvpp45vergrnytad7ezsku75tefyro4qrrcfrrmrt4';
+const labsLogo = 'bafkreie2jto3flk2r43yt545xrasftbsc2atp5eb7qcbsmhacm26k4wiz4';
 const defaultFooterMsg = "If you didn't request this email, there's nothing to worry about, you can safely ignore it.";
 
 const MainLayout = ({ children, footerMsg = defaultFooterMsg }: { children: JSX.Element; footerMsg?: string }) => {
@@ -55,11 +51,11 @@ const MainLayout = ({ children, footerMsg = defaultFooterMsg }: { children: JSX.
             <Container className="backdrop-blur-2xl bg-opacity-50">
               <Section className="h-full backdrop-blur-lg w-full" align="center">
                 <Img
-                  src={`${emailAssetsBaseUrl}/${labsLogo}`}
+                  src={ `${emailAssetsBaseUrl}/${labsLogo}` }
                   width="193"
                   height="60"
                   alt="Desci Labs"
-                  className="m-auto invert"
+                  className="m-auto invert mix-blend-difference"
                 />
               </Section>
               <Section>{children}</Section>
@@ -70,11 +66,11 @@ const MainLayout = ({ children, footerMsg = defaultFooterMsg }: { children: JSX.
                 <Column className="">
                   <Link href="https://desci.com" target="_blank" rel="noopener noreferrer">
                     <Img
-                      src={`${emailAssetsBaseUrl}/${labsLogo}`}
+                      src={ `${emailAssetsBaseUrl}/${labsLogo}` }
                       width="135"
                       height="42"
                       alt="Desci Labs"
-                      className="invert"
+                      className="invert mix-blend-difference"
                     />
                   </Link>
                 </Column>


### PR DESCRIPTION
Switched to a PNG version of the logo. Curious to know how the blend mode works on dark BG, but can't be worse than a broken image :D

Learnings:
1. Gmail refuses to render SVG under basically any circumstances
2. Gmail refuses base64 image embeds under any circumstances
3. The reason is their gigantic image cache system can't work them

![image](https://github.com/desci-labs/nodes/assets/479022/9ffcc1a1-050c-4b10-9163-391aac59b6e6)

Resolves #388