### PR TITLE
Node debug route

### DIFF
--- a/desci-server/src/config/index.ts
+++ b/desci-server/src/config/index.ts
@@ -1,3 +1,4 @@
+import { contracts } from '@desci-labs/desci-contracts';
 import 'dotenv/config';
 
 export const PUBLIC_IPFS_PATH =
@@ -9,3 +10,45 @@ export const PUBLIC_IPFS_PATH =
 
 export const MEDIA_SERVER_API_URL = process.env.NODES_MEDIA_SERVER_URL;
 export const MEDIA_SERVER_API_KEY = process.env.MEDIA_SECRET_KEY;
+export const SERVER_URL = process.env.SERVER_URL;
+
+const CERAMIC_API_URLS = {
+  local: 'http://host.docker.internal:7007',
+  dev: 'https://ceramic-dev.desci.com',
+  prod: 'https://ceramic-prod.desci.com',
+} as const;
+
+const OPTIMISM_RPC_URLS = {
+  local: 'http://host.docker.internal:8545',
+  opSepolia: 'https://reverse-proxy-dev.desci.com/rpc_opt_sepolia',
+  opMainnet: 'https://reverse-proxy-prod.desci.com/rpc_opt_mainnet',
+} as const;
+
+/** Not secret: pre-seeded ganache account for local dev */
+export const GANACHE_PKEY = 'ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+/** Manually set in this module since the envvar needs to support OG ethereum during migration */
+export let OPTIMISM_RPC_URL: string;
+export let ALIAS_REGISTRY_ADDRESS: string;
+export let CERAMIC_API_URL: string;
+
+export const serverIsLocal = SERVER_URL.includes('localhost') || SERVER_URL.includes('host.docker.internal');
+const serverIsDev = SERVER_URL.includes('dev');
+const serverIsProdOrStaging = process.env.NODE_ENV === 'production' || SERVER_URL.includes('staging');
+
+if (serverIsLocal) {
+  ALIAS_REGISTRY_ADDRESS = contracts.localDpidAliasInfo.proxies.at(0).address;
+  CERAMIC_API_URL = CERAMIC_API_URLS.local;
+  OPTIMISM_RPC_URL = OPTIMISM_RPC_URLS.local;
+} else if (serverIsDev) {
+  ALIAS_REGISTRY_ADDRESS = contracts.devDpidAliasInfo.proxies.at(0).address;
+  CERAMIC_API_URL = CERAMIC_API_URLS.dev;
+  OPTIMISM_RPC_URL = OPTIMISM_RPC_URLS.opSepolia;
+} else if (serverIsProdOrStaging) {
+  ALIAS_REGISTRY_ADDRESS = contracts.prodDpidAliasInfo.proxies.at(0).address;
+  CERAMIC_API_URL = CERAMIC_API_URLS.prod;
+  OPTIMISM_RPC_URL = OPTIMISM_RPC_URLS.opSepolia;
+} else {
+  console.error('Cannot derive configuration due to ambiguous environment');
+  throw new Error('Ambiguous environment');
+};

