### PR TITLE
Guard API (Protected attestations)

### DIFF
--- a/desci-server/src/controllers/attestations/verification.ts
+++ b/desci-server/src/controllers/attestations/verification.ts
@@ -3,15 +3,10 @@ import { NextFunction, Request, Response } from 'express';
 import _ from 'lodash';
 
 import {
-  AuthFailureResponse,
-  BadRequestError,
   ForbiddenError,
-  NotFoundError,
-  RequestWithUser,
   SuccessMessageResponse,
   SuccessResponse,
   attestationService,
-  communityService,
   ensureUuidEndsWithDot,
   prisma,
 } from '../../internal.js';
@@ -131,17 +126,17 @@ export const getAttestationVerifications = async (req: Request, res: Response, n
   return new SuccessResponse(data).send(res);
 };
 
-export const canVerifyClaim = async (req: RequestWithUser, res: Response) => {
-  const logger = parentLogger.child({
-    module: 'ATTESTATIONS::canVerify',
-  });
-  const userId = req.user.id;
-  const claimId = parseInt(req.params.claimId);
+// export const canVerifyClaim = async (req: RequestWithUser, res: Response) => {
+//   const logger = parentLogger.child({
+//     module: 'ATTESTATIONS::canVerify',
+//   });
+//   const userId = req.user.id;
+//   const claimId = parseInt(req.params.claimId);
 
-  const claim = await attestationService.findClaimById(claimId);
-  const isMember = await communityService.findMemberByUserId(claim.desciCommunityId, userId);
+//   const claim = await attestationService.findClaimById(claimId);
+//   const isMember = await communityService.findMemberByUserId(claim.desciCommunityId, userId);
 
-  logger.info({ userId: req.user.id, claimId, community: claim.desciCommunityId }, 'Claim Verification check');
-  if (!isMember) new SuccessResponse({ ok: false }).send(res);
-  else new SuccessResponse({ ok: true }).send(res);
-};
+//   logger.info({ userId: req.user.id, claimId, community: claim.desciCommunityId }, 'Claim Verification check');
+//   if (!isMember) new SuccessResponse({ ok: false }).send(res);
+//   else new SuccessResponse({ ok: true }).send(res);
+// };

--- a/desci-server/src/controllers/attestations/verification.ts
+++ b/desci-server/src/controllers/attestations/verification.ts
@@ -125,18 +125,3 @@ export const getAttestationVerifications = async (req: Request, res: Response, n
 
   return new SuccessResponse(data).send(res);
 };
-
-// export const canVerifyClaim = async (req: RequestWithUser, res: Response) => {
-//   const logger = parentLogger.child({
-//     module: 'ATTESTATIONS::canVerify',
-//   });
-//   const userId = req.user.id;
-//   const claimId = parseInt(req.params.claimId);
-
-//   const claim = await attestationService.findClaimById(claimId);
-//   const isMember = await communityService.findMemberByUserId(claim.desciCommunityId, userId);
-
-//   logger.info({ userId: req.user.id, claimId, community: claim.desciCommunityId }, 'Claim Verification check');
-//   if (!isMember) new SuccessResponse({ ok: false }).send(res);
-//   else new SuccessResponse({ ok: true }).send(res);
-// };

--- a/desci-server/src/controllers/communities/guard.ts
+++ b/desci-server/src/controllers/communities/guard.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express';
+
+import { SuccessResponse, communityService, logger } from '../../internal.js';
+import { RequestWithUser } from '../../middleware/authorisation.js';
+
+export const checkMemberGuard = async (req: RequestWithUser, res: Response) => {
+  const log = logger.child({
+    module: 'ATTESTATIONS::MemberGuard',
+  });
+  const userId = req.user.id;
+  const communityId = parseInt(req.params.communityId);
+
+  log.info({ userId: req.user.id, community: communityId }, 'Community Member Guard check');
+  const isMember = await communityService.findMemberByUserId(communityId, userId);
+
+  if (!isMember) new SuccessResponse({ ok: false }).send(res);
+  else new SuccessResponse({ ok: true }).send(res);
+};

--- a/desci-server/src/controllers/communities/index.ts
+++ b/desci-server/src/controllers/communities/index.ts
@@ -3,3 +3,4 @@ export * from './radar.js';
 export * from './list.js';
 export * from './types.js';
 export * from './util.js';
+export * from './guard.js';

