### PR TITLE
Metadata extraction & Api enhancement

### DIFF
--- a/desci-server/src/controllers/attestations/claims.ts
+++ b/desci-server/src/controllers/attestations/claims.ts
@@ -134,7 +134,7 @@ export const removeClaim = async (req: RequestWithUser, res: Response, _next: Ne
   await saveInteraction(req, ActionType.REVOKE_CLAIM, body);
 
   logger.info({ removeOrRevoke, totalSignal, claimSignal }, 'Claim Removed|Revoked');
-  return new SuccessMessageResponse('Attestation unclaimed').send(res);
+  return new SuccessMessageResponse().send(res);
 };
 
 export const claimEntryRequirements = async (req: Request, res: Response, _next: NextFunction) => {

--- a/desci-server/src/core/ApiError.ts
+++ b/desci-server/src/core/ApiError.ts
@@ -8,6 +8,7 @@ import {
   ForbiddenResponse,
   InternalErrorResponse,
   NotFoundResponse,
+  UnProcessableRequestResponse,
 } from './ApiResponse.js';
 import { DoiError, DoiErrorType } from './doi/error.js';
 
@@ -18,6 +19,7 @@ export enum ApiErrorType {
   NOT_FOUND = 'NotFoundError',
   NO_DATA = 'NotDataError',
   FORBIDDEN = 'ForbiddenError',
+  UNPROCESSABLE = 'UnProcessableError',
 }
 
 export abstract class ApiError extends Error {
@@ -40,6 +42,8 @@ export abstract class ApiError extends Error {
         return new NotFoundResponse(err.message).send(res);
       case ApiErrorType.FORBIDDEN:
         return new ForbiddenResponse(err.message).send(res);
+      case ApiErrorType.UNPROCESSABLE:
+        return new UnProcessableRequestResponse(err.message).send(res);
       default:
         let message = err.message;
         if (process.env.NODE_ENV === 'production') message = 'Something wrong happened.';
@@ -89,6 +93,14 @@ export class BadRequestError extends ApiError {
     private err?: unknown,
   ) {
     super(ApiErrorType.BAD_REQUEST, message, err);
+  }
+}
+export class UnProcessableRequestError extends ApiError {
+  constructor(
+    message = 'Request could not be processed',
+    private err?: unknown,
+  ) {
+    super(ApiErrorType.UNPROCESSABLE, message, err);
   }
 }
 

--- a/desci-server/src/core/ApiResponse.ts
+++ b/desci-server/src/core/ApiResponse.ts
@@ -7,6 +7,7 @@ enum ResponseStatus {
   FORBIDDEN = 403,
   NOT_FOUND = 404,
   INTERNAL_ERROR = 500,
+  UNPROCESSABLE_ENTITY = 422,
 }
 
 type Headers = { [key: string]: string };
@@ -18,7 +19,7 @@ export interface ToApiResponse {
 export abstract class ApiResponse {
   constructor(
     private status: ResponseStatus,
-    private message: string,
+    private message?: string,
   ) {}
 
   protected prepare<T extends ApiResponse>(res: Response, response: T, headers: { [key: string]: string }): Response {
@@ -35,12 +36,13 @@ export abstract class ApiResponse {
     Object.assign(clone, response);
     delete clone.status;
     for (const field in clone) if (clone[field] === 'undefined') delete clone[field];
+    // if (!clone['message']) delete clone.message;
     return clone;
   }
 }
 
 export class SuccessMessageResponse extends ApiResponse {
-  constructor(message = '') {
+  constructor() {
     super(ResponseStatus.SUCCESS, undefined);
   }
 }
@@ -48,7 +50,7 @@ export class SuccessMessageResponse extends ApiResponse {
 export class SuccessResponse<T> extends ApiResponse {
   constructor(
     private data: T,
-    message = '',
+    message?: string,
   ) {
     super(ResponseStatus.SUCCESS, message);
   }
@@ -76,6 +78,12 @@ export class BadRequestResponse<T> extends ApiResponse {
     private error: T,
   ) {
     super(ResponseStatus.BAD_REQUEST, message);
+  }
+}
+
+export class UnProcessableRequestResponse extends ApiResponse {
+  constructor(message = 'Request cannot be processed') {
+    super(ResponseStatus.UNPROCESSABLE_ENTITY, message);
   }
 }
 


### PR DESCRIPTION
## Description of the Problem / Feature
- Descriptive error message in case extraction not possible

## Explanation of the solution
- Add new error type to support unprocessable entity,
-  Throw error in automateDoiManuscript if no metadata was extracted, 
- Sanitize response object to remove empty message field

## Instructions on making this work

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
