### PR TITLE
server: include stream & dpid with other public info in checkNodeAccess

### DIFF
--- a/desci-server/src/controllers/nodes/byDpid.ts
+++ b/desci-server/src/controllers/nodes/byDpid.ts
@@ -14,6 +14,8 @@ type NodeByDpidParams = {
 
 type NodeByDpidSuccess = {
   uuid: string;
+  dpidAlias: number;
+  ceramicStream: string;
 };
 
 type NodeByDpidError = {
@@ -43,6 +45,8 @@ export const nodeByDpid = async (
     node = await prisma.node.findFirstOrThrow({
       select: {
         uuid: true,
+        dpidAlias: true,
+        ceramicStream: true,
       },
       where: {
         dpidAlias: {

--- a/desci-server/src/controllers/nodes/checkNodeAccess.ts
+++ b/desci-server/src/controllers/nodes/checkNodeAccess.ts
@@ -13,8 +13,10 @@ type GetCheckNodeAccessResponse = {
   isOwner: boolean;
   isShared: boolean;
   hasAccess: boolean;
-  sharedOn?: number;
   isPublished: boolean;
+  ceramicStream?: string;
+  dpidAlias?: number;
+  sharedOn?: number;
   recentCid?: string;
   manifestUrl?: string;
 };
@@ -42,14 +44,10 @@ export const checkNodeAccess = async (
   const node = await prisma.node.findFirst({
     select: {
       uuid: true,
-      id: true,
-      createdAt: true,
-      updatedAt: true,
       ownerId: true,
-      title: true,
       manifestUrl: true,
-      cid: true,
-      NodeCover: true,
+      dpidAlias: true,
+      ceramicStream: true,
       versions: {
         select: {
           manifestUrl: true,
@@ -92,6 +90,8 @@ export const checkNodeAccess = async (
     isShared: !isOwner && !!privSharedNode,
     hasAccess,
     isPublished,
+    ceramicStream: node.ceramicStream,
+    dpidAlias: node.dpidAlias,
     sharedOn: privSharedNode?.createdAt.getTime(),
     recentCid: latestPublishedVersion?.manifestUrl,
     manifestUrl: hasAccess ? node.versions[0]?.manifestUrl : undefined,


### PR DESCRIPTION
## Description of the Problem / Feature
Webapp state needed the `ceramicStream` field to fix the publish permission check. The access check is used to check if a node is published, and is run early in the node loading process on the frontend.

## Explanation of the solution
Together with the other publish information, `/v1/nodes/access/:uuid` returns the `dpidAlias` and `ceramicStream` on record.

## Instructions on making this work
N/A

## UI changes for review
N/A
