### PR TITLE
add traceIds to logs and also fix ipfs image imports

### DIFF
--- a/desci-server/scripts/be-node-dev.sh
+++ b/desci-server/scripts/be-node-dev.sh
@@ -14,6 +14,12 @@ chmod -R 777 /app/node_modules/prisma
 cd desci-server
 yarn run migrate
 npx prisma db seed
+
+# import required images from ipfs to local
+echo "Hi"
+chmod +x ./scripts/import-ipfs-content.sh
+./scripts/import-ipfs-content.sh 
+
 # note: for local dev, you can probably import dpid 46 using the following script, however it doesn't work due to local IPFS client not being open to the public (swarm key)
 # when you set NODE_ENV=prod, it uses the public IPFS reader. Need to adjust this for local dev so we can properly import in the future
 # NODE_ENV=prod OPERATION=fillPublic USER_EMAIL=noreply@desci.com NODE_UUID=pOV6-0ZN8k8Nlb3iJ7BHgbHt4V_xt-H-dUbRQCLKl78. npm run script:fix-data-refs

--- a/desci-server/scripts/be-node-dev.sh
+++ b/desci-server/scripts/be-node-dev.sh
@@ -16,7 +16,6 @@ yarn run migrate
 npx prisma db seed
 
 # import required images from ipfs to local
-echo "Hi"
 chmod +x ./scripts/import-ipfs-content.sh
 ./scripts/import-ipfs-content.sh 
 

--- a/desci-server/scripts/import-ipfs-content.sh
+++ b/desci-server/scripts/import-ipfs-content.sh
@@ -1,0 +1,4 @@
+# import required images from ipfs to local
+
+wget https://ipfs.desci.com/ipfs/bafkreih6yx7ywj7trvpp45vergrnytad7ezsku75tefyro4qrrcfrrmrt4 -O /tmp/cover.png
+curl -F file=@/tmp/cover.png "http://host.docker.internal:5001/api/v0/add?cid-version=1"

--- a/desci-server/src/logger.ts
+++ b/desci-server/src/logger.ts
@@ -1,10 +1,12 @@
+import { AsyncLocalStorage } from 'async_hooks';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { pino } from 'pino';
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+export const als = new AsyncLocalStorage();
 
 const logLevel = process.env.PINO_LOG_LEVEL || 'trace';
 
@@ -28,6 +30,48 @@ export const logger = pino({
   level: logLevel,
   serializers: {
     files: omitBuffer,
+  },
+  hooks: {
+    logMethod: function (inputArgs, method) {
+      //get caller
+      const stack = new Error().stack.split('\n');
+      // find first line that is not from this file
+
+      let callerFilePath;
+      try {
+        callerFilePath = stack
+          .filter((a) => a.includes('file:///') && !a.includes('src/logger.ts'))[0]
+          .split('(')[1]
+          .split(')')[0]
+          .replace('file:///app/desci-server/src/', '');
+      } catch (err) {
+        // callerFilePath = '-unknown-';
+      }
+
+      const target = typeof inputArgs[0] == 'string' ? 1 : 0;
+      const newInputArgs = [...inputArgs];
+      if (!newInputArgs[target]) {
+        newInputArgs[target] = {};
+      }
+
+      newInputArgs[target]['caller'] = callerFilePath;
+
+      newInputArgs[target]['userAuth'] = (als.getStore() as any)?.userAuth;
+
+      const traceId = (als.getStore() as any)?.traceId;
+      if (traceId) {
+        newInputArgs[target]['traceId'] = traceId;
+
+        const timingArray = (als.getStore() as any)?.timing;
+        if (timingArray) {
+          newInputArgs[target]['traceIndex'] = timingArray.length;
+          newInputArgs[target]['traceDelta'] = Date.now() - timingArray[timingArray.length - 1];
+        }
+        (als.getStore() as any)?.timing.push(Date.now());
+      }
+
+      return method.apply(this, [...newInputArgs]);
+    },
   },
   transport:
     process.env.NODE_ENV === 'production'

--- a/desci-server/src/middleware/authorisation.ts
+++ b/desci-server/src/middleware/authorisation.ts
@@ -10,6 +10,8 @@ import { ensureUuidEndsWithDot, hideEmail } from '../utils.js';
 
 export interface RequestWithUser extends Request {
   user: User;
+  userAuth?: any;
+  traceId?: string;
 }
 
 export interface RequestWithNode extends RequestWithUser {

--- a/desci-server/src/server.ts
+++ b/desci-server/src/server.ts
@@ -187,7 +187,7 @@ class AppServer {
         customProps: (req: RequestWithUser, res) => ({
           userAuth: req.userAuth,
           traceId: (als.getStore() as any)?.traceId,
-          http: true,
+          http: 1,
         }),
         serializers: {
           res: (res) => {


### PR DESCRIPTION
## Description of the Problem / Feature
- when logging to betterstack we have no ability to tell which log items were related or which user triggered them

secondarily: when developing locally certain images were expected to be on IPFS public resolver, but when deving locally we use a private IPFS node which has no access

## Explanation of the solution
- add traceId to all requests
- make any other log lines read from AsyncLocalStorage to also include traceId
- log the userId if logged in
- send X-Desci-Trace-Id in response for debugging failed requests in the wild

secondarily: - add import-ipfs-content.sh script to fix broken images when local dev

## Instructions on making this work

no action required