### PR TITLE
fix how we log ES queries

### DIFF
--- a/desci-server/src/controllers/search/types.ts
+++ b/desci-server/src/controllers/search/types.ts
@@ -32,10 +32,7 @@ export interface QuerySuccessResponse extends QueryDebuggingResponse {
 }
 
 export interface QueryDebuggingResponse {
-  esQuery?: any;
-  esQueries?: any;
-  esBoolQuery?: any;
-  esSort?: any;
+  finalQuery?: any;
 }
 
 export interface QueryErrorResponse extends QueryDebuggingResponse {

--- a/desci-server/src/controllers/search/types.ts
+++ b/desci-server/src/controllers/search/types.ts
@@ -33,6 +33,7 @@ export interface QuerySuccessResponse extends QueryDebuggingResponse {
 
 export interface QueryDebuggingResponse {
   finalQuery?: any;
+  duration?: any;
 }
 
 export interface QueryErrorResponse extends QueryDebuggingResponse {

--- a/desci-server/src/services/ElasticSearchService.ts
+++ b/desci-server/src/services/ElasticSearchService.ts
@@ -29,7 +29,7 @@ export const VALID_ENTITIES = [
  * Ordered from most relevant to least relevant
  */
 export const RELEVANT_FIELDS = {
-  works: ['title', 'abstract', 'doi'],
+  works: ['title', 'abstract'],
   authors: ['display_name', 'orcid', 'last_known_institution', 'authors.affiliation'],
   topics: ['display_name'],
   fields: ['field_display_name'],
@@ -62,7 +62,7 @@ export const RELEVANT_FIELDS = {
 };
 
 type SortOrder = 'asc' | 'desc';
-type SortField = { [field: string]: { order: SortOrder; missing?: string } };
+type SortField = { [field: string]: { order: SortOrder; missing?: string; type?: string; script?: any } };
 
 const baseSort: SortField[] = [{ _score: { order: 'desc' } }];
 
@@ -233,7 +233,7 @@ function buildFilter(filter: Filter) {
           [filter.field]: {
             query: filter.value,
             operator: filter.matchLogic || 'or',
-            // ...(filter.fuzziness && { fuzziness: filter.fuzziness }),
+            ...(filter.fuzziness && { fuzziness: filter.fuzziness }),
           },
         },
       };
@@ -276,7 +276,11 @@ function getRelevantFields(entity: string) {
   return RELEVANT_FIELDS.works_single;
 }
 
-export function buildMultiMatchQuery(query: string, entity: string, fuzzy: string = 'AUTO'): QueryDslQueryContainer {
+export function buildMultiMatchQuery(
+  query: string,
+  entity: string,
+  fuzzy: string | number = 0,
+): QueryDslQueryContainer {
   const fields = getRelevantFields(entity);
 
   let multiMatchQuery: QueryDslQueryContainer;
@@ -291,7 +295,7 @@ export function buildMultiMatchQuery(query: string, entity: string, fuzzy: strin
             query: query,
             fields: fields,
             type: 'best_fields',
-            // fuzziness: fuzzy, // Retained fuzziness
+            fuzziness: fuzzy, // Retained fuzziness
           },
         },
       },
@@ -302,7 +306,7 @@ export function buildMultiMatchQuery(query: string, entity: string, fuzzy: strin
         query: query,
         fields: fields,
         type: 'best_fields',
-        // fuzziness: fuzzy, // Retained fuzziness
+        fuzziness: fuzzy, // Retained fuzziness
       },
     };
   }


### PR DESCRIPTION
## Description of the Problem / Feature
Previously I wasn't able to copy/paste an ES query direct from logs to ES Dev Console

## Explanation of the solution
Now we format the final query in the logs, for copy/paste ease