### PR TITLE
Fix dpid urls

### DIFF
--- a/desci-media-isolated/.env.example
+++ b/desci-media-isolated/.env.example
@@ -3,3 +3,5 @@ NODE_ENV=development
 PORT=7771
 
 IPFS_GATEWAY=http://host.docker.internal:5420/v1/ipfs
+
+DPID_RESOLVER_URL=https://dev-beta.dpid.org

--- a/desci-media-isolated/kubernetes/deployment_dev.yaml
+++ b/desci-media-isolated/kubernetes/deployment_dev.yaml
@@ -46,6 +46,8 @@ spec:
               value: '7771'
             - name: IPFS_GATEWAY
               value: 'https://ipfs.desci.com/ipfs'
+            - name: DPID_RESOLVER_URL
+              value: 'https://dev-beta.dpid.org'
           resources:
             limits:
               cpu: '4'

--- a/desci-media-isolated/kubernetes/deployment_prod.yaml
+++ b/desci-media-isolated/kubernetes/deployment_prod.yaml
@@ -46,6 +46,8 @@ spec:
               value: '7771'
             - name: IPFS_GATEWAY
               value: 'http://host.docker.internal:5420/v1/ipfs'
+            - name: DPID_RESOLVER_URL
+              value: 'https://beta.dpid.org'
           resources:
             limits:
               cpu: '0.5'

--- a/desci-media-isolated/kubernetes/deployment_staging.yaml
+++ b/desci-media-isolated/kubernetes/deployment_staging.yaml
@@ -46,6 +46,8 @@ spec:
               value: '7771'
             - name: IPFS_GATEWAY
               value: 'http://host.docker.internal:5420/v1/ipfs'
+            - name: DPID_RESOLVER_URL
+              value: 'https://dev-beta.dpid.org'
           resources:
             limits:
               cpu: '0.5'

--- a/desci-media-isolated/src/services/pdf.ts
+++ b/desci-media-isolated/src/services/pdf.ts
@@ -85,8 +85,10 @@ export class PdfManipulationService {
       /*
        * Header
        */
+      const dpidResolverUrl = process.env.DPID_RESOLVER_URL ?? 'https://beta.dpid.org';
+
       const licenseStartsWithVowel = startsWithVowel(license);
-      const nodeUrl = usingDoi ? `https://doi.org/${doi}` : `https://beta.dpid.org/${dpid}`;
+      const nodeUrl = usingDoi ? `https://doi.org/${doi}` : `${dpidResolverUrl}/${dpid}`;
       const topHeader = `Research object ${nodeUrl}, this version posted ${publishDate}. The copyright holder for this research object (which was not certified by peer review) is the author/funder, who has granted DeSci Labs a non-exclsuive license to display the research object in perpetuity. It is made available under a${
         licenseStartsWithVowel ? 'n' : ''
       } ${license} license.`;

--- a/desci-server/src/services/PublishPackage.ts
+++ b/desci-server/src/services/PublishPackage.ts
@@ -73,12 +73,13 @@ class PublishPackageService {
     const openCodeAttestation = attestations.find((a) => a.attestationVersion.name === 'Open Code');
     const openDataAttestation = attestations.find((a) => a.attestationVersion.name === 'Open Data');
 
+    const dpidUrl = process.env.DPID_URL_OVERRIDE ?? 'https://beta.dpid.org';
     const attestationLinks = {
       ...(openCodeAttestation && {
-        codeAvailableDpid: `https://beta.dpid.org/${dpid}/attestations/${toKebabCase(openCodeAttestation.attestationVersion.name)}`,
+        codeAvailableDpid: `${dpidUrl}/${dpid}/attestations/${toKebabCase(openCodeAttestation.attestationVersion.name)}`,
       }),
       ...(openDataAttestation && {
-        dataAvailableDpid: `https://beta.dpid.org/${dpid}/attestations/${toKebabCase(openDataAttestation.attestationVersion.name)}`,
+        dataAvailableDpid: `${dpidUrl}/${dpid}/attestations/${toKebabCase(openDataAttestation.attestationVersion.name)}`,
       }),
     };
 


### PR DESCRIPTION
## Description of the Problem / Feature
- DPID resolver urls were hardcoded for prepub generations, leading to covers generated in dev containing prod URLs
## Explanation of the solution
- Added an env in the media server to set the env depending on the environment
