### PR TITLE
make cookie auth isolated per environment

### DIFF
--- a/desci-repo/.env.example
+++ b/desci-repo/.env.example
@@ -3,3 +3,4 @@ NODE_ENV=dev
 JWT_SECRET=secretshhh
 DATABASE_URL=postgresql://walter:white@db_boilerplate:5432/boilerplate
 IPFS_RESOLVER_OVERRIDE=http://host.docker.internal:8089/ipfs
+# DESCI_SERVER_URL=

--- a/desci-repo/kubernetes/deployment_dev.yaml
+++ b/desci-repo/kubernetes/deployment_dev.yaml
@@ -48,6 +48,7 @@ spec:
           export JWT_SECRET={{ .Data.JWT_SECRET }}
           export DATABASE_URL={{ .Data.DATABASE_URL }}
           export IPFS_RESOLVER_OVERRIDE={{ .Data.IPFS_RESOLVER_OVERRIDE }}
+          export DESCI_SERVER_URL={{ .Data.DESCI_SERVER_URL }}
 
           {{- end -}}
       labels:

--- a/desci-repo/kubernetes/deployment_prod.yaml
+++ b/desci-repo/kubernetes/deployment_prod.yaml
@@ -49,6 +49,7 @@ spec:
           export JWT_SECRET={{ .Data.JWT_SECRET }}
           export DATABASE_URL={{ .Data.DATABASE_URL }}
           export IPFS_RESOLVER_OVERRIDE={{ .Data.IPFS_RESOLVER_OVERRIDE }}
+          export DESCI_SERVER_URL={{ .Data.DESCI_SERVER_URL }}
 
           {{- end -}}
       labels:

--- a/desci-repo/kubernetes/deployment_staging.yaml
+++ b/desci-repo/kubernetes/deployment_staging.yaml
@@ -49,6 +49,7 @@ spec:
           export JWT_SECRET={{ .Data.JWT_SECRET }}
           export DATABASE_URL={{ .Data.DATABASE_URL }}
           export IPFS_RESOLVER_OVERRIDE={{ .Data.IPFS_RESOLVER_OVERRIDE }}
+          export DESCI_SERVER_URL={{ .Data.DESCI_SERVER_URL }}
 
           {{- end -}}
       labels:

--- a/desci-repo/src/middleware/permissions.ts
+++ b/desci-repo/src/middleware/permissions.ts
@@ -25,6 +25,16 @@ export const ensureUser = async (req: ExpressRequest, res: Response, next: NextF
   }
 };
 
+const AUTH_COOKIE_DOMAIN_MAPPING = {
+  'https://nodes-api.desci.com': 'auth',
+  'https://nodes-api-dev.desci.com': 'auth-dev',
+  'https://nodes-api-stage.desci.com': 'auth-stage',
+};
+
+// auth, auth-stage, auth-dev
+export const AUTH_COOKIE_FIELDNAME =
+  AUTH_COOKIE_DOMAIN_MAPPING[process.env.DESCI_SERVER_URL || 'https://nodes-api.desci.com'] || 'auth';
+
 /**
  * Extract JWT Authorisation token from IncommingRequest
  */
