### PR TITLE
Fixes so staging uses production environments

### DIFF
--- a/desci-server/src/controllers/nodes/createDpid.ts
+++ b/desci-server/src/controllers/nodes/createDpid.ts
@@ -47,11 +47,11 @@ if (apiServerUrl.includes('localhost') || apiServerUrl.includes('host.docker.int
   aliasRegistryAddress = contracts.localDpidAliasInfo.proxies.at(0).address;
   ceramicApiUrl = CERAMIC_API_URLS.local;
   optimismRpcUrl = OPTIMISM_RPC_URLS.local;
-} else if (apiServerUrl.includes('dev') || apiServerUrl.includes('staging')) {
+} else if (apiServerUrl.includes('dev')) {
   aliasRegistryAddress = contracts.devDpidAliasInfo.proxies.at(0).address;
   ceramicApiUrl = CERAMIC_API_URLS.dev;
   optimismRpcUrl = OPTIMISM_RPC_URLS.opSepolia;
-} else if (process.env.NODE_ENV === 'production') {
+} else if (process.env.NODE_ENV === 'production' || apiServerUrl.includes('staging')) {
   aliasRegistryAddress = contracts.prodDpidAliasInfo.proxies.at(0).address;
   ceramicApiUrl = CERAMIC_API_URLS.prod;
   optimismRpcUrl = OPTIMISM_RPC_URLS.opSepolia;

--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/src/config/chain.ts
+++ b/nodes-lib/src/config/chain.ts
@@ -109,12 +109,12 @@ export const CHAIN_CONFIGS = {
     chainId: "11155420",
     rpcUrl: "https://reverse-proxy-staging.desci.com/rpc_opt_sepolia",
     dpidAliasRegistryConnector: signerOrProvider => tc.DpidAliasRegistry__factory.connect(
-      contracts.devDpidAliasInfo.proxies[0].address,
+      contracts.prodDpidAliasInfo.proxies[0].address, // also uses prod contracts
       signerOrProvider,
     ),
   },
   prod: {
-    chainId: "10",
+    chainId: "11155420",
     rpcUrl: "https://reverse-proxy-prod.desci.com/rpc_opt_sepolia",
     dpidAliasRegistryConnector: signerOrProvider => tc.DpidAliasRegistry__factory.connect(
       contracts.prodDpidAliasInfo.proxies[0].address,

--- a/nodes-lib/src/config/index.ts
+++ b/nodes-lib/src/config/index.ts
@@ -33,9 +33,9 @@ export const NODESLIB_CONFIGS = {
   staging: {
     apiUrl: "https://nodes-api-staging.desci.com",
     apiKey: undefined,
-    ceramicNodeUrl: "https://ceramic-dev.desci.com",
-    legacyChainConfig: LEGACY_CHAIN_CONFIGS.dev, // also using the dev contracts
-    chainConfig: CHAIN_CONFIGS.dev, // also using dev contracts
+    ceramicNodeUrl: "https://ceramic-prod.desci.com",
+    legacyChainConfig: LEGACY_CHAIN_CONFIGS.prod, // also using the prod contracts
+    chainConfig: CHAIN_CONFIGS.prod, // also using prod contracts
   },
   prod: {
     apiUrl: "https://nodes-api.desci.com",


### PR DESCRIPTION
Ensures our friend the staging environment uses external production environments, so it matches up with the resolver :medical_symbol: 