### PR TITLE
nodes-lib: force sep eth chainid in CACAO unless overridden

### DIFF
--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.0.11-rc1",
+  "version": "0.0.11",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/src/util/signing.ts
+++ b/nodes-lib/src/util/signing.ts
@@ -76,7 +76,9 @@ export const authorizedSessionDidFromSigner = async (
 
   const address = await signer.getAddress();
   const network = await jsonRpcProvider.getNetwork();
-  const chainId = `eip155:${chainIdOverride ?? network.chainId}`;
+  // Force sepolia chainID in CACAO to prevent segmenting the
+  // user's streams over AccountIDs with different chainIDs
+  const chainId = `eip155:${chainIdOverride ?? "11155111" }`;
   const caipAccountId = new AccountId({ address, chainId });
 
   let authMethod: AuthMethod;


### PR DESCRIPTION
This change was already published and installed to nodes-web-v2 as part of a hotfix last friday.

To prevent DID's forking history from using whatever chainID the wallet currently provides when creating the ceramic CACAO, we continue to use the eth sepolia one until we have a better solution.