### PR TITLE
Local backend hotfix

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,7 +54,6 @@ services:
       - "5420:5420"
       - "9228:9228"
       - "9277:9277"
-      - "9228:9228"
       - "5555:5555"
     extra_hosts:
       - host.docker.internal:host-gateway


### PR DESCRIPTION

## Description of the Problem / Feature
2 PRs got merged with a port duplicate under the same service on different lines preventing the local backend from being spun up

