### PR TITLE
Inherit contributions

### DIFF
--- a/desci-server/src/controllers/auth/magic.ts
+++ b/desci-server/src/controllers/auth/magic.ts
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken';
 import { prisma as prismaClient } from '../../client.js';
 import { logger } from '../../logger.js';
 import { magicLinkRedeem, sendMagicLink } from '../../services/auth.js';
+import { contributorService } from '../../services/Contributors.js';
 import { saveInteraction } from '../../services/interactionLog.js';
 import { checkIfUserAcceptedTerms, connectOrcidToUserIfPossible } from '../../services/user.js';
 import { sendCookie } from '../../utils/sendCookie.js';
@@ -52,6 +53,15 @@ export const magic = async (req: Request, res: Response, next: NextFunction) => 
           email,
         },
       });
+
+      if (user.email) {
+        // Inherits existing user contribution entries that were made with the same email
+        const inheritedContributions = await contributorService.updateContributorEntriesForNewUser({
+          email: user.email,
+          userId: user.id,
+        });
+        logger.trace({ inheritedContributions: inheritedContributions?.count, user, email });
+      }
     }
 
     try {

--- a/desci-server/src/services/Contributors.ts
+++ b/desci-server/src/services/Contributors.ts
@@ -1,7 +1,7 @@
 import { format } from 'path';
 
 import { IpldUrl, ResearchObjectV1Dpid } from '@desci-labs/desci-models';
-import { Node, NodeContribution, User } from '@prisma/client';
+import { Node, NodeContribution, Prisma, User } from '@prisma/client';
 import ShortUniqueId from 'short-unique-id';
 
 import { prisma } from '../client.js';
@@ -340,6 +340,30 @@ class ContributorService {
 
     if (privShare) return privShare.shareId;
     return null;
+  }
+
+  /*
+  Associates the user's nodes profile (userId) with all entries under that email/orcid, used on new signups to link previously added contributions
+  */
+  async updateContributorEntriesForNewUser({
+    email,
+    orcid,
+    userId,
+  }: {
+    email?: string;
+    orcid?: string;
+    userId: number;
+  }): Promise<Prisma.BatchPayload> {
+    if (!orcid && !email) return { count: 0 };
+    return await prisma.nodeContribution.updateMany({
+      where: {
+        email,
+        orcid,
+      },
+      data: {
+        userId,
+      },
+    });
   }
 
   async getContributionById(contributorId: string): Promise<NodeContribution> {

--- a/desci-server/src/services/user.ts
+++ b/desci-server/src/services/user.ts
@@ -6,6 +6,7 @@ import { OrcIdRecordData, generateAccessToken, getOrcidRecord } from '../control
 import { logger as parentLogger } from '../logger.js';
 import { hideEmail } from '../utils.js';
 
+import { contributorService } from './Contributors.js';
 import { getUserConsent } from './interactionLog.js';
 const logger = parentLogger.child({
   module: 'Services::User',
@@ -247,6 +248,13 @@ export async function setOrcidForUser(
         },
       });
       logger.trace({ fn: 'setOrcidForUser' }, 'added auth token');
+
+      // Inherits existing user contribution entries that were made with the same ORCID
+      const inheritedContributions = await contributorService.updateContributorEntriesForNewUser({
+        orcid,
+        userId: user.id,
+      });
+      logger.trace({ inheritedContributions: inheritedContributions?.count, user, orcid });
     } else {
       logger.trace({ fn: 'setOrcidForUser' }, 'no user found');
       return false;


### PR DESCRIPTION
## Description of the Problem / Feature
- If a user doesn't use the shared link in their email they're unable to verify their contribution
## Explanation of the solution
- Added contribution inheritance logic in signup flow, when a user registers they inherit all contributions that used their email/orcid, allowing them to access their shared nodes from profile and verifying their contributions.

Relies on the priv share fixes being merged in:
FE: https://github.com/desci-labs/nodes-web-v2/pull/811
BE: https://github.com/desci-labs/nodes/pull/431