### PR TITLE
server: dedupe dev subgraph responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,7 +119,10 @@ ETHEREUM_RPC_URL=http://host.docker.internal:8545
 # Use this for Sepolia testnet
 # ETHEREUM_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/demo
 
-DPID_URL_OVERRIDE=https://dev-beta.dpid.org
+# Use resolver in compose cluster locally
+DPID_URL_OVERRIDE=http://host.docker.internal:5460
+# Use public dev resolver
+# DPID_URL_OVERRIDE=https://dev-beta.dpid.org
 
 # Set to true if you want to mute the publish worker in local dev
 MUTE_PUBLISH_WORKER=false
@@ -139,8 +142,6 @@ CROSSREF_PASSWORD=
 # Cross ref notification callback envs
 CROSSREF_NOTIFY_ENDPOINT=endpoint
 
-# automated metadata
-
 # Automated metadata
 AUTOMATED_METADATA_API=http://host.docker.internal:5005
 AUTOMATED_METADATA_API_KEY=
@@ -157,7 +158,6 @@ ES_DB_PORT=
 ES_DB_NAME=
 ES_DB_USER=
 ES_DB_PASSWORD=
-
 
 ### open Alex Database - Postgres 
 OPEN_ALEX_DATABASE_URL=postgresql://username:password@host/database?schema=openalex

--- a/desci-server/src/config/index.ts
+++ b/desci-server/src/config/index.ts
@@ -11,6 +11,7 @@ export const PUBLIC_IPFS_PATH =
 export const MEDIA_SERVER_API_URL = process.env.NODES_MEDIA_SERVER_URL;
 export const MEDIA_SERVER_API_KEY = process.env.MEDIA_SECRET_KEY;
 export const SERVER_URL = process.env.SERVER_URL;
+export const THEGRAPH_API_URL = process.env.THEGRAPH_API_URL;
 
 const CERAMIC_API_URLS = {
   local: 'http://host.docker.internal:7007',

--- a/desci-server/src/services/fixDpid.ts
+++ b/desci-server/src/services/fixDpid.ts
@@ -22,7 +22,7 @@ export const getTargetDpidUrl = () => {
     'https://nodes-api.desci.com': 'https://beta.dpid.org',
   };
   const targetDpidUrl = TARGET_DPID_URL_BY_SERVER_URL[process.env.SERVER_URL];
-  return targetDpidUrl;
+  return targetDpidUrl as string;
 };
 
 // usage: npx tsx scripts/fix-dpid.ts 211

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -232,7 +232,7 @@ services:
       - JAVA_OPTS=-Xmx2G -Xms2G
 
   dpid_resolver:
-    image: descilabs/dpid-resolver
+    image: descilabs/dpid-resolver:develop
     container_name: dpid_resolver
     # Uncomment and set to local repo path for tinkering
     # build:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -242,7 +242,7 @@ services:
       OPTIMISM_RPC_URL: http://host.docker.internal:8545
       CERAMIC_URL: http://host.docker.internal:7007
       IPFS_GATEWAY: http://host.docker.internal:8089/ipfs
-      REDIS_HOST: http://host.docker.internal
+      REDIS_HOST: host.docker.internal
       REDIS_PORT: 6379
       # How long to store anchored commit info (default 24 hours)
       CACHE_TTL_ANCHORED: 86400

--- a/dockerDev.sh
+++ b/dockerDev.sh
@@ -18,7 +18,7 @@ assert_command_available() {
 }
 
 init_node() {
-  if ! printenv NVM_DIR &> /dev/null; then
+  if ! printenv NVM_DIR &> /dev/null && ! command -v fnm; then
     echo "[dockerDev] NVM_DIR not set, please install NVM"
     echo "[dockerDev] curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash"
     exit 1
@@ -27,13 +27,17 @@ init_node() {
   # Since nvm is loaded through shell config, it's not available
   # in scripts unless we source it manually
   local NVM_SCRIPT="$NVM_DIR/nvm.sh"
-  if [[ -s "$NVM_SCRIPT" ]]; then
+  if command -v fnm &>/dev/null; then
+    # A script doesn't inherit get aliases, so if fnm is available, "implement" nvm with that
+    nvm() { fnm "$@"; }
+  elif [[ -s "$NVM_SCRIPT" ]]; then
     source "$NVM_SCRIPT"
   else
     echo "[dockerDev] Could not find $NVM_SCRIPT, aborting"
     exit 1
   fi
-  nvm install $(cat .nvmrc)
+
+  nvm install "$(cat .nvmrc)"
   nvm use
 }
 


### PR DESCRIPTION
Closes #537

Tiny fixes:
- Allow using the faster `fnm` instead of `nvm`, if available
- Add `.env.example` docs on configuring the resolver
- Use the `develop` image for the compose resolver, as `latest` is the production build

## Description of the Problem / Feature
The görli -> sepolia migration created dupes in the version history for migrated entries. We have previously filtered these our in the frontend, but it's better if the app doesn't need to know about this every time it's using the results.

## Explanation of the solution
If the configured `THEGRAPH_API_URL` is the dev sepolia one, do a deduplication pass on the returned versions.

## Instructions on making this work
N/A

## UI changes for review
N/A
