### PR TITLE
server: fix history lookup for nodes missing in the database

### DIFF
--- a/desci-server/src/controllers/raw/versions.ts
+++ b/desci-server/src/controllers/raw/versions.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
 import { logger } from '../../logger.js';
-import { getIndexedResearchObjects } from '../../theGraph.js';
+import { getIndexedResearchObjects, IndexedResearchObject } from '../../theGraph.js';
 import { ensureUuidEndsWithDot } from '../../utils.js';
 
 /**
@@ -10,7 +10,7 @@ import { ensureUuidEndsWithDot } from '../../utils.js';
 export const versions = async (req: Request, res: Response, next: NextFunction) => {
   const uuid = ensureUuidEndsWithDot(req.params.uuid);
   let graphOk = false;
-  let result;
+  let result: IndexedResearchObject;
   try {
     const { researchObjects } = await getIndexedResearchObjects([uuid]);
     result = researchObjects[0];

--- a/desci-server/src/theGraph.ts
+++ b/desci-server/src/theGraph.ts
@@ -75,7 +75,7 @@ export const getIndexedResearchObjects = async (
     },
   });
 
-  // 1. These (upgraded nodes) we can resolve normally
+  // 1. Upgraded nodes we can resolve normally
   const nodesWithStream = nodeRes.filter(n => !!n.ceramicStream);
 
   // Create stream to hex UUID lookup mapping
@@ -94,15 +94,16 @@ export const getIndexedResearchObjects = async (
     logger.info({ streamHistory }, "Resolver history for nodes found");
   };
 
-  // 2. These are simplest to fallback to graph lookup as we don't have the dPID handy
-  const nodesWithoutStream = nodeRes
-    .filter(n => !n.ceramicStream)
-    .map(n => n.uuid);
+  // 2. Other nodes we need to graph lookup, as we don't have the dPID handy
+  //   - Can't filter on !ceramicStream, as some really old nodes aren't in the database
+  const uuidsWithoutStream = urlSafeBase64s.filter(
+    u => !nodeRes.some(({ uuid }) => u === uuid)
+  );
 
   let legacyHistory = [];
-  if (nodesWithoutStream.length > 0) {
-    logger.info({ nodesWithoutStream }, "Falling back to subgraph query for history");
-    legacyHistory = (await _getIndexedResearchObjects(nodesWithoutStream))
+  if (uuidsWithoutStream.length > 0) {
+    logger.info({ uuidsWithoutStream}, "Falling back to subgraph query for history");
+    legacyHistory = (await _getIndexedResearchObjects(uuidsWithoutStream))
       .researchObjects;
     logger.info({ legacyHistory }, "Subgraph history for nodes found");
   };


### PR DESCRIPTION
Was unaware that some really old nodes were missing the database, should have worked anyway but due to a bug in filtering UUID's not so much  :bug: 