### PR TITLE
server: fix sluggish lookups

### DIFF
--- a/desci-server/src/controllers/raw/resolve.ts
+++ b/desci-server/src/controllers/raw/resolve.ts
@@ -7,7 +7,7 @@ import {
 import axios from 'axios';
 import { NextFunction, Request, Response } from 'express';
 import { logger as parentLogger } from '../../logger.js';
-import { getIndexedResearchObjects, IndexedResearchObject } from '../../theGraph.js';
+import { getIndexedResearchObjects } from '../../theGraph.js';
 import { decodeBase64UrlSafeToHex, hexToCid } from '../../utils.js';
 
 const IPFS_RESOLVER_OVERRIDE = process.env.IPFS_RESOLVER_OVERRIDE || '';
@@ -44,16 +44,17 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
   });
   logger.debug(`[resolve::resolve] firstParam=${firstParam} secondParam=${secondParam}`);
 
-  let result: IndexedResearchObject;
+  let result;
   try {
     const res = await getIndexedResearchObjects([uuid]);
     result = res.researchObjects[0];
+    result.versions.reverse();
   } catch (err) {
     logger.warn({ err }, `[ERROR] index lookup failed: ${err.message}`);
   };
 
   if (!result) {
-    logger.warn({ uuid, result }, 'empty result or indexer down');
+    logger.warn({ result }, 'empty result or indexer down');
     return res.status(404).send({
       ok: false,
       msg: `resource not found`,
@@ -61,9 +62,6 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
       env: process.env.NODE_ENV,
     });
   };
-
-  // Flip history to chronological
-  result.versions.reverse();
 
   const ipfsResolver = IPFS_RESOLVER_OVERRIDE || req.query.g || 'https://ipfs.desci.com/ipfs';
   // TODO: add whitelist of resolvers

--- a/desci-server/src/services/ceramic.ts
+++ b/desci-server/src/services/ceramic.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosError } from "axios";
 import { CERAMIC_API_URL } from "../config/index.js";
 import { logger as parentLogger } from "../logger.js";
-import { newCeramicClient, resolveHistory } from "@desci-labs/desci-codex-lib";
 
 const logger = parentLogger.child({
   module: "Service::Ceramic",

--- a/desci-server/src/services/ceramic.ts
+++ b/desci-server/src/services/ceramic.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from "axios";
 import { CERAMIC_API_URL } from "../config/index.js";
 import { logger as parentLogger } from "../logger.js";
+import { CommitID } from "@desci-labs/desci-codex-lib/dist/streams.js";
 
 const logger = parentLogger.child({
   module: "Service::Ceramic",
@@ -37,7 +38,7 @@ export type LogEntry = {
   /** On 0 and 1: expiration time of CACAO JWT, anchor must be made before this */
   expirationTime?: number,
   /** Time of anchoring */
-  timestamp: number,
+  timestamp?: number,
 };
 
 export type RawStream = {
@@ -48,7 +49,9 @@ export type RawStream = {
 export const directStreamLookup = async (stream: string) => {
   let result: { data: RawStream };
   try {
-    result = await axios.get<RawStream>(DESCI_STREAM_API + stream);
+    // sync=2 => ask the node to return whatever it already knows, not query the p2p network on-demand
+    // https://developers.ceramic.network/reference/typescript/enums/_ceramicnetwork_common.SyncOptions.html
+    result = await axios.get<RawStream>(DESCI_STREAM_API + stream + '?sync=2');
   } catch (e) {
     const err = e as AxiosError;
     return {
@@ -61,4 +64,48 @@ export const directStreamLookup = async (stream: string) => {
     };
   };
   return result.data;
+};
+
+/**
+ * Get the anchor timestamp, if any, for each commitID.
+ *
+ * When we just need the timestamp for commits (e.g., `getTreeAndFill`), it's unnecessary
+ * to compute all historical states as this info is part of the raw stream event log
+ * present in the state.
+ *
+ * TODO: resolver should probably support raw resolution and/or timestamp lookups
+ *
+ * @returns a map between { commitIdStr: timestamp} if successful, empty map otherwise
+ */
+export const getCommitTimestamps = async (
+  commitIdStrs: string[]
+): Promise<Record<string, string>> => {
+  if (commitIdStrs.length === 0) {
+    return {};
+  }
+
+  logger.debug({ fn: 'getCommitTimestamps', commitIdStrs }, "getting timestamps");
+  const firstCommitId = CommitID.fromString(commitIdStrs[0]);
+  const streamId = firstCommitId.baseID;
+  const streamState = await directStreamLookup(streamId.toString());
+
+  if ('err' in streamState) {
+    logger.warn(
+      { fn: 'getCommitTimestamps', streamId: streamId.toString() },
+      'failed to load stream, returning empty map',
+    );
+    return {};
+  };
+
+  const rawLog = streamState.state.log;
+  const timeMap = rawLog.reduce(
+    (acc, logEvent) => ({
+      ...acc,
+      [CommitID.make(streamId, logEvent.cid).toString()]: logEvent.timestamp?.toString()
+    }),
+    {} as Record<string, string>
+  );
+
+  logger.debug({ fn: 'getCommitTimestamps', timeMap }, "returning timestamps");
+  return timeMap;
 };

--- a/desci-server/src/utils/driveUtils.ts
+++ b/desci-server/src/utils/driveUtils.ts
@@ -224,7 +224,9 @@ export async function getTreeAndFill(
     });
 
     let blockTimeMap: Record<string, string> = {};
-    const blockTimeMapCacheKey = `blockTimeMap-${nodeUuid}`;
+
+    // TODO: add back redis cache code if needed after NEVER_SYNC setting in ceramic service
+    // const blockTimeMapCacheKey = `blockTimeMap-${nodeUuid}`;
 
     try {
       // blockTimeMap = await getFromCache(blockTimeMapCacheKey);


### PR DESCRIPTION
## Description of the Problem / Feature
`getTreeAndFill` super sluggish due to missing anchors leading to spamming repeated history lookups.

## Explanation of the solution
`getTreeAndFill` just needs timestamps, which we can get from the raw stream state, not having to resolve the individual versions at all.

Additionally, by using [`SyncOpts.NEVER_SYNC`](https://developers.ceramic.network/reference/typescript/enums/_ceramicnetwork_common.SyncOptions.html)  (or `?sync=2` on the HTTP route) when loading the stream, we tell the node we only care about what it currently knows. This prevents it to going to check libp2p pubsub for new updates, which is pointless because we know exactly what commit ID we are looking for.
