### PR TITLE
compose: sync kubo with live deployments, bump ceramic to 6.4.0

### DIFF
--- a/ceramic-k8s/ceramic_deployment_dev.yaml
+++ b/ceramic-k8s/ceramic_deployment_dev.yaml
@@ -32,7 +32,7 @@ spec:
 
           {{- end -}}
           {{- with secret "secrets/desci-server/dev/db" -}}
-          echo "{\"anchor\":{\"ethereum-rpc-url\":\"{{ .data.ceramic_rpc }}\"},\"http-api\":{\"cors-allowed-origins\":[\".*\"],\"admin-dids\":[\"did:key:z6mktbkjrmnhvj37qfto12911ycm2jukduzwhdvetu9s5a9t\"]},\"ipfs\":{\"mode\":\"remote\",\"host\":\"http://public-ceramic-ipfs-dev-service-internal.default.svc.cluster.local:5001\"},\"logger\":{\"log-level\":0},\"metrics\":{\"prometheus-exporter-enabled\":true,\"prometheus-exporter-port\":9464},\"network\":{\"name\":\"testnet-clay\"},\"node\":{},\"state-store\":{\"mode\":\"s3\",\"s3-bucket\":\"ceramic-node-dev-prime2\"},\"indexing\":{\"db\":\"{{ .data.ceramic_url }}\",\"allow-queries-before-historical-sync\":true,\"enable-historical-sync\":true}}" > daemon.config.json
+          echo "{\"anchor\":{\"ethereum-rpc-url\":\"{{ .Data.ceramic_rpc }}\"},\"http-api\":{\"cors-allowed-origins\":[\".*\"],\"admin-dids\":[\"did:key:z6MktbKJrMnhVJ37QFTo12911ycm2juKDUzWHDVETu9s5a9T\"]},\"ipfs\":{\"mode\":\"remote\",\"host\":\"http://public-ceramic-ipfs-dev-service-internal.default.svc.cluster.local:5001\"},\"logger\":{\"log-level\":0},\"metrics\":{\"prometheus-exporter-enabled\":true,\"prometheus-exporter-port\":9464},\"network\":{\"name\":\"testnet-clay\"},\"node\":{},\"state-store\":{\"mode\":\"s3\",\"s3-bucket\":\"ceramic-node-dev-prime2\"},\"indexing\":{\"db\":\"{{ .Data.ceramic_url }}\",\"allow-queries-before-historical-sync\":true,\"enable-historical-sync\":true}}" > daemon.config.json
           export NODE_ENV=production
           export CERAMIC_PUBSUB_QPS_LIMIT=500
           echo "envset"; 

--- a/ceramic-k8s/ceramic_deployment_dev.yaml
+++ b/ceramic-k8s/ceramic_deployment_dev.yaml
@@ -32,7 +32,7 @@ spec:
 
           {{- end -}}
           {{- with secret "secrets/desci-server/dev/db" -}}
-          echo "{\"anchor\":{\"ethereum-rpc-url\":\"{{ .Data.ceramic_rpc }}\"},\"http-api\":{\"cors-allowed-origins\":[\".*\"],\"admin-dids\":[\"did:key:z6MktbKJrMnhVJ37QFTo12911ycm2juKDUzWHDVETu9s5a9T\"]},\"ipfs\":{\"mode\":\"remote\",\"host\":\"http://public-ceramic-ipfs-dev-service-internal.default.svc.cluster.local:5001\"},\"logger\":{\"log-level\":0},\"metrics\":{\"metrics-exporter-enabled\":false,\"metrics-port\":9090},\"network\":{\"name\":\"testnet-clay\"},\"node\":{},\"state-store\":{\"mode\":\"s3\",\"s3-bucket\":\"ceramic-node-dev-prime2\"},\"indexing\":{\"db\":\"{{ .Data.ceramic_url }}\",\"allow-queries-before-historical-sync\":true,\"models\":[]}}" > daemon.config.json
+          echo "{\"anchor\":{\"ethereum-rpc-url\":\"{{ .data.ceramic_rpc }}\"},\"http-api\":{\"cors-allowed-origins\":[\".*\"],\"admin-dids\":[\"did:key:z6mktbkjrmnhvj37qfto12911ycm2jukduzwhdvetu9s5a9t\"]},\"ipfs\":{\"mode\":\"remote\",\"host\":\"http://public-ceramic-ipfs-dev-service-internal.default.svc.cluster.local:5001\"},\"logger\":{\"log-level\":0},\"metrics\":{\"prometheus-exporter-enabled\":true,\"prometheus-exporter-port\":9464},\"network\":{\"name\":\"testnet-clay\"},\"node\":{},\"state-store\":{\"mode\":\"s3\",\"s3-bucket\":\"ceramic-node-dev-prime2\"},\"indexing\":{\"db\":\"{{ .data.ceramic_url }}\",\"allow-queries-before-historical-sync\":true,\"enable-historical-sync\":true}}" > daemon.config.json
           export NODE_ENV=production
           export CERAMIC_PUBSUB_QPS_LIMIT=500
           echo "envset"; 
@@ -41,7 +41,7 @@ spec:
         App: JsCeramicDev
     spec:
       containers:
-        - image: ceramicnetwork/js-ceramic:5.16.0
+        - image: ceramicnetwork/js-ceramic:6.4.0
           name: js-ceramic-dev
           command: ["/bin/bash", "-c"]
           args:
