### PR TITLE
Debug route only investigates published nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20.8.1-bullseye-slim
 
 VOLUME /root/.yarn
 
-RUN apt-get -qy update && apt-get -qy install openssl curl wget
+RUN apt-get -qy update && apt-get -qy install openssl curl
 
 RUN npm install -g npm@9.8.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20.8.1-bullseye-slim
 
 VOLUME /root/.yarn
 
-RUN apt-get -qy update && apt-get -qy install openssl
+RUN apt-get -qy update && apt-get -qy install openssl curl wget
 
 RUN npm install -g npm@9.8.1
 

--- a/desci-server/scripts/import-ipfs-content.sh
+++ b/desci-server/scripts/import-ipfs-content.sh
@@ -1,16 +1,7 @@
 # import required images from ipfs to local
 
-check_and_install() {
-  echo "check and install: $1"
-  # local shell_cmd = $1
-  if ! command -v $1 &> /dev/null;
-  then
-    apt-get install -y $1
-  fi
-}
+set -eux
 
-check_and_install "wget"
-check_and_install "curl"
-
+# curl and wget are installed in the docker image
 wget https://ipfs.desci.com/ipfs/bafkreih6yx7ywj7trvpp45vergrnytad7ezsku75tefyro4qrrcfrrmrt4 -O /tmp/cover.png
 curl -F file=@/tmp/cover.png "http://host.docker.internal:5001/api/v0/add?cid-version=1"

--- a/desci-server/scripts/import-ipfs-content.sh
+++ b/desci-server/scripts/import-ipfs-content.sh
@@ -3,5 +3,5 @@
 set -eux
 
 # curl and wget are installed in the docker image
-wget https://ipfs.desci.com/ipfs/bafkreih6yx7ywj7trvpp45vergrnytad7ezsku75tefyro4qrrcfrrmrt4 -O /tmp/cover.png
+curl https://ipfs.desci.com/ipfs/bafkreih6yx7ywj7trvpp45vergrnytad7ezsku75tefyro4qrrcfrrmrt4 -o /tmp/cover.png
 curl -F file=@/tmp/cover.png "http://host.docker.internal:5001/api/v0/add?cid-version=1"

--- a/desci-server/src/logger.ts
+++ b/desci-server/src/logger.ts
@@ -133,6 +133,13 @@ function omitBuffer(array) {
   });
 }
 
+// These should probably exit the process as it is not safe to continue
+// execution after a generic exception has occurred:
+// https://nodejs.org/api/process.html#warning-using-uncaughtexception-correctly
 process.on('uncaughtException', (err) => {
   logger.fatal(err, 'uncaught exception');
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  logger.fatal({ reason, promise }, 'unhandled rejection');
 });

--- a/dockerDev.sh
+++ b/dockerDev.sh
@@ -42,6 +42,8 @@ assert_command_available "docker"
 assert_command_available "docker-compose"
 assert_command_available "lsof"
 assert_command_available "make"
+assert_command_available "wget"
+assert_command_available "curl"
 
 init_node
 npm i -g hardhat

--- a/dockerDev.sh
+++ b/dockerDev.sh
@@ -42,7 +42,6 @@ assert_command_available "docker"
 assert_command_available "docker-compose"
 assert_command_available "lsof"
 assert_command_available "make"
-assert_command_available "wget"
 assert_command_available "curl"
 
 init_node


### PR DESCRIPTION
Also filters on first/last publish instead, as this is makes more sense than node create/update timestamps

Also fixes bug where `import-ipfs-content.sh` can fail if image hasn't been rebuilt in a while, as it tries to install `curl`/`wget` but the package URL in `apt` may 404. We should anyway have dependencies declared in the image :ok_hand: 