--- a/desci-server/src/controllers/admin/debug.ts
+++ b/desci-server/src/controllers/admin/debug.ts
@@ -1,0 +1,189 @@
+import { Request, Response } from 'express';
+import { logger as parentLogger } from '../../logger.js';
+import { prisma } from '../../client.js';
+import { Node, NodeVersion, Prisma, PublicDataReference } from '@prisma/client';
+import { ensureUuidEndsWithDot } from '../../utils.js';
+import { directStreamLookup } from '../../services/ceramic.js';
+import { getAliasRegistry, getHotWallet } from '../../services/chain.js';
+import { getIndexedResearchObjects, IndexedResearchObject } from '../../theGraph.js';
+
+const logger = parentLogger.child({ module: 'ADMIN::DebugController' });
+
+export const debugNodeHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  const uuid = req.params.uuid;
+  logger.info({ uuid }, "handling debug query");
+
+  const result = await debugNode(uuid);
+  res.send(result);
+};
+
+type DebugAllNodesQueryParams = {
+  fromDate?: string,
+  toDate?: string,
+  timeColumn?: "createdAt" | "updatedAt",
+};
+
+export const debugAllNodesHandler = async (
+  req: Request<never, never, never, DebugAllNodesQueryParams>,
+  res: Response,
+) => {
+  const { fromDate, toDate, timeColumn } = req.query;
+
+  const nodes = await prisma.node.findMany({
+    select: {
+      uuid: true,
+    },
+    where: makeTimeFilter(timeColumn ?? "createdAt", { fromDate, toDate }),
+  });
+  logger.info(
+    { ...req.query, uuids: nodes.map(n => n.uuid) },
+    "handling debugAll query",
+  );
+
+  const results = await Promise.all(
+    nodes.map(async n => await debugNode(n.uuid))
+  );
+  res.send(results);
+};
+
+const debugNode = async (uuid: string) => {
+  const node = await prisma.node.findFirst({
+    where: {
+      uuid: ensureUuidEndsWithDot(uuid),
+    },
+    include: {
+      versions: true,
+      PublicDataReference: true,
+    },
+  });
+
+  const streamDebugData = await debugStream(node.ceramicStream);
+  const dpidDebugData = await debugDpid(node.dpidAlias);
+  const dbDebugData = await debugDb(node);
+  const shouldBeIndexed: boolean = node.versions
+    .findIndex(v =>
+      v.transactionId !== null || v.commitId !== null
+    ) > -1;
+  const indexerDebugData = await debugIndexer(uuid, shouldBeIndexed);
+
+  const hasError = streamDebugData.error
+    || dpidDebugData.error
+    || dbDebugData.error
+    || indexerDebugData.error;
+
+  return {
+    uuid,
+    hasError,
+    stream: streamDebugData,
+    dpid: dpidDebugData,
+    db: dbDebugData,
+    indexer: indexerDebugData,
+  };
+};
+
+const makeTimeFilter = (
+  timeColumn: "createdAt" | "updatedAt",
+  bounds: { fromDate?: string, toDate?: string }
+): Prisma.NodeWhereInput => {
+  const { fromDate, toDate } = bounds;
+
+  let filter: Prisma.DateTimeFilter = {};
+
+  if (fromDate) {
+    filter.gte = new Date(fromDate).toISOString();
+  };
+
+  if (toDate){
+    filter.lte = new Date(toDate).toString();
+  };
+
+  return { [timeColumn]: filter };
+};
+
+type NodeDbClosure = Node & {
+  versions: NodeVersion[],
+  PublicDataReference: PublicDataReference[],
+};
+
+/** Get stream state response, or an error object */
+const debugStream = async (
+  stream?: string
+) => {
+  if (!stream) return { present: false, error: false };
+  const raw = await directStreamLookup(stream);
+
+  if ("err" in raw) {
+    return { present: true, error: true, raw };
+  };
+
+  const isAnchored = raw.state.anchorStatus === "ANCHORED";
+  const lastCommitIx = raw.state.log.findLastIndex(l => l.expirationTime);
+  const lastCommit = raw.state.log[lastCommitIx];
+  const tailAnchor = raw.state.log
+    .slice(lastCommitIx)
+    .findLast(l => l.type === 2);
+  const timeNow = Math.floor(new Date().getTime() / 1000);
+  const timeLeft = isAnchored
+    ? lastCommit.expirationTime - tailAnchor.timestamp
+    : lastCommit.expirationTime - timeNow;
+
+  const anchoring = {
+    isAnchored,
+    timeLeft
+  };
+
+  // Excluding anchor events
+  const versions = raw.state.log.filter(l => l.type !== 2);
+
+  return {
+    present: true,
+    error: false,
+    nVersions: versions.length,
+    anchoring,
+    raw,
+  };
+};
+
+const debugDpid = async (dpid?: number) => {
+  if (!dpid) return { present: false, error: false };
+
+  const wallet = await getHotWallet();
+  const registry = getAliasRegistry(wallet);
+
+  const mappedStream = await registry.resolve(dpid);
+  if (!mappedStream) {
+    return { present: true, error: true, mappedStream: null };
+  };
+
+  return { present: true, error: false, mappedStream };
+};
+
+const debugIndexer = async (
+  uuid: string,
+  shouldExist: boolean
+) => {
+  let indexResult: { researchObjects: IndexedResearchObject[] };
+  try {
+    indexResult = await getIndexedResearchObjects([uuid]);
+  } catch (e) {
+    const err = e as Error;
+    return { error: true, name: err.name, msg: err.message, stack: err.stack };
+  };
+
+  const result = indexResult.researchObjects[0];
+  if (!result) {
+    return { error: shouldExist, result: null };
+  };
+
+  return { error: false, nVersions: result.versions.length , result };
+};
+
+const debugDb = async (
+  _node: NodeDbClosure
+) => {
+
+  return { error: false, result: "skipped" };
+};