--- a/desci-server/src/routes/v1/attestations/index.ts
+++ b/desci-server/src/routes/v1/attestations/index.ts
@@ -19,7 +19,6 @@ import {
   getAttestationVerifications,
   validate,
   getValidatedRecommendations,
-  canVerifyClaim,
 } from '../../../internal.js';
 import { ensureUser } from '../../../middleware/permissions.js';
 
@@ -38,7 +37,6 @@ import {
   showCommunityClaimsSchema,
   showNodeAttestationsSchema,
   claimEntryAttestationsSchema,
-  canVerificationSchema,
 } from './schema.js';
 
 const router = Router();
@@ -67,7 +65,6 @@ router.post('/claimAll', [ensureUser, validate(claimEntryAttestationsSchema)], a
 router.post('/comment', [ensureUser, validate(createCommentSchema)], asyncHander(addComment));
 router.post('/reaction', [ensureUser, validate(addReactionSchema)], asyncHander(addReaction));
 router.post('/verification', [ensureUser, validate(addVerificationSchema)], asyncHander(addVerification));
-router.post('/verification/check/:claimId', [ensureUser, validate(canVerificationSchema)], asyncHander(canVerifyClaim));
 
 router.delete('/comments/:commentId', [ensureUser, validate(deleteCommentSchema)], asyncHander(removeComment));
 router.delete('/reactions/:reactionId', [ensureUser, validate(deleteReactionSchema)], asyncHander(removeReaction));

--- a/desci-server/src/routes/v1/attestations/schema.ts
+++ b/desci-server/src/routes/v1/attestations/schema.ts
@@ -128,12 +128,6 @@ export const addVerificationSchema = z.object({
   }),
 });
 
-export const canVerificationSchema = z.object({
-  params: z.object({
-    claimId: z.coerce.number(),
-  }),
-});
-
 export const deleteCommentSchema = z.object({
   params: z.object({ commentId: z.coerce.number() }),
 });

--- a/desci-server/src/routes/v1/communities/index.ts
+++ b/desci-server/src/routes/v1/communities/index.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 
 import {
   asyncHander,
+  checkMemberGuard,
+  ensureUser,
   getAllFeeds,
   getCommunityDetails,
   getCommunityFeed,
@@ -12,7 +14,7 @@ import {
   validate,
 } from '../../../internal.js';
 
-import { getCommunityDetailsSchema, getCommunityFeedSchema } from './schema.js';
+import { getCommunityDetailsSchema, getCommunityFeedSchema, memberGuardSchema } from './schema.js';
 
 const router = Router();
 
@@ -34,5 +36,7 @@ router.get(
 
 router.get('/:communityId/feed', [validate(getCommunityFeedSchema)], asyncHander(getCommunityFeed));
 router.get('/:communityId/radar', [validate(getCommunityFeedSchema)], asyncHander(getCommunityRadar));
+
+router.post('/:communityId/memberGuard', [ensureUser, validate(memberGuardSchema)], asyncHander(checkMemberGuard));
 
 export default router;

--- a/desci-server/src/routes/v1/communities/schema.ts
+++ b/desci-server/src/routes/v1/communities/schema.ts
@@ -11,3 +11,9 @@ export const getCommunityFeedSchema = z.object({
     communityId: z.coerce.number(),
   }),
 });
+
+export const memberGuardSchema = z.object({
+  params: z.object({
+    communityId: z.coerce.number(),
+  }),
+});

--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -2,7 +2,6 @@ import assert from 'assert';
 
 import { HighlightBlock } from '@desci-labs/desci-models';
 import { AnnotationType, Attestation, Prisma } from '@prisma/client';
-import { logger } from 'ethers';
 import _ from 'lodash';
 
 import { prisma } from '../client.js';
@@ -19,6 +18,7 @@ import {
   NoAccessError,
   VerificationError,
   VerificationNotFoundError,
+  logger,
 } from '../internal.js';
 import { communityService } from '../internal.js';
 
@@ -107,6 +107,7 @@ export class AttestationService {
     const member = await prisma.communityMember.findUnique({
       where: { userId_communityId: { userId, communityId } },
     });
+    logger.error({ member, userId, communityId }, 'Check community member');
     if (!member) throw new NoAccessError('Only Community members are allowed');
 
     return true;

--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -102,15 +102,15 @@ export class AttestationService {
     };
   }
 
