### PR TITLE
DeferredEmail table revert, correct fix applied

### DIFF
--- a/desci-server/prisma/migrations/20240808190859_revert_deferred_table/migration.sql
+++ b/desci-server/prisma/migrations/20240808190859_revert_deferred_table/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `nodeAttestationId` on the `DeferredEmails` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "DeferredEmails" DROP CONSTRAINT "DeferredEmails_nodeAttestationId_fkey";
+
+-- AlterTable
+ALTER TABLE "DeferredEmails" DROP COLUMN "nodeAttestationId",
+ADD COLUMN     "attestationId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "DeferredEmails" ADD CONSTRAINT "DeferredEmails_attestationId_fkey" FOREIGN KEY ("attestationId") REFERENCES "Attestation"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -712,6 +712,7 @@ model Attestation {
   AttestationVersion        AttestationVersion[]
   NodeAttestation           NodeAttestation[]
   CommunityEntryAttestation CommunityEntryAttestation[]
+  DeferredEmails            DeferredEmails[]
 
   @@unique([name, communityId])
 }
@@ -768,7 +769,6 @@ model NodeAttestation {
   NodeAttestationVerification NodeAttestationVerification[]
   NodeAttestationReaction     NodeAttestationReaction[]
   OrcidPutCodes               OrcidPutCodes[]
-  DeferredEmails              DeferredEmails[]
 
   @@unique([nodeUuid, nodeVersion, attestationId, attestationVersionId])
 }
@@ -779,8 +779,8 @@ model DeferredEmails {
   nodeUuid             String
   emailType            EmailType
   attestationVersionId Int?
-  nodeAttestationId    Int?
-  nodeAttestation      NodeAttestation?    @relation(fields: [nodeAttestationId], references: [id])
+  attestationId        Int?
+  attestation          Attestation?        @relation(fields: [attestationId], references: [id])
   node                 Node                @relation(fields: [nodeUuid], references: [uuid])
   User                 User?               @relation(fields: [userId], references: [id])
   userId               Int?

--- a/desci-server/src/controllers/attestations/claims.ts
+++ b/desci-server/src/controllers/attestations/claims.ts
@@ -72,7 +72,7 @@ export const claimAttestation = async (req: RequestWithUser, res: Response, _nex
       data: {
         nodeUuid: uuid,
         emailType: EmailType.PROTECTED_ATTESTATION,
-        nodeAttestationId: nodeClaim.id,
+        attestationId: nodeClaim.attestationId,
         attestationVersionId: attestationVersion.id,
         userId: req.user.id,
       },
@@ -113,7 +113,7 @@ export const removeClaim = async (req: RequestWithUser, res: Response, _next: Ne
       where: {
         nodeUuid: ensureUuidEndsWithDot(body.nodeUuid),
         emailType: EmailType.PROTECTED_ATTESTATION,
-        nodeAttestationId: claim.id,
+        attestationId: claim.attestationId,
         userId: req.user.id,
       },
     });

--- a/desci-server/src/services/PublishServices.ts
+++ b/desci-server/src/services/PublishServices.ts
@@ -141,7 +141,7 @@ export class PublishServices {
         await Promise.allSettled(
           protectedAttestationEmails.map((entry) => {
             return attestationService.emailProtectedAttestationCommunityMembers(
-              entry.nodeAttestationId,
+              entry.attestationId,
               entry.attestationVersionId,
               nodeVersion - 1, // 0-indexed total expected
               dpid,


### PR DESCRIPTION
## Description of the Problem / Feature
- The Attestation relation in the deferredEmail table in the initial PR was correct, reverted the table back to this state
- Reverted the changed functions, fixed the one broken function that was taking in the wrong type of attestation id.

Includes migrations