@@ -51,10 +51,10 @@ spec:
               name: http-api
           resources:
             limits:
-              cpu: "0.7"
+              cpu: 2
               memory: 4Gi
             requests:
-              cpu: "0.6"
+              cpu: 1
               memory: 4Gi
           # # restart pod after failureThreshold*periodSeconds total seconds
           livenessProbe:

--- a/ceramic-k8s/ceramic_deployment_prod.yaml
+++ b/ceramic-k8s/ceramic_deployment_prod.yaml
@@ -53,7 +53,7 @@ spec:
         vault.hashicorp.com/agent-inject-secret-config: secrets/desci-server/production/db
         vault.hashicorp.com/agent-inject-template-config: |
           {{- with secret "secrets/desci-server/production/db" -}}
-          echo "{\"anchor\":{\"auth-method\":\"did\",\"ethereum-rpc-url\":\"{{ .Data.ceramic_rpc }}\"},\"node\":{\"privateSeedUrl\":\"inplace:ed25519#{{ .Data.ceramic_cas_pkey }}\"},\"http-api\":{\"cors-allowed-origins\":[\".*\"],\"admin-dids\":[\"did:key:z6MktbKJrMnhVJ37QFTo12911ycm2juKDUzWHDVETu9s5a9T\"]},\"ipfs\":{\"mode\":\"remote\",\"host\":\"http://public-ceramic-ipfs-prod-service-internal.default.svc.cluster.local:5001\"},\"logger\":{\"log-level\":0},\"metrics\":{\"metrics-exporter-enabled\":false,\"metrics-port\":9090},\"network\":{\"name\":\"mainnet\"},\"state-store\":{\"mode\":\"fs\",\"local-directory\":\"/root/.ceramic/statestore\"},\"indexing\":{\"db\":\"{{ .Data.ceramic_url }}\",\"allow-queries-before-historical-sync\":true,\"models\":[]}}" > daemon.config.json
+          echo "{\"anchor\":{\"auth-method\":\"did\",\"ethereum-rpc-url\":\"{{ .Data.ceramic_rpc }}\"},\"node\":{\"privateSeedUrl\":\"inplace:ed25519#{{ .Data.ceramic_cas_pkey }}\"},\"http-api\":{\"cors-allowed-origins\":[\".*\"],\"admin-dids\":[\"did:key:z6MktbKJrMnhVJ37QFTo12911ycm2juKDUzWHDVETu9s5a9T\"]},\"ipfs\":{\"mode\":\"remote\",\"host\":\"http://public-ceramic-ipfs-prod-service-internal.default.svc.cluster.local:5001\"},\"logger\":{\"log-level\":0},\"metrics\":{\"prometheus-exporter-enabled\":true,\"prometheus-exporter-port\":9464},\"network\":{\"name\":\"mainnet\"},\"state-store\":{\"mode\":\"fs\",\"local-directory\":\"/root/.ceramic/statestore\"},\"indexing\":{\"db\":\"{{ .Data.ceramic_url }}\",\"allow-queries-before-historical-sync\":true,\"enable-historical-sync\":true}}" > daemon.config.json
           export NODE_ENV=production
           export CERAMIC_PUBSUB_QPS_LIMIT=500
           echo "envset"; 
@@ -62,7 +62,7 @@ spec:
         App: JsCeramicProd
     spec:
       containers:
-        - image: ceramicnetwork/js-ceramic:5.16.0
+        - image: ceramicnetwork/js-ceramic:6.4.0
           name: js-ceramic-prod
           command: ["/bin/bash", "-c"]
           volumeMounts:
@@ -75,10 +75,10 @@ spec:
               name: http-api
           resources:
             limits:
-              cpu: "0.7"
+              cpu: 2
               memory: 4Gi
             requests:
-              cpu: "0.6"
+              cpu: 1
               memory: 4Gi
           # # restart pod after failureThreshold*periodSeconds total seconds
           livenessProbe:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -121,7 +121,7 @@ services:
       # EXPERIMENTAL_SUBGRAPH_VERSION_SWITCHING_MODE: synced
 
   ipfs:
-    image: ipfs/kubo:v0.24.0
+    image: ipfs/kubo:v0.26.0
     container_name: "ipfs"
     environment:
       IPFS_SWARM_KEY: "/key/swarm/psk/1.0.0/\n/base16/\n9d002c50635a479d29dcc0ccb49d862952a0dcc52baddd253167adcd496c8d04"
@@ -147,7 +147,7 @@ services:
       timeout: 2s
 
   ipfs_public:
-    image: ipfs/kubo:v0.24.0
+    image: ipfs/kubo:v0.26.0
     container_name: "ipfs_public"
     ports:
       - "5002:5001"
@@ -184,7 +184,7 @@ services:
       - ./local-data/redis:/data
 
   ceramic:
-    image: ceramicnetwork/js-ceramic:5.16.0
+    image: ceramicnetwork/js-ceramic:6.4.0
     container_name: ceramic
     ports:
       - "7007:7007"


### PR DESCRIPTION
- Bump the ceramic node to 6.4.0 to get a couple of fixes
  - This is a major because new nodes default to using RECON for tip synchronization, but existing node can continue to use kubo for p2p comms and tip sync.
- Change the compose cluster versions of kubo to match the ones we are running in the live envs.

Switching around between versions 0.23-0.29 should be fine as they use the same version of the IPFS repo:
https://github.com/ipfs/fs-repo-migrations?tab=readme-ov-file#when-should-i-migrate