### PR TITLE
Revert "DPID url config "

### DIFF
--- a/desci-server/kubernetes/deployment_dev.yaml
+++ b/desci-server/kubernetes/deployment_dev.yaml
@@ -41,7 +41,6 @@ spec:
           export SESSION_KEY={{ .Data.SESSION_KEY }}
           export COOKIE_DOMAIN={{ .Data.COOKIE_DOMAIN }}
           export ORCID_API_DOMAIN={{ .Data.ORCID_API_DOMAIN }}
-          export DPID_URL_OVERRIDE={{ .Data.DPID_URL_OVERRIDE }}
           export ORCID_CLIENT_ID={{ .Data.ORCID_CLIENT_ID }}
           export ORCID_CLIENT_SECRET={{ .Data.ORCID_CLIENT_SECRET }}
           export ARWEAVE_ENABLED=0

--- a/desci-server/kubernetes/deployment_prod.yaml
+++ b/desci-server/kubernetes/deployment_prod.yaml
@@ -43,7 +43,6 @@ spec:
           export ORCID_API_DOMAIN={{ .Data.ORCID_API_DOMAIN }}
           export ORCID_CLIENT_ID={{ .Data.ORCID_CLIENT_ID }}
           export ORCID_CLIENT_SECRET={{ .Data.ORCID_CLIENT_SECRET }}
-          export DPID_URL_OVERRIDE={{ .Data.DPID_URL_OVERRIDE }}
           export ARWEAVE_ENABLED=0
           export ARWEAVE_HOST=
           export ARWEAVE_PORT=1984

--- a/desci-server/kubernetes/deployment_staging.yaml
+++ b/desci-server/kubernetes/deployment_staging.yaml
@@ -55,7 +55,6 @@ spec:
           export ORCID_API_DOMAIN={{ .Data.ORCID_API_DOMAIN }}
           export ORCID_CLIENT_ID={{ .Data.ORCID_CLIENT_ID }}
           export ORCID_CLIENT_SECRET={{ .Data.ORCID_CLIENT_SECRET }}
-          export DPID_URL_OVERRIDE={{ .Data.DPID_URL_OVERRIDE }}
           export ARWEAVE_ENABLED=0
           export ARWEAVE_HOST=
           export ARWEAVE_PORT=1984

--- a/desci-server/src/services/orcid.ts
+++ b/desci-server/src/services/orcid.ts
@@ -10,7 +10,7 @@ import { getManifestByCid } from './data/processing.js';
 
 // const PUTCODE_REGEX = /put-code=.*?(?<code>\d+)/m;
 
-const DPID_URL_OVERRIDE = process.env.DPID_URL_OVERRIDE || 'https://beta.dpid.org';
+const DPID_URL_OVERRIDE = process.env.DPID_URL_OVERRIDE || 'https://dev-beta.dpid.org';
 const ORCID_DOMAIN = process.env.ORCID_API_DOMAIN || 'sandbox.orcid.org';
 type Claim = Awaited<ReturnType<typeof attestationService.getProtectedNodeClaims>>[number];
 const logger = parentLogger.child({ module: 'ORCIDApiService' });


### PR DESCRIPTION
Reverts desci-labs/nodes#344

Interpolating a value that doesn't exist in the env renders a syntactically incorrect config file, putting pods that upgrade in a crash loop by preventing the entire environment to load. When this happens, the repo "worker" process throws and crashes the container.

![image](https://github.com/desci-labs/nodes/assets/479022/818e7afd-9885-4440-8362-5d80ff348cb4)
![image](https://github.com/desci-labs/nodes/assets/479022/c9ba0b37-5ddd-4437-97f1-ba867d31915c)

```json
{
  "err": {
    "message": "[REPO SERVICE]: env.REPO_SERVER_URL or env.REPO_SERVICE_SECRET_KEY missing",
    "stack": "Error: [REPO SERVICE]: env.REPO_SERVER_URL or env.REPO_SERVICE_SECRET_KEY missing\n    at new RepoService (file:///app/dist/services/repoService.js:10:19)\n    at file:///app/dist/services/repoService.js:92:21\n    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)\n    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)\n    at async loadESM (node:internal/process/esm_loader:34:7)\n    at async handleMainPromise (node:internal/modules/run_main:106:12)",
    "type": "Error"
  },
  "hostname": "desci-server-dev-66f8786cf7-l7nv2",
  "level": 60,
  "msg": "uncaught exception",
  "pid": 1,
  "time": 1716808274000
}
```