### PR TITLE
Speedup node queries ⚡

### DIFF
--- a/desci-server/src/client.ts
+++ b/desci-server/src/client.ts
@@ -1,3 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
-export const prisma = new PrismaClient();
+export const prisma = new PrismaClient(
+  process.env.PRISMA_DEBUG
+    ? { log: ["info", "query", "warn", "error"] }
+    : { log: ["warn", "error"]}
+);

--- a/desci-server/src/controllers/nodes/contributions/getUserContributions.ts
+++ b/desci-server/src/controllers/nodes/contributions/getUserContributions.ts
@@ -32,7 +32,10 @@ export const getUserContributions = async (
   }
 
   try {
-    const user = await prisma.user.findUnique({ where: { id: parseInt(userId) } });
+    const user = await prisma.user.findUnique({
+      select: { id: true },
+      where: { id: parseInt(userId) },
+    });
     const userContributions = await contributorService.retrieveContributionsForUser(user);
     if (userContributions) {
       logger.info({ totalContributions: userContributions.length }, 'Contributions retrieved successfully');

--- a/desci-server/src/controllers/nodes/getPublishedNodeStats.ts
+++ b/desci-server/src/controllers/nodes/getPublishedNodeStats.ts
@@ -1,29 +1,10 @@
-import type { Request, Response, NextFunction } from 'express';
-
+import type { Request, Response } from 'express';
 import { prisma } from '../../client.js';
-import { NodeUuid, resolveNodeManifest } from '../../internal.js';
 import { logger as parentLogger } from '../../logger.js';
-import { type ThumbnailMap, thumbnailsService } from '../../services/Thumbnails.js';
-import { asyncMap, decodeBase64UrlSafeToHex, ensureUuidEndsWithDot, randomUUID64 } from '../../utils.js';
-import { IndexedResearchObject, getIndexedResearchObjects } from '../../theGraph.js';
-import { ResearchObjectV1, ResearchObjectV1Dpid } from '@desci-labs/desci-models';
-import { Node, NodeCover } from '@prisma/client';
 
 const logger = parentLogger.child({
   module: 'NODE::getPublishedNodesController',
 });
-
-type NodeWithDpid = {
-  uuid: string;
-  createdAt: Date;
-  updatedAt: Date;
-  ownerId: number;
-  title: string;
-  manifestUrl: string;
-  cid: string;
-  NodeCover: NodeCover[];
-  isPublished: boolean;
-} & { dpid?: ResearchObjectV1Dpid; isPublished: boolean; index?: IndexedResearchObject };
 
 type GetPublishedNodeStatsResponse = {
   ok: true;
@@ -43,67 +24,28 @@ export const getPublishedNodeStats = async (
     ipfsQuery,
   });
 
-  let nodes = await prisma.node.findMany({
+  // _count unavailable in prisma <4.16
+  let publishedNodeIds = await prisma.node.findMany({
     select: {
-      uuid: true,
-      id: true,
-      createdAt: true,
-      updatedAt: true,
-      ownerId: true,
-      title: true,
-      manifestUrl: true,
-      cid: true,
-      NodeCover: true,
+      id: true
     },
     where: {
-      ownerId: owner.id,
-      isDeleted: false,
-      ceramicStream: {
-        not: null,
+      ownerId: {
+        equals: owner.id
       },
+      versions: {
+        some: {
+          OR: [
+            { transactionId: { not: null }},
+            { commitId: { not: null }},
+          ]
+        }
+      }
     },
-    orderBy: { updatedAt: 'desc' },
-    // take: limit,
-    // skip: (page - 1) * limit,
   });
 
-  // transition UUID
-  const indexMap = {};
+  const totalPublishedNodes = publishedNodeIds.length;
 
-  try {
-    const uuids = nodes.map((n) => n.uuid);
-    const indexed = await getIndexedResearchObjects(uuids);
-    indexed.researchObjects.forEach((e) => {
-      indexMap[e.id] = e;
-    });
-  } catch (err) {
-    logger.error({ err: err.message }, '[ERROR] graph index lookup fail');
-    // todo: try on chain direct (current method doesnt support batch, so fix that and add here)
-  }
-
-  logger.info({ indexMap }, 'indexMap');
-  logger.info({ nodes }, 'nodes');
-
-  const enhancedNodes = await asyncMap(nodes, async (n) => {
-    const hex = `0x${decodeBase64UrlSafeToHex(n.uuid)}`;
-    const result = indexMap[hex];
-    const manifest: ResearchObjectV1 = result?.recentCid
-      ? await resolveNodeManifest(result?.recentCid, ipfsQuery as string)
-      : null;
-    const o = {
-      ...n,
-      uuid: n.uuid.replaceAll('.', ''),
-      isPublished: !!indexMap[hex],
-      index: indexMap[hex],
-      dpid: manifest?.dpid,
-    };
-    delete o.id;
-
-    return o;
-  });
-  logger.info({ enhancedNodes }, 'enhancedNodes');
-
-  const totalPublishedNodes = enhancedNodes.filter((n) => n.isPublished).length;
   logger.info({ totalPublishedNodes }, 'totalPublishedNodes');
 
   res.send({

--- a/desci-server/src/controllers/nodes/getPublishedNodeStats.ts
+++ b/desci-server/src/controllers/nodes/getPublishedNodeStats.ts
@@ -30,9 +30,7 @@ export const getPublishedNodeStats = async (
       id: true
     },
     where: {
-      ownerId: {
-        equals: owner.id
-      },
+      ownerId: owner.id,
       versions: {
         some: {
           OR: [

--- a/desci-server/src/controllers/nodes/getPublishedNodes.ts
+++ b/desci-server/src/controllers/nodes/getPublishedNodes.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from 'express';
-import { prisma } from '../../client.js';
 import { cachedGetDpidFromManifest } from '../../internal.js';
 import { logger as parentLogger } from '../../logger.js';
 import { asyncMap } from '../../utils.js';
 import { User } from '@prisma/client';
+import { listAllUserNodes, PublishedNode } from './list.js';
 
 const logger = parentLogger.child({
   module: 'NODE::getPublishedNodes',
@@ -16,23 +16,9 @@ type PublishedNodesQueryParams = {
   size?: string;
 };
 
-type PublishedNodesRequest = 
+// User populated by auth middleware
+type PublishedNodesRequest =
   Request<never, never, never, PublishedNodesQueryParams> & { user: User };
-
-type PublishedNode = {
-    uuid: string;
-    /** Current version index */
-    versionIx: number;
-    /** The latest published manifest CID */
-    cid: string;
-    /** Datetime of latest publish */
-    publishedAt: Date;
-    /** Current title of the node (could have changed after publish) */
-    title: string;
-    /** Creation time of the node */
-    createdAt: Date;
-    dpid?: number;
-};
 
 type PublishedNodesResponse = Response<{
   nodes: PublishedNode[];
@@ -45,66 +31,33 @@ export const getPublishedNodes = async (
   const owner = req.user;
   const gateway = req.query.g;
 
-  // implement paging
   const page: number = req.query.page ? parseInt(req.query.page as string) : 1;
   const size: number = req.query.size ? parseInt(req.query.size as string) : 20;
 
-  const publishedNodes = await prisma.node.findMany({
-    select: {
-      uuid: true,
-      title: true,
-      createdAt: true,
-      dpidAlias: true,
-      versions: {
-        select: {
-          manifestUrl: true,
-          createdAt: true,
-          commitId: true,
-          transactionId: true,
-        },
-        where: {
-          OR: [
-            { transactionId: { not: null }},
-            { commitId: { not: null }},
-          ]
-        },
-        orderBy: { createdAt: "desc" }
-      }
-    },
-    where: {
-      ownerId: owner.id,
-      isDeleted: false,
-      // Without additional filter, we'll get results with empty versions array
-      versions: {
-        some: {
-          OR: [
-            { transactionId: { not: null }},
-            { commitId: { not: null }},
-          ]
-        }
-       }
-    },
-    // Note this is the node update, not time of last publish
-    orderBy: { updatedAt: "desc" },
-    take: size,
-    skip: (page -1) * size,
-  });
+  logger.info({
+    queryParams: req.query,
+    gateway,
+  }, "getting published nodes");
 
-  const formattedNodes = await asyncMap(publishedNodes, async n => {
-    const versionIx = n.versions.length - 1;
-    const cid = n.versions[0].manifestUrl;
-    const publishedAt = n.versions[0].createdAt;
+  const nodes = await listAllUserNodes(owner.id, page, size, true);
+  const publishedNodes = nodes.filter(n => n.versions.length);
 
-    return {
-      uuid: n.uuid.replace(".", ""),
-      title: n.title,
-      createdAt: n.createdAt,
-      cid,
-      versionIx,
-      publishedAt,
-      dpid: n.dpidAlias ?? await cachedGetDpidFromManifest(cid, gateway),
-    };
-  });
+  const formattedNodes = await asyncMap( publishedNodes, async n => {
+      const versionIx = n.versions.length - 1;
+      const cid = n.versions[0].manifestUrl;
+      const dpid = n.dpidAlias ?? await cachedGetDpidFromManifest(cid, gateway);
+      const publishedAt = n.versions[0].createdAt;
 
-  res.send({ nodes: formattedNodes });
+      return {
+        uuid: n.uuid.replace(".", ""),
+        title: n.title,
+        createdAt: n.createdAt,
+        versionIx,
+        publishedAt,
+        isPublished: true as const,
+        dpid,
+      };
+    });
+
+  return res.send({ nodes: formattedNodes });
 };

--- a/desci-server/src/controllers/nodes/list.ts
+++ b/desci-server/src/controllers/nodes/list.ts
@@ -1,58 +1,81 @@
-import { ResearchObjectV1 } from '@desci-labs/desci-models';
-import { Request, Response, NextFunction } from 'express';
-
+import { Request, Response } from 'express';
 import { prisma } from '../../client.js';
-import { resolveNodeManifest } from '../../internal.js';
+import { cachedGetDpidFromManifest } from '../../internal.js';
 import { logger as parentLogger } from '../../logger.js';
-import { getIndexedResearchObjects } from '../../theGraph.js';
-import { asyncMap, decodeBase64UrlSafeToHex, randomUUID64 } from '../../utils.js';
+import { asyncMap, randomUUID64 } from '../../utils.js';
+import { Prisma, PrismaClient, User } from '@prisma/client';
 
 const logger = parentLogger.child({
   module: 'NODE::listController',
 });
 
-export const list = async (req: Request, res: Response, next: NextFunction) => {
-  const owner = (req as any).user;
-  const ipfsQuery = req.query.g;
+type UserNodesQueryParams = {
+  /** Alternative IPFS gateway */
+  g?: string;
+  page?: string;
+  size?: string;
+};
 
-  // implement paging
+// User populated by auth middleware
+type UserNodesRequest =
+  Request<never, never, never, UserNodesQueryParams> & { user: User };
+
+export type UserNode =
+  | PublishedNode
+  | DraftNode;
+
+export type PublishedNode = {
+  uuid: string;
+  /** Current version index */
+  versionIx: number;
+  /** Datetime of latest publish */
+  publishedAt: Date;
+  /** Current title of the node (could have changed after publish) */
+  title: string;
+  /** Creation time of the node */
+  createdAt: Date;
+  /** dPID, from alias or legacy manifest entry */
+  dpid: number;
+  /** Whether the node has published versions */
+  isPublished: true;
+};
+
+export type DraftNode = {
+  uuid: string;
+  /** Current title of the node (could have changed after publish) */
+  title: string;
+  /** Creation time of the node */
+  createdAt: Date;
+  /** Whether the node has published versions */
+  isPublished: false;
+};
+
+type UserNodesResponse = Response<{
+  nodes: UserNode[];
+}>;
+
+export const list = async (
+  req: UserNodesRequest,
+  res: UserNodesResponse,
+) => {
+  const owner = req.user;
+  const gateway = req.query.g;
+
   const page: number = req.query.page ? parseInt(req.query.page as string) : 1;
-  const limit: number = req.query.limit ? parseInt(req.query.limit as string) : 10;
+  const size: number = req.query.size ? parseInt(req.query.size as string) : 10;
 
   logger.info({
-    body: req.body,
-    user: (req as any).user,
-    ipfsQuery,
-  });
+    queryParams: req.query,
+    gateway,
+  }, "getting all user nodes");
 
-  let nodes = await prisma.node.findMany({
-    select: {
-      uuid: true,
-      id: true,
-      createdAt: true,
-      updatedAt: true,
-      ownerId: true,
-      title: true,
-      manifestUrl: true,
-      cid: true,
-      NodeCover: true,
-      ceramicStream: true,
-      dpidAlias: true,
-    },
-    where: {
-      ownerId: owner.id,
-      isDeleted: false,
-    },
-    orderBy: { updatedAt: 'desc' },
-    take: limit,
-    skip: (page - 1) * limit,
-  });
+  let nodes = await listAllUserNodes(owner.id, page, size);
 
-  // transition UUID
-  const ns = nodes.filter((a) => !a.uuid);
-  if (ns.length) {
+  // Create uuid for any old nodes, and re-fetch if so
+  const nodesWithoutUuid = nodes.filter((a) => !a.uuid);
+  if (nodesWithoutUuid.length) {
     await Promise.all(
-      ns.map(
+      nodesWithoutUuid.map(
         async (n) =>
           await prisma.node.update({
             where: {
@@ -64,57 +87,87 @@ export const list = async (req: Request, res: Response, next: NextFunction) => {
           }),
       ),
     );
-    nodes = await prisma.node.findMany({
-      select: {
-        uuid: true,
-        id: true,
-        createdAt: true,
-        updatedAt: true,
-        ownerId: true,
-        title: true,
-        manifestUrl: true,
-        cid: true,
-        NodeCover: true,
-        ceramicStream: true,
-        dpidAlias: true,
-      },
-      where: {
-        ownerId: owner.id,
-        isDeleted: false,
-      },
-      orderBy: { updatedAt: 'desc' },
-    });
-  }
-  const indexMap = {};
+    nodes = await listAllUserNodes(owner.id, page, size);
+  };
 
-  try {
-    const uuids = nodes.map((n) => n.uuid);
-    const indexed = await getIndexedResearchObjects(uuids);
-    indexed.researchObjects.forEach((e) => {
-      indexMap[e.id] = e;
-    });
-  } catch (err) {
-    logger.error({ err: err.message }, '[ERROR] graph index lookup fail');
-    // todo: try on chain direct (current method doesnt support batch, so fix that and add here)
-  }
+  const formattedNodes = await asyncMap(nodes, async n => {
+    logger.info({ uuid: n.uuid, versions: n.versions })
+    const isPublished = n.versions.length > 0;
 
-  nodes = await asyncMap(nodes, async (n) => {
-    const hex = `0x${decodeBase64UrlSafeToHex(n.uuid)}`;
-    const result = indexMap[hex];
-    const manifest: ResearchObjectV1 = result?.recentCid
-      ? await resolveNodeManifest(result?.recentCid, ipfsQuery as string)
-      : null;
-    const o = {
-      ...n,
-      uuid: n.uuid.replaceAll('.', ''),
-      isPublished: !!indexMap[hex],
-      index: indexMap[hex],
-      dpid: manifest?.dpid,
+    const draftInfo = {
+      uuid: n.uuid.replace(".", ""),
+      title: n.title,
+      createdAt: n.createdAt,
     };
-    delete o.id;
 
-    return o;
+    if (isPublished) {
+      const cid = n.versions[0].manifestUrl;
+      return {
+        ...draftInfo,
+        dpid: n.dpidAlias ?? await cachedGetDpidFromManifest(cid, gateway),
+        versionIx: n.versions.length - 1,
+        publishedAt: n.versions[0].createdAt,
+        isPublished: true as const,
+      }
+    } else {
+      return {
+        ...draftInfo,
+        isPublished: false as const,
+      };
+    };
   });
 
-  res.send({ nodes });
+  res.send({ nodes: formattedNodes });
+};
+
+/** List all nodes for the given user, including published versions, if any */
+export const listAllUserNodes = async (
+  ownerId: number,
+  page: number,
+  size: number,
+  onlyPublished = false,
+) => await prisma.node.findMany({
+  select: {
+    id: true,
+    uuid: true,
+    title: true,
+    createdAt: true,
+    dpidAlias: true,
+    versions: {
+      select: {
+        manifestUrl: true,
+        createdAt: true,
+        commitId: true,
+        transactionId: true,
+      },
+      where: {
+        OR: [
+          { transactionId: { not: null } },
+          { commitId: { not: null } },
+        ]
+      },
+      orderBy: { createdAt: "desc" }
+    }
+  },
+  where: {
+    ownerId,
+    isDeleted: false,
+    // Can't filter afterward with onlyPublished because then paging won't make sense
+    ...(onlyPublished ? onlyPublishedFilter : {})
+  },
+  // Note this is the node update, not time of last publish
+  orderBy: { updatedAt: "desc" },
+  take: size,
+  skip: (page - 1) * size,
+});
+
+const onlyPublishedFilter: { versions: Prisma.NodeVersionListRelationFilter } = {
+  versions: {
+    some: {
+      OR: [
+        { transactionId: { not: null } },
+        { commitId: { not: null } }
+      ]
+    }
+  }
 };

--- a/desci-server/src/controllers/nodes/sharedNodes.ts
+++ b/desci-server/src/controllers/nodes/sharedNodes.ts
@@ -1,4 +1,3 @@
-import { IpldUrl, ResearchObjectV1Dpid } from '@desci-labs/desci-models';
 import { User } from '@prisma/client';
 import { Request, Response } from 'express';
 
@@ -6,20 +5,15 @@ import { prisma } from '../../client.js';
 import { getLatestManifestFromNode } from '../../internal.js';
 import { logger as parentLogger } from '../../logger.js';
 import { PRIV_SHARE_CONTRIBUTION_PREFIX } from '../../services/Contributors.js';
-import { getIndexedResearchObjects } from '../../theGraph.js';
 
 export type SharedNode = {
-  uuid: string;
-  manifestCid: string;
-  title?: string;
-  versions: number;
-  coverImageCid?: string | IpldUrl;
-  published?: boolean;
-  dpid?: ResearchObjectV1Dpid;
-  publishDate?: string;
-  pendingVerification: boolean;
-  pendingContributionId?: string;
-  shareKey: string;
+    uuid: string;
+    title: string;
+    published: boolean;
+    dpid?: number;
+    shareKey: string;
+    pendingVerification: boolean;
+    pendingContributionId?: string;
 };
 
 export type ListSharedNodesRequest = Request<never, never> & {
@@ -57,8 +51,24 @@ export const listSharedNodes = async (req: ListSharedNodesRequest, res: Response
       where: {
         memo: `${PRIV_SHARE_CONTRIBUTION_PREFIX}${user.email}`,
       },
-      include: {
-        node: true,
+      select: {
+        shareId: true,
+        node: {
+          select: {
+            uuid: true,
+            manifestUrl: true,
+            dpidAlias: true,
+            // Get published versions, if any
+            versions: {
+              where: {
+                OR: [
+                  { transactionId: { not: null }},
+                  { commitId: { not: null }},
+                ],
+              },
+            },
+          },
+        },
       },
     });
 
@@ -66,30 +76,9 @@ export const listSharedNodes = async (req: ListSharedNodesRequest, res: Response
 
     if (privSharedNodes?.length === 0) {
       return res.status(200).json({ ok: true, sharedNodes: [] });
-    }
+    };
 
     const nodeUuids = privSharedNodes.map((priv) => priv.node.uuid);
-    const { researchObjects } = await getIndexedResearchObjects(nodeUuids);
-
-    logger.trace({ researchObjectsLength: researchObjects.length }, 'Research objects retrieved successfully');
-
-    const publishedNodesMap = researchObjects.reduce((acc, ro) => {
-      try {
-        // convert hex string to integer
-        const nodeUuidInt = Buffer.from(ro.id.substring(2), 'hex');
-        // convert integer to hex
-        const nodeUuid = nodeUuidInt.toString('base64url');
-        acc[nodeUuid] = ro;
-      } catch (e) {
-        logger.error({ acc, ro, e, message: e?.message }, 'Failed to convert hex string to integer');
-      }
-      return acc;
-    }, {});
-
-    logger.trace(
-      { publishedNodesMapKeyLength: Object.keys(publishedNodesMap).length },
-      'Published nodes map created successfully',
-    );
 
     // Work out if any action on the shared node is required (e.g. verifying the contribution)
     const contributionEntries = await prisma.nodeContribution.findMany({
@@ -103,35 +92,38 @@ export const listSharedNodes = async (req: ListSharedNodesRequest, res: Response
           },
         },
       },
-      include: { node: true },
+      select: {
+        verified: true,
+        denied: true,
+        contributorId: true,
+        node: { select: { uuid: true }}
+      },
     });
 
     const contributionEntryMap = contributionEntries.reduce((acc, entry) => {
       acc[entry.node.uuid] = entry;
       return acc;
-    }, {});
+    }, {} as Record<string, typeof contributionEntries[number]>);
 
     const filledSharedNodes = await Promise.all(
-      privSharedNodes.map(async (priv) => {
-        const { node } = priv;
+      privSharedNodes.map(async ({ shareId, node }) => {
         const latestManifest = await getLatestManifestFromNode(node);
-        const publishedEntry = publishedNodesMap[node.uuid];
+        const manifestDpid = latestManifest.dpid
+          ? parseInt(latestManifest.dpid.id)
+          : undefined;
+        const published = node.versions.length > 0;
+
         const contributionEntry = contributionEntryMap[node.uuid];
         const pendingVerification = contributionEntry?.verified === false && contributionEntry?.denied === false;
 
         return {
           uuid: node.uuid,
-          manifestCid: node.manifestUrl,
+          published,
           title: latestManifest.title,
-          versions: publishedEntry?.versions.length,
-          coverImageCid: latestManifest.coverImage,
-          dpid: latestManifest.dpid,
-          publishDate: publishedEntry?.versions[0].time,
-          published: !!publishedEntry,
+          dpid: node.dpidAlias ?? manifestDpid,
           pendingVerification: !!pendingVerification,
           ...(!!pendingVerification && { pendingContributionId: contributionEntry.contributorId }),
-          shareKey: priv.shareId,
-          dpidAlias: node.dpidAlias,
+          shareKey: shareId,
         };
       }),
     );

--- a/desci-server/src/controllers/nodes/show.ts
+++ b/desci-server/src/controllers/nodes/show.ts
@@ -115,7 +115,7 @@ export const show = async (req: RequestWithNode, res: Response, next: NextFuncti
     res.send(data);
     return;
   } catch (e) {
-    logger.error({ error: e }, 'error');
+    logger.error({ e }, 'error');
     // res.status(404).send();
     // example
     res.status(404).send();

--- a/desci-server/src/services/data/processing.ts
+++ b/desci-server/src/services/data/processing.ts
@@ -348,7 +348,7 @@ export function extractRootDagCidFromManifest(manifest: ResearchObjectV1, manife
 }
 
 export async function getManifestFromNode(
-  node: Node,
+  node: { manifestUrl: string, cid?: string },
   queryString?: string,
 ): Promise<{ manifest: ResearchObjectV1; manifestCid: string }> {
   // debugger;

--- a/desci-server/src/services/manifestRepo.ts
+++ b/desci-server/src/services/manifestRepo.ts
@@ -10,7 +10,9 @@ export const getAutomergeUrl = (documentId: DocumentId): AutomergeUrl => {
   return `automerge:${documentId}` as AutomergeUrl;
 };
 
-export const getLatestManifestFromNode = async (node: Node) => {
+export const getLatestManifestFromNode = async (
+  node: Pick<Node, "manifestUrl" | "uuid">
+) => {
   logger.info({ uuid: node.uuid }, 'START [getLatestManifestFromNode]');
   let manifest = await repoService.getDraftManifest(node.uuid as NodeUuid);
   if (!manifest) {

--- a/desci-server/src/theGraph.ts
+++ b/desci-server/src/theGraph.ts
@@ -145,6 +145,10 @@ const getHistoryFromStreams = async (
     { ids: Object.keys(streamToHexUuid) },
   );
 
+  // Aid in figuring out why sometimes v.time is undefined in production
+  // TODO remove me
+  logger.debug({fn: "getHistoryFromStreams", data: historyRes.data })
+
   // Convert resolver format to server format
   const indexedHistory: IndexedResearchObject[] = historyRes.data.map(ro => ({
     id: streamToHexUuid[ro.id],

--- a/desci-server/src/utils.ts
+++ b/desci-server/src/utils.ts
@@ -38,6 +38,16 @@ export const randomUUID64 = () => {
   return encoded;
 };
 
+/** Test if a string is a valid, plain-text CID */
+export const isCid = (maybeCid: string) => {
+  try {
+    CID.parse(maybeCid);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
 export const hexToCid = (hexCid: string) => {
   hexCid = hexCid.substring(2); // remove 0x
   hexCid = hexCid.length % 2 === 0 ? hexCid.substring(1) : hexCid;

--- a/desci-server/src/utils.ts
+++ b/desci-server/src/utils.ts
@@ -113,6 +113,9 @@ export function ensureUuidEndsWithDot(uuid: string): string {
   return uuid.endsWith('.') ? uuid : uuid + '.';
 }
 
+export const unpadUuid = (uuid: string): string =>
+  uuid.replace(".", "");
+
 export async function calculateTotalZipUncompressedSize(zipPath: string): Promise<number> {
   return new Promise((resolve, reject) => {
     let totalSize = 0;

--- a/desci-server/src/utils/manifest.ts
+++ b/desci-server/src/utils/manifest.ts
@@ -4,7 +4,8 @@ import axios from 'axios';
 
 import { PUBLIC_IPFS_PATH } from '../config/index.js';
 import { logger as parentLogger } from '../logger.js';
-import { hexToCid } from '../utils.js';
+import { hexToCid, isCid } from '../utils.js';
+import { getOrCache } from '../redisClient.js';
 
 const IPFS_RESOLVER_OVERRIDE = process.env.IPFS_RESOLVER_OVERRIDE;
 
@@ -33,9 +34,18 @@ export const transformManifestWithHistory = (data: ResearchObjectV1, researchNod
   return ro;
 };
 
-export const resolveNodeManifest = async (targetCid: string, query?: string) => {
-  const ipfsResolver = IPFS_RESOLVER_OVERRIDE || query || 'https://ipfs.desci.com/ipfs';
-  const cidString = hexToCid(targetCid);
+/** Resolve manifest given its CID, in either hex or plain-text format */
+export const resolveNodeManifest = async (
+  targetCid: string,
+  gateway?: string
+) => {
+  const ipfsResolver = IPFS_RESOLVER_OVERRIDE || gateway || 'https://ipfs.desci.com/ipfs';
+  let cidString = targetCid;
+
+  if (!isCid(targetCid)) {
+    cidString = hexToCid(targetCid);
+  };
+
   try {
     parentLogger.info(`Calling IPFS Resolver ${ipfsResolver} for CID ${cidString}`);
     const { data } = await axios.get(`${ipfsResolver}/${cidString}`);
@@ -45,5 +55,24 @@ export const resolveNodeManifest = async (targetCid: string, query?: string) => 
     return null;
   }
 };
+
+export const cachedGetDpidFromManifest = async (
+  cid: string,
+  gateway: string
+) => {
+  const fnGetDpidFromManifest = async () => {
+    const manifest = await resolveNodeManifest(cid, gateway) as ResearchObjectV1;
+    return manifest.dpid
+      ? parseInt(manifest.dpid.id)
+      : -1;
+  };
+
+  const manifestDpid = await getOrCache(`manifest-dpid-${cid}`, fnGetDpidFromManifest);
+  if (manifestDpid === -1) {
+    return undefined;
+  } else {
+    return manifestDpid;
+  }
+}
 
 export const zeropad = (data: string) => (data.length < 2 ? `0${data}` : data);


### PR DESCRIPTION
Changes the implementation of (almost) all node enumeration routes in desci-server to avoid (needlessly) using `getIndexedResearchObjects`, as this is too slow for the frequency we're hitting it. It's also causing a ton of traffic on the ceramic node, and when we don't even need the results this is a bit pointless.

It does change the return types a bit in the cases where the webapp anyway wasn't using the fields that are more complicated to derive. Simplification and speedup in both ends :eyes: 

Even locally, this branch is a quite massive speedup for me :zap::dancing_men::zap: 


Also fixes a bug in `getBlockTime` which could be the one I've been chasing, throwing in some extra debug logging just in case though so we can track it.

Companion webapp PR: https://github.com/desci-labs/nodes-web-v2/pull/847