-  async checkUserIsMember(userId: number, communityId: number) {
-    // const attestation = await this.findAttestationById(claim.attestationId);
+  async assertUserIsMember(userId: number, communityId: number) {
     const member = await prisma.communityMember.findUnique({
       where: { userId_communityId: { userId, communityId } },
     });
-    logger.error({ member, userId, communityId }, 'Check community member');
-    if (!member) throw new NoAccessError('Only Community members are allowed');
 
-    return true;
+    if (!member) {
+      logger.error({ userId, communityId }, 'UnAuthorized Verify Attestation Call');
+      throw new NoAccessError('Only Community members are allowed');
+    }
   }
 
   async #publishVersion(attestationVersion: Prisma.AttestationVersionUncheckedCreateInput) {
@@ -459,7 +459,7 @@ export class AttestationService {
 
     const attestation = await this.findAttestationById(claim.attestationId);
     if (attestation.protected) {
-      await this.checkUserIsMember(userId, claim.desciCommunityId);
+      await this.assertUserIsMember(userId, claim.desciCommunityId);
     }
 
     const node = await prisma.node.findFirst({ where: { uuid: claim.nodeUuid } });
@@ -516,7 +516,7 @@ export class AttestationService {
 
     const attestation = await this.findAttestationById(claim.attestationId);
     if (attestation.protected) {
-      await this.checkUserIsMember(authorId, claim.desciCommunityId);
+      await this.assertUserIsMember(authorId, claim.desciCommunityId);
     }
 
     return prisma.nodeAttestationReaction.create({ data: { authorId, reaction, nodeAttestationId: claimId } });
@@ -556,7 +556,7 @@ export class AttestationService {
 
     const attestation = await this.findAttestationById(claim.attestationId);
     if (attestation.protected) {
-      await this.checkUserIsMember(authorId, attestation.communityId);
+      await this.assertUserIsMember(authorId, attestation.communityId);
     }
 
     const data: Prisma.AnnotationUncheckedCreateInput = {
@@ -590,7 +590,7 @@ export class AttestationService {
 
     const attestation = await this.findAttestationById(claim.attestationId);
     if (attestation.protected) {
-      await this.checkUserIsMember(authorId, attestation.communityId);
+      await this.assertUserIsMember(authorId, attestation.communityId);
     }
 
     const data: Prisma.AnnotationUncheckedCreateInput = {

--- a/desci-server/test/integration/Attestation.test.ts
+++ b/desci-server/test/integration/Attestation.test.ts
@@ -2179,49 +2179,96 @@ describe('Attestations Service', async () => {
       expect(verifications.some((v) => v.userId === members[0].userId)).to.equal(true);
       expect(verifications.some((v) => v.userId === members[1].userId)).to.equal(true);
     });
+  });
 
-    it.skip('should prevent double verification of Node Attestation(Claim)', async () => {
-      try {
-        await attestationService.verifyClaim(openCodeClaim.id, users[1].id);
-      } catch (err) {
-        expect(err).to.be.instanceOf(DuplicateVerificationError);
-      }
-    });
+  describe.only('Protected Attestation Review', async () => {
+    let openCodeClaim: NodeAttestation;
+    let openDataClaim: NodeAttestation;
+    let node: Node;
+    const nodeVersion = 0;
+    let attestationVersion: AttestationVersion;
+    let author: User;
+    let members: (CommunityMember & {
+      user: User;
+    })[];
+    let UserJwtToken: string,
+      UserAuthHeaderVal: string,
+      MemberJwtToken1: string,
+      MemberJwtToken2: string,
+      memberAuthHeaderVal1: string,
+      memberAuthHeaderVal2: string;
 
-    it.skip('should restrict author from verifying their claim', async () => {
-      try {
-        assert(author.id === node.ownerId);
-        await attestationService.verifyClaim(openCodeClaim.id, author.id);
-      } catch (err) {
-        expect(err).to.be.instanceOf(VerificationError);
-      }
-    });
-
-    it.skip('should remove verification', async () => {
-      const removedVerification = await attestationService.removeVerification(verification.id, users[1].id);
-      expect(removedVerification).to.not.be.null;
-      expect(removedVerification).to.not.be.undefined;
-      expect(removedVerification.id).to.equal(verification.id);
-
-      const voidVerification = await attestationService.getUserClaimVerification(openCodeClaim.id, users[1].id);
-      expect(voidVerification).to.be.null;
-    });
-
-    it.skip('should allow multiple users verify a node attestation(claim)', async () => {
-      const user2Verification = await attestationService.verifyClaim(openCodeClaim.id, users[2].id);
-      expect(user2Verification.nodeAttestationId).to.be.equal(openCodeClaim.id);
-      expect(user2Verification.userId).to.be.equal(users[2].id);
-
-      const user3Verification = await attestationService.verifyClaim(openCodeClaim.id, users[3].id);
-      expect(user3Verification.nodeAttestationId).to.be.equal(openCodeClaim.id);
-      expect(user3Verification.userId).to.be.equal(users[3].id);
-
-      const verifications = await attestationService.getAllClaimVerfications(openCodeClaim.id);
-      expect(verifications.length).to.be.equal(2);
-
+    before(async () => {
+      node = nodes[0];
+      author = users[0];
       assert(node.uuid);
-      const nodeVerifications = await attestationService.getAllNodeVerfications(node.uuid);
-      expect(nodeVerifications.length).to.be.equal(2);
+      const versions = await attestationService.getAttestationVersions(protectedOpenCode.id);
+      attestationVersion = versions[versions.length - 1];
+      openCodeClaim = await attestationService.claimAttestation({
+        attestationId: protectedOpenCode.id,
+        attestationVersion: attestationVersion.id,
+        nodeDpid: '1',
+        nodeUuid: node.uuid,
+        nodeVersion,
+        claimerId: author.id,
+      });
+
+      members = await communityService.getAllMembers(desciCommunity.id);
+      MemberJwtToken1 = jwt.sign({ email: members[0].user.email }, process.env.JWT_SECRET!, {
+        expiresIn: '1y',
+      });
+      memberAuthHeaderVal1 = `Bearer ${MemberJwtToken1}`;
+
+      MemberJwtToken2 = jwt.sign({ email: members[1].user.email }, process.env.JWT_SECRET!, {
+        expiresIn: '1y',
+      });
+      memberAuthHeaderVal2 = `Bearer ${MemberJwtToken2}`;
+
+      UserJwtToken = jwt.sign({ email: users[1].email }, process.env.JWT_SECRET!, {
+        expiresIn: '1y',
+      });
+      UserAuthHeaderVal = `Bearer ${UserJwtToken}`;
+    });
+
+    after(async () => {
+      await prisma.$queryRaw`TRUNCATE TABLE "NodeAttestation" CASCADE;`;
+      await prisma.$queryRaw`TRUNCATE TABLE "Annotation" CASCADE;`;
+      await prisma.$queryRaw`TRUNCATE TABLE "NodeAttestationVerification" CASCADE;`;
+      // await prisma.$queryRaw`TRUNCATE TABLE "CommunityMember" CASCADE;`;
+    });
+
+    it('should allow only community members review/comment a claimed attestation', async () => {
+      let res = await request(app).post(`/v1/attestations/comment`).set('authorization', memberAuthHeaderVal1).send({
+        author: members[0].id,
+        claimId: openCodeClaim.id,
+        body: 'review 1',
+      });
+      expect(res.statusCode).to.equal(200);
+
+      res = await request(app).post(`/v1/attestations/comment`).set('authorization', memberAuthHeaderVal2).send({
+        claimId: openCodeClaim.id,
+        author: members[1].id,
+        body: 'review 2',
+      });
+      expect(res.statusCode).to.equal(200);
+
+      const comments = await attestationService.getAllClaimComments({ nodeAttestationId: openCodeClaim.id });
+      expect(comments.length).to.equal(2);
+      expect(comments.some((v) => v.authorId === members[0].userId && v.body)).to.equal(true);
+      expect(comments.some((v) => v.authorId === members[1].userId)).to.equal(true);
+    });
+
+    it('should prevent non-authorized users from reviewing a protected attestation(claim)', async () => {
+      const apiResponse = await request(app)
+        .post(`/v1/attestations/comment`)
+        .set('authorization', UserAuthHeaderVal)
+        .send({
+          claimId: openDataClaim.id,
+        });
+      expect(apiResponse.statusCode).to.equal(401);
+
+      const comments = await attestationService.getAllClaimComments({ nodeAttestationId: openDataClaim.id });
+      expect(comments.length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Description of the Problem / Feature
- Restrict protected attestations review/comments to authorised validators only
- Add guard api to check if auth user has community member authorisation
