### PR TITLE
compose: use on-failure restart policy for compose services

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ services:
   db_postgres:
     container_name: "db_boilerplate"
     image: "postgres:12.6-alpine"
-    restart: always
+    restart: on-failure
     healthcheck:
       test: "pg_isready -U walter -d postgres"
       interval: 5s
@@ -22,7 +22,7 @@ services:
   desci_blockchain_ganache:
     container_name: "desci_blockchain_ganache"
     build: ./desci-contracts
-    restart: always
+    restart: on-failure
     healthcheck:
       test: curl -sf -X POST --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' localhost:8545
       interval: 10s
@@ -80,7 +80,7 @@ services:
   graph_node:
     image: graphprotocol/graph-node
     container_name: "graph_node"
-    restart: always
+    restart: on-failure
     # healthcheck:
     #   test: "pg_isready -U walter -d postgres"
     #   interval: 5s
@@ -241,7 +241,7 @@ services:
       OPTIMISM_RPC_URL: http://host.docker.internal:8545
       CERAMIC_URL: http://host.docker.internal:7007
       IPFS_GATEWAY: http://host.docker.internal:8089/ipfs
-    restart: always
+    restart: on-failure
     ports:
       - "5460:5460"
     extra_hosts:

--- a/docker-compose.media.yml
+++ b/docker-compose.media.yml
@@ -4,7 +4,7 @@ services:
   nodes_media:
     container_name: 'nodes_media'
     build: ./nodes-media
-    restart: always
+    restart: on-failure
     entrypoint: /bin/sh './scripts/nodes-media-dev.sh'
     env_file:
       - ./nodes-media/.env

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,7 @@ services:
   nodes_test_db:
     container_name: "nodes_test_db"
     image: "postgres:12.6-alpine"
-    restart: always
+    restart: on-failure
     env_file:
       - .env.test
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   desci_nodes_backend:
     container_name: "desci_nodes_backend"
     build: .
-    restart: always
+    restart: on-failure
     volumes:
       - .:/app/
       - /app/node_modules


### PR DESCRIPTION
Using the policy `always` is suboptimal for two reasons:
- it covers up if a service exits 0 on errors, as this does not signal to the docker/kubernetes daemons that the service failed
- it forces automatically restarting all containers after a reboot / docker daemon restart, leading to unexpected results when running `./dockerDev.sh`