### PR TITLE
nodes-lib: override DID EIP155 namespace in SIWE message to match stream controller

### DIFF
--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.10",
+  "version": "0.0.11-rc1",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/src/util/signing.ts
+++ b/nodes-lib/src/util/signing.ts
@@ -66,6 +66,8 @@ const getManualSignatureAuthMethod = (
 export const authorizedSessionDidFromSigner = async (
   signer: Signer,
   resources: string[],
+  /** Force a particular chainID to match controller EIP155 prefix in `dids:validateJWS` */
+  chainIdOverride?: string,
 ) => {
   // Fuckery to get the inner provider for a metamask signer
   const externalProvider = (signer.provider as providers.Web3Provider)?.provider;
@@ -74,7 +76,7 @@ export const authorizedSessionDidFromSigner = async (
 
   const address = await signer.getAddress();
   const network = await jsonRpcProvider.getNetwork();
-  const chainId = `eip155:${network.chainId}`;
+  const chainId = `eip155:${chainIdOverride ?? network.chainId}`;
   const caipAccountId = new AccountId({ address, chainId });
 
   let authMethod: AuthMethod;


### PR DESCRIPTION
## Description of the Problem / Feature
When switching chains, the optimism sepolia chainID in the app config went from 11155111 to 11155420. This caused the commit JWS validation to fail in `js-did/dids`, as the fully qualified CAIP addresses aren't equal: https://github.com/ceramicnetwork/js-did/blob/main/packages/dids/src/did.ts#L407-L410

(`did:pkh:eip155:11155111:0xec..." !== "did:pkh:eip155:11155420:0xec...`)

## Explanation of the solution
Override the chainID with whatever the registered stream controller has, if we had an existing stream to append to. 

We should figure out a sane default, as it's unclear whether we need to set any particular chainID at all in these messages.

## Instructions on making this work
- Bump `@desci-labs/nodes-lib@0.0.11-rc1` in nodes-web-v2
