### PR TITLE
server: use `/readyz` for probes and squelch logging on that route

### DIFF
--- a/desci-server/kubernetes/deployment_dev.yaml
+++ b/desci-server/kubernetes/deployment_dev.yaml
@@ -122,21 +122,21 @@ spec:
           # restart pod after failureThreshold*periodSeconds total seconds
           livenessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 80
             periodSeconds: 3
           # temporarily stop sending traffic to pod after failureThreshold*periodSeconds total seconds
           readinessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 3
             periodSeconds: 1
           # wait for pod to start for failureThreshold*periodSeconds total seconds
           startupProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 200
             periodSeconds: 1

--- a/desci-server/kubernetes/deployment_prod.yaml
+++ b/desci-server/kubernetes/deployment_prod.yaml
@@ -121,21 +121,21 @@ spec:
           # restart pod after failureThreshold*periodSeconds total seconds
           livenessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 80
             periodSeconds: 3
           # temporarily stop sending traffic to pod after failureThreshold*periodSeconds total seconds
           readinessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 3
             periodSeconds: 1
           # wait for pod to start for failureThreshold*periodSeconds total seconds
           startupProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 200
             periodSeconds: 1

--- a/desci-server/kubernetes/deployment_staging.yaml
+++ b/desci-server/kubernetes/deployment_staging.yaml
@@ -132,21 +132,21 @@ spec:
           # restart pod after failureThreshold*periodSeconds total seconds
           livenessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 80
             periodSeconds: 3
           # temporarily stop sending traffic to pod after failureThreshold*periodSeconds total seconds
           readinessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 3
             periodSeconds: 1
           # wait for pod to start for failureThreshold*periodSeconds total seconds
           startupProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: server-api
             failureThreshold: 200
             periodSeconds: 1


### PR DESCRIPTION
## Description of the Problem / Feature
Logs spammy af, about half a million per hour just from the probes 🥴 This is costing us proper pesetas in Betterstack.

## Explanation of the solution
1. Switch to using the dedicated probe route `/readyz`
2. Handler returns responses early on the `/readyz`, avoiding any meaningful work on the request
3.  Disable `pino-http` autologging of requests on this route

## Instructions on making this work
N/A

## UI changes for review
N/A