### PR TITLE
Smarter external url processing for PDFs

### DIFF
--- a/desci-server/src/services/data/externalUrlProcessing.ts
+++ b/desci-server/src/services/data/externalUrlProcessing.ts
@@ -128,10 +128,17 @@ export async function processExternalUrlDataToIpfs({
          */
         if (componentType === ResearchObjectComponentType.PDF) {
           const url = externalUrl.url;
-          const res = await axios.get(url, { responseType: 'arraybuffer' });
-          const buffer = Buffer.from(res.data, 'binary');
-          externalUrlFiles = [{ path: externalUrl.path, content: buffer }];
-          externalUrlTotalSizeBytes = buffer.length;
+          const response = await axios.head(url);
+          const contentType = response.headers['content-type'];
+
+          if (contentType === 'application/pdf') {
+            const res = await axios.get(url, { responseType: 'arraybuffer' });
+            const buffer = Buffer.from(res.data, 'binary');
+            externalUrlFiles = [{ path: externalUrl.path, content: buffer }];
+            externalUrlTotalSizeBytes = buffer.length;
+          } else {
+            throw new Error('Invalid file type. Only PDF files are supported.');
+          }
         }
       } catch (e) {
         logger.warn(

--- a/desci-server/src/services/data/processing.ts
+++ b/desci-server/src/services/data/processing.ts
@@ -14,6 +14,7 @@ import {
 } from '@desci-labs/desci-models';
 import { User, Node, DataType, Prisma } from '@prisma/client';
 import axios from 'axios';
+import { CID } from 'multiformats';
 import { v4 } from 'uuid';
 
 import { prisma } from '../../client.js';
@@ -59,7 +60,6 @@ import {
   createNotEnoughSpaceError,
   createUnhandledError,
 } from './processingErrors.js';
-import { CID } from 'multiformats';
 
 interface ProcessS3DataToIpfsParams {
   files: any[];


### PR DESCRIPTION
Partially addresses #336

## Description of the Problem / Feature
- PDF determination was done by seeing if the URL ends with .pdf, this logic caused pdf components that would be supported within the app to be uploaded as external URLs instead.
## Explanation of the solution
- A head call is done on the external URL and the mimeType is checked to see if it could be a PDF, this expands the scope of links that can be correctly used to import PDFs externally via URL, however this still doesn't work for some links that don't directly send the user to the PDF download and instead redirect users to their own PDF renderer (like google links) as their mimeTypes would instead be text/html, these types will probably need special handling for commonly used services.
