### PR TITLE
fix: metadata extraction error

### DIFF
--- a/desci-server/src/services/AutomatedMetadata.ts
+++ b/desci-server/src/services/AutomatedMetadata.ts
@@ -248,7 +248,7 @@ export class AutomatedMetadataClient {
       );
       logger.info({ status: result.status, message: result.statusText }, 'OPEN ALEX QUERY');
       const work = (await result.json()) as OpenAlexWork;
-      logger.info({ openAlexWork: work }, 'OPEN ALEX QUERY');
+      // logger.info({ openAlexWork: work }, 'OPEN ALEX QUERY');
       return transformOpenAlexWorkToMetadata(work);
     } catch (err) {
       logger.error({ err }, 'ERROR: OPEN ALEX WORK QUERY');


### PR DESCRIPTION
Closes [Issue 848](https://github.com/desci-labs/capybara-feedback/issues/848)

## Description of the Problem / Feature
Api crash due to unchecked access on `author` array which is undefined

## Explanation of the solution
- Fix unchecked access
- Improve api speed by preventing double calls to open alex api if grobid extracts DOI from pdf
 
## UI changes for review

[preview.webm](https://github.com/user-attachments/assets/83895539-0bf6-4319-bdfd-b75d74bb0d32)
