### PR TITLE
Doi Api routes

### DIFF
--- a/desci-server/src/controllers/doi/check.ts
+++ b/desci-server/src/controllers/doi/check.ts
@@ -56,7 +56,7 @@ export const retrieveDoi = async (req: Request, res: Response, _next: NextFuncti
   const { doi: doiQuery, uuid, dpid } = req.query;
   const identifier = doiQuery || uuid || dpid;
 
-  if (!identifier) throw new BadRequestError();
+  if (!doiQuery) throw new BadRequestError();
 
   if (uuid) {
     const pending = await doiService.hasPendingSubmission(ensureUuidEndsWithDot(uuid as string));
@@ -67,7 +67,7 @@ export const retrieveDoi = async (req: Request, res: Response, _next: NextFuncti
     }
   }
 
-  const doiLink = (doiQuery as string).startsWith('https') ? doiQuery : `https://doi.org/${doiQuery}`;
+  const doiLink = (doiQuery as string)?.startsWith('https') ? doiQuery : `https://doi.org/${doiQuery}`;
 
   const client = new Client({
     connectionString: process.env.OPEN_ALEX_DATABASE_URL,

--- a/desci-server/src/routes/v1/nodes.ts
+++ b/desci-server/src/routes/v1/nodes.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { createNodeBookmark } from '../../controllers/nodes/bookmarks/create.js';
 import { deleteNodeBookmark } from '../../controllers/nodes/bookmarks/delete.js';
 import { listBookmarkedNodes } from '../../controllers/nodes/bookmarks/index.js';
+import { nodeByDpid } from '../../controllers/nodes/byDpid.js';
 import { checkIfPublishedNode } from '../../controllers/nodes/checkIfPublishedNode.js';
 import { checkNodeAccess } from '../../controllers/nodes/checkNodeAccess.js';
 import { addContributor } from '../../controllers/nodes/contributions/create.js';
@@ -15,6 +16,7 @@ import { updateContributor } from '../../controllers/nodes/contributions/update.
 import { verifyContribution } from '../../controllers/nodes/contributions/verify.js';
 import { createDpid } from '../../controllers/nodes/createDpid.js';
 import { dispatchDocumentChange, getNodeDocument } from '../../controllers/nodes/documents.js';
+import { explore } from '../../controllers/nodes/explore.js';
 import { feed } from '../../controllers/nodes/feed.js';
 import { frontmatterPreview } from '../../controllers/nodes/frontmatterPreview.js';
 import { getDraftNodeStats } from '../../controllers/nodes/getDraftNodeStats.js';
@@ -47,6 +49,7 @@ import {
   generateMetadataSchema,
   automateManuscriptDoi,
   attachDoiSchema,
+  retrieveNodeDoi,
 } from '../../controllers/nodes/index.js';
 import { retrieveTitle } from '../../controllers/nodes/legacyManifestApi.js';
 import { preparePublishPackage } from '../../controllers/nodes/preparePublishPackage.js';
@@ -58,8 +61,6 @@ import { versionDetails } from '../../controllers/nodes/versionDetails.js';
 import { asyncHandler, attachUser, validate, ensureUserIfPresent } from '../../internal.js';
 import { ensureNodeAccess, ensureWriteNodeAccess } from '../../middleware/authorisation.js';
 import { ensureUser } from '../../middleware/permissions.js';
-import { nodeByDpid } from '../../controllers/nodes/byDpid.js';
-import { explore } from '../../controllers/nodes/explore.js';
 
 const router = Router();
 
@@ -74,7 +75,6 @@ router.get('/access/:uuid', [ensureUserIfPresent], checkNodeAccess);
 router.post('/search/:query', [ensureUser], searchNodes);
 router.get('/explore', [], explore);
 
-
 router.post('/createDpid', [ensureUser, ensureWriteNodeAccess], createDpid);
 router.post('/createDraft', [ensureUser], draftCreate);
 // is this api deprecated?
@@ -82,7 +82,6 @@ router.post('/addComponentToDraft', [ensureUser], draftAddComponent);
 router.post('/updateDraft', [ensureUser], draftUpdate);
 router.get('/versionDetails', [], versionDetails);
 router.get('/', [ensureUser], list);
-router.post('/doi', [ensureUser], retrieveDoi);
 router.get('/pdf', proxyPdf);
 router.post('/consent', [], consent);
 router.post('/consent/publish', [ensureUser, validate(publishConsentSchema)], asyncHandler(publishConsent));
@@ -114,6 +113,9 @@ router.get('/contributions/user/:userId', [], getUserContributions);
 router.get('/contributions/user', [ensureUser], getUserContributionsAuthed);
 router.post('/distribution', preparePublishPackage);
 router.post('/distribution/preview', [ensureUser], frontmatterPreview);
+
+// Doi api routes
+router.get('/:identifier/doi', [ensureUser], asyncHandler(retrieveNodeDoi));
 router.post(
   '/:uuid/automate-metadata',
   [ensureUser, ensureNodeAccess, validate(automateMetadataSchema)],

--- a/desci-server/src/services/Doi.ts
+++ b/desci-server/src/services/Doi.ts
@@ -97,10 +97,11 @@ export class DoiService {
     // retrieve node manifest/metadata
     const { researchObjects } = await getIndexedResearchObjects([uuid]);
     const researchObject = researchObjects[0] as IndexedResearchObject;
-    logger.info({ researchObject }, 'RESEARCH OBJECT');
-    const manifestCid = hexToCid(researchObject?.recentCid);
+    logger.info({ researchObject, uuid }, 'RESEARCH OBJECT');
+    if (!researchObject) throw new ForbiddenMintError('Node not published yet!');
 
-    if (!manifestCid) throw new ForbiddenMintError('Node not published yet!');
+    const manifestCid = hexToCid(researchObject?.recentCid);
+    // if (!manifestCid) throw new ForbiddenMintError('Node not published yet!');
 
     const latestManifest = await getManifestByCid(manifestCid);
     researchObject.versions.reverse();


### PR DESCRIPTION
## Description of the Problem / Feature
- Retrieve Doi routes was refactored to resolve openAlex doi and broke some features on the frontend
- `DoiService#checkMintability` crashes due to skipped check

## Explanation of the solution
- Add separate api for retrieving auth node Doi details
- Fix invariants in `DoiService#checkMintability`
