### PR TITLE
Blocktime lookup caching layer fix

### DIFF
--- a/desci-server/src/utils/driveUtils.ts
+++ b/desci-server/src/utils/driveUtils.ts
@@ -170,6 +170,12 @@ export async function getTreeAndFill(
    ** Both entries neccessary to determine publish state, prioritize public entries over private
    */
   const privEntries = await prisma.dataReference.findMany({
+    select: {
+      cid: true,
+      size: true,
+      createdAt: true,
+      external: true,
+    },
     where: {
       userId: ownerId,
       type: { not: DataType.MANIFEST },
@@ -180,14 +186,23 @@ export async function getTreeAndFill(
     },
   });
   const pubEntries = await prisma.publicDataReference.findMany({
+    select: {
+      createdAt: true,
+      size: true,
+      external: true,
+      cid: true,
+      nodeVersion: {
+        select: {
+          transactionId: true,
+          commitId: true,
+        }
+      }
+    },
     where: {
       type: { not: DataType.MANIFEST },
       node: {
         uuid: ensureUuidEndsWithDot(nodeUuid),
       },
-    },
-    include: {
-      nodeVersion: true,
     },
   });
 


### PR DESCRIPTION
## Description of the Problem / Feature
- After we refactored the blocktime function, it resulted in skipping cache for every invalid key as we stopped caching invalid keys in redis to prevent stale data, whilst this was good it resulted in excessive ceramic node calls if a blocktime wasn't returned (null).
## Explanation of the solution
- Added a second layer caching solution to the getBlockTime function, and only calling a retrieve on each unique commit/txHash