@@ -43,7 +53,7 @@ export const extractAuthToken = async (request: ExpressRequest | Request) => {
 
     // If auth token wasn't found in the header, try retrieve from cookies
     if (!token && request['cookies']) {
-      token = request['cookies']['auth'];
+      token = request['cookies'][AUTH_COOKIE_FIELDNAME];
     }
 
     // If Auth token is null and request.headers.cookie is valid, attempt to parse auth token from cookie

--- a/desci-server/src/controllers/auth/logout.ts
+++ b/desci-server/src/controllers/auth/logout.ts
@@ -1,10 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 
+import { AUTH_COOKIE_FIELDNAME } from '../../utils/sendCookie.js';
+
 export const logout = async (req: Request, res: Response, next: NextFunction) => {
   // req.session.destroy((err) => {
   // if you send data here it gives an error and kills the process lol
   // });
-  res.cookie('auth', 'unset', {
+  res.cookie(AUTH_COOKIE_FIELDNAME, 'unset', {
     maxAge: 0,
     httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
     secure: process.env.NODE_ENV === 'production',
@@ -14,7 +16,7 @@ export const logout = async (req: Request, res: Response, next: NextFunction) =>
   });
 
   (process.env.COOKIE_DOMAIN?.split(',') || [undefined]).map((domain) => {
-    res.cookie('auth', 'unset', {
+    res.cookie(AUTH_COOKIE_FIELDNAME, 'unset', {
       maxAge: 0,
       httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
       secure: process.env.NODE_ENV === 'production',
@@ -26,7 +28,7 @@ export const logout = async (req: Request, res: Response, next: NextFunction) =>
 
   if (process.env.SERVER_URL === 'https://nodes-api-dev.desci.com') {
     // insecure cookie for local dev, should only be used for testing
-    res.cookie('auth', 'unset', {
+    res.cookie(AUTH_COOKIE_FIELDNAME, 'unset', {
       maxAge: 0,
       httpOnly: true,
       sameSite: 'strict',

--- a/desci-server/src/middleware/permissions.ts
+++ b/desci-server/src/middleware/permissions.ts
@@ -6,6 +6,7 @@ import { prisma } from '../client.js';
 import { hashApiKey } from '../controllers/auth/utils.js';
 import { logger } from '../logger.js';
 import { getUserByEmail, getUserByOrcId } from '../services/user.js';
+import { AUTH_COOKIE_FIELDNAME } from '../utils/sendCookie.js';
 
 export enum AuthMethods {
   AUTH_TOKEN = 'AUTH_TOKEN',
@@ -32,7 +33,7 @@ export const ensureUser = async (req: ExpressRequest, res: Response, next: NextF
  * Extract JWT Authorisation token from IncommingRequest
  */
 export const extractAuthToken = async (request: ExpressRequest | Request) => {
-  let token = await extractTokenFromCookie(request, 'auth');
+  let token = await extractTokenFromCookie(request, AUTH_COOKIE_FIELDNAME);
 
   if (!token) {
     // Try to retrieve the token from the header

--- a/desci-server/src/utils/sendCookie.ts
+++ b/desci-server/src/utils/sendCookie.ts
@@ -2,12 +2,22 @@ import { type Response } from 'express';
 
 import { oneDay, oneMinute, oneYear } from '../controllers/auth/magic.js';
 import { logger } from '../logger.js';
-export const sendCookie = (res: Response, token: string, isDevMode: boolean, cookieName = 'auth') => {
+
+const AUTH_COOKIE_DOMAIN_MAPPING = {
+  'https://nodes-api.desci.com': 'auth',
+  'https://nodes-api-dev.desci.com': 'auth-dev',
+  'https://nodes-api-staging.desci.com': 'auth-stage',
+};
+
+// auth, auth-stage, auth-dev
+export const AUTH_COOKIE_FIELDNAME = AUTH_COOKIE_DOMAIN_MAPPING[process.env.SERVER_URL] || 'auth';
+
+export const sendCookie = (res: Response, token: string, isDevMode: boolean, cookieName = AUTH_COOKIE_FIELDNAME) => {
   if (isDevMode && process.env.SERVER_URL === 'https://nodes-api-dev.desci.com') {
     // insecure cookie for local dev, should only be used for testing
     logger.info({ fn: 'sendCookie' }, `insecure dev cookie set`);
     res.cookie(cookieName, token, {
-      maxAge: cookieName === 'auth' ? oneDay : oneMinute,
+      maxAge: cookieName === AUTH_COOKIE_FIELDNAME ? oneDay : oneMinute,
       httpOnly: true,
       sameSite: 'strict',
     });
@@ -16,7 +26,7 @@ export const sendCookie = (res: Response, token: string, isDevMode: boolean, coo
   (process.env.COOKIE_DOMAIN?.split(',') || [undefined]).map((domain) => {
     logger.info({ fn: 'sendCookie', domain, env: process.env.NODE_ENV }, `cookie set`);
     res.cookie(cookieName, token, {
-      maxAge: cookieName === 'auth' ? oneYear : oneMinute,
+      maxAge: cookieName === AUTH_COOKIE_FIELDNAME ? oneYear : oneMinute,
       httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
       secure: process.env.NODE_ENV === 'production',
       domain: process.env.NODE_ENV === 'production' ? domain || '.desci.com' : 'localhost',

--- a/desci-server/src/utils/sendCookie.ts
+++ b/desci-server/src/utils/sendCookie.ts
@@ -3,6 +3,10 @@ import { type Response } from 'express';
 import { oneDay, oneMinute, oneYear } from '../controllers/auth/magic.js';
 import { logger } from '../logger.js';
 
+/**
+ * To enable a wildcard auth cookie that works across all subdomains, we need to modify the auth cookie name for each domain.
+ */
+
 const AUTH_COOKIE_DOMAIN_MAPPING = {
   'https://nodes-api.desci.com': 'auth',
   'https://nodes-api-dev.desci.com': 'auth-dev',


### PR DESCRIPTION
frontend PR https://github.com/desci-labs/nodes-web-v2/pull/761

make cookie auth isolated per environment, preventing collisions across nodes-api-dev nodes-api-staging and nodes-api

this fixes the bug users experience when navigating between nodes prod and nodes dev

<img width="703" alt="Screenshot 2024-06-16 at 10 20 45 PM" src="https://github.com/desci-labs/nodes/assets/278886/7f77dcf3-2aff-4d08-9460-c426e58240ed">
