### PR TITLE
hotfix: add support to claim all optional attestations

### DIFF
--- a/desci-server/src/controllers/attestations/claims.ts
+++ b/desci-server/src/controllers/attestations/claims.ts
@@ -129,7 +129,7 @@ export const claimEntryRequirements = async (req: Request, res: Response, _next:
   logger.info({ communityId, body: req.body }, 'claimEntryRequirements');
   const uuid = ensureUuidEndsWithDot(nodeUuid);
 
-  const entryAttestations = await attestationService.getCommunityEntryAttestations(communityId);
+  const entryAttestations = await attestationService.getAllCommunityEntryAttestations(communityId);
   logger.info({ entryAttestations });
 
   const claimables = (await asyncMap(entryAttestations, async (attestation) => {

--- a/desci-server/src/routes/v1/attestations/index.ts
+++ b/desci-server/src/routes/v1/attestations/index.ts
@@ -43,8 +43,8 @@ import {
 
 const router = Router();
 
-router.get('/suggestions/all', [ensureUser], asyncHander(getAllRecommendations));
-router.get('/suggestions/protected', [ensureUser], asyncHander(getValidatedRecommendations));
+router.get('/suggestions/all', [], asyncHander(getAllRecommendations));
+router.get('/suggestions/protected', [], asyncHander(getValidatedRecommendations));
 router.get(
   '/claims/:communityId/:dpid',
   [ensureUser, validate(showCommunityClaimsSchema)],

--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -290,6 +290,12 @@ export class AttestationService {
     return prisma.communityEntryAttestation.findMany({ where: { desciCommunityId: communityId, required: true } });
   }
 
+  async getAllCommunityEntryAttestations(communityId: number) {
+    const community = await communityService.findCommunityById(communityId);
+    if (!community) throw new CommunityNotFoundError();
+    return prisma.communityEntryAttestation.findMany({ where: { desciCommunityId: communityId } });
+  }
+
   async claimAttestation({
     attestationId,
     attestationVersion,


### PR DESCRIPTION
when attestations are optional they are not automatically claim in CLAIM ALL workflow, this makes them all claimed

![image](https://github.com/desci-labs/nodes/assets/278886/1caf6f9c-da63-4ffe-86db-9da867d9effc)