--- a/desci-server/src/controllers/admin/index.ts
+++ b/desci-server/src/controllers/admin/index.ts
@@ -1,1 +1,2 @@
 export * from './analytics.js';
+export * from './debug.js';

--- a/desci-server/src/controllers/nodes/byDpid.ts
+++ b/desci-server/src/controllers/nodes/byDpid.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { prisma } from '../../client.js';
 import { logger as parentLogger } from '../../logger.js';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/index.js';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library.js';
 
 const logger = parentLogger.child({
   module: 'NODE::nodeByDpidController',

--- a/desci-server/src/routes/v1/admin.ts
+++ b/desci-server/src/routes/v1/admin.ts
@@ -1,12 +1,16 @@
 import { Router } from 'express';
 
-import { createCsv, getAnalytics } from '../../controllers/admin/analytics.js';
 import { ensureAdmin } from '../../middleware/ensureAdmin.js';
 import { ensureUser } from '../../middleware/permissions.js';
+import { createCsv, getAnalytics } from '../../controllers/admin/analytics.js';
+import { debugAllNodesHandler, debugNodeHandler } from '../../controllers/admin/debug.js';
 
 const router = Router();
 
 router.get('/analytics', [ensureUser, ensureAdmin], getAnalytics);
 router.get('/analytics/csv', [ensureUser, ensureAdmin], createCsv);
+
+router.get('/debug', [ensureUser, ensureAdmin], debugAllNodesHandler);
+router.get('/debug/:uuid', [ensureUser, ensureAdmin], debugNodeHandler);
 
 export default router;

--- a/desci-server/src/services/ceramic.ts
+++ b/desci-server/src/services/ceramic.ts
@@ -1,0 +1,65 @@
+import axios, { AxiosError } from "axios";
+import { CERAMIC_API_URL } from "../config/index.js";
+import { logger as parentLogger } from "../logger.js";
+import { newCeramicClient, resolveHistory } from "@desci-labs/desci-codex-lib";
+
+const logger = parentLogger.child({
+  module: "Service::Ceramic",
+});
+
+const DESCI_STREAM_API = CERAMIC_API_URL + "/api/v0/streams/";
+
+export type RawState = {
+  content: { title: string, license: string, manifest: string },
+  metadata: {
+    /** Single-element array with fully qualified EIP155 address */
+    controllers: string[],
+    /** StreamID of model schema */
+    model: string,
+    /** Client randomness for stream uniqueness */
+    unique: string,
+  },
+  /** Signing status. 0 is genesis, 2 is signed */
+  signature: number,
+  /** Likely: NOT_REQUESTED, PENDING, ANCHORED
+   *  Unlikely: PROCESSING, FAILED, REPLACED
+  */
+  anchorStatus: string,
+  log: LogEntry[],
+  anchorProof: any,
+  doctype: "MID",
+};
+
+export type LogEntry = {
+  /** Commit CID */
+  cid: string,
+  /** 0 is genesis, 1 is data (update), 2 is anchor */
+  type: number,
+  /** On 0 and 1: expiration time of CACAO JWT, anchor must be made before this */
+  expirationTime?: number,
+  /** Time of anchoring */
+  timestamp: number,
+};
+
+export type RawStream = {
+  streamId: string,
+  state: RawState,
+};
+
+export const directStreamLookup = async (stream: string) => {
+  let result: { data: RawStream };
+  try {
+    result = await axios.get<RawStream>(DESCI_STREAM_API + stream);
+  } catch (e) {
+    const err = e as AxiosError;
+    return {
+      err: err.name,
+      status: err.response?.status,
+      body: err.response?.data,
+      msg: err.message,
+      cause: err.cause,
+      stack: err.stack,
+    };
+  };
+  return result.data;
+};

--- a/desci-server/src/services/chain.ts
+++ b/desci-server/src/services/chain.ts
@@ -1,0 +1,56 @@
+import { providers, Wallet } from "ethers";
+import {
+  ALIAS_REGISTRY_ADDRESS,
+  GANACHE_PKEY,
+  OPTIMISM_RPC_URL,
+  serverIsLocal
+} from "../config/index.js";
+import { logger as parentLogger } from "../logger.js";
+import { DpidAliasRegistry__factory } from "@desci-labs/desci-contracts/dist/typechain-types/index.js";
+
+const logger = parentLogger.child({
+  module: 'Services::Chain',
+});
+
+export const getOptimismProvider = async () => {
+  const provider = new providers.JsonRpcProvider(OPTIMISM_RPC_URL);
+  await provider.ready;
+  return provider;
+};
+
+export const getHotWalletKey = () => {
+  if (serverIsLocal) {
+    return GANACHE_PKEY;
+  } else if (process.env.HOT_WALLET_KEY){
+    return process.env.HOT_WALLET_KEY;
+  } else {
+    logger.error({ fn: 'getHotWalletKey' }, "HOT_WALLET_KEY not set");
+    throw new Error("HOT_WALLET_KEY missing");
+  };
+};
+
+export const getOwnerWalletKey = () => {
+  if (serverIsLocal) {
+    return GANACHE_PKEY;
+  } else if (process.env.REGISTRY_OWNER_PKEY) {
+    return process.env.REGISTRY_OWNER_PKEY;
+  } else {
+    logger.error({ fn: 'getOwnerWalletKey' }, "REGISTRY_OWNER_PKEY not set");
+    throw new Error("REGISTRY_OWNER_PKEY missing")
+  };
+};
+
+export const getHotWallet = async () => {
+  const key = getHotWalletKey();
+  const provider = await getOptimismProvider();
+  return new Wallet(key, provider);
+};
+
+export const getRegistryOwnerWallet = async () => {
+  const key = getOwnerWalletKey();
+  const provider = await getOptimismProvider();
+  return new Wallet(key, provider);
+}
+
+export const getAliasRegistry = (wallet: Wallet) =>
+  DpidAliasRegistry__factory.connect(ALIAS_REGISTRY_ADDRESS, wallet);


### PR DESCRIPTION
Adds `/v1/admin/debug/:uuid` and `/v1/admin/debug` routes to automatically sanity check nodes. 

Does this stuff, among other things:
- validates anchoring
- show anchor timing
- compares db/stream/index versions
- tries resolving dpid alias
- verifies all published manifests have a PublicDataRef

The non-uuid route takes args to search in time over recent activity/node creation, super useful but will result in a ton of activity all over the cluster if not used carefully :p
```ts
type DebugAllNodesQueryParams = {
  fromDate?: string,
  toDate?: string,
  timeColumn?: "createdAt" | "updatedAt",
};
```