### PR TITLE
API Optimisation and enhancement

### DIFF
--- a/desci-repo/src/controllers/nodes/documents.ts
+++ b/desci-repo/src/controllers/nodes/documents.ts
@@ -35,26 +35,26 @@ export const createNodeDocument = async function (req: Request, res: Response) {
       { message: 'Init Document', time: Date.now() },
     );
 
-    logger.info({ peerId: backendRepo.networkSubsystem.peerId, uuid }, 'Document Created');
+    logger.trace({ peerId: backendRepo.networkSubsystem.peerId, uuid }, 'Document Created');
 
-    const document = await handle.doc();
+    // const document = await handle.doc();
 
-    logger.trace({ document: !!document }, 'Document Retrieved');
+    logger.trace({ handleReady: handle.isReady() }, 'Document Retrieved');
 
-    const node = await findNodeByUuid(uuid);
-    logger.trace({ node }, 'Node Retrieved');
+    // const node = await findNodeByUuid(uuid);
+    // logger.trace({ node }, 'Node Retrieved');
     // await prisma.node.update({ where: { id: node.id }, data: { manifestDocumentId: handle.documentId } });
-    const result = await query('UPDATE "Node" SET "manifestDocumentId" = $1 WHERE uuid = $2', [
-      handle.documentId,
-      uuid,
-    ]);
+    // const result = await query('UPDATE "Node" SET "manifestDocumentId" = $1 WHERE uuid = $2', [
+    //   handle.documentId,
+    //   uuid,
+    // ]);
 
-    logger.trace(
-      { node, uuid, documentId: handle.documentId, url: handle.url, isReady: handle.isReady() },
-      'Node Updated',
-    );
+    // logger.trace(
+    //   { node, uuid, documentId: handle.documentId, url: handle.url, isReady: handle.isReady() },
+    //   'Node Updated',
+    // );
 
-    logger.info({ result }, 'UPDATE DOCUMENT ID');
+    // logger.info({ result }, 'UPDATE DOCUMENT ID');
 
     res.status(200).send({ ok: true, documentId: handle.documentId, document });
 

--- a/desci-repo/src/controllers/nodes/documents.ts
+++ b/desci-repo/src/controllers/nodes/documents.ts
@@ -37,7 +37,7 @@ export const createNodeDocument = async function (req: Request, res: Response) {
 
     logger.trace({ peerId: backendRepo.networkSubsystem.peerId, uuid }, 'Document Created');
 
-    // const document = await handle.doc();
+    const document = await handle.doc();
 
     logger.trace({ handleReady: handle.isReady() }, 'Document Retrieved');
 
@@ -68,15 +68,16 @@ export const createNodeDocument = async function (req: Request, res: Response) {
 export const getLatestNodeManifest = async function (req: Request, res: Response) {
   const logger = parentLogger.child({ module: 'getLatestNodeManifest', params: req.params });
   logger.trace('getLatestNodeManifest');
+  const { uuid, documentId } = req.params;
 
+  // todo: add support for documentId params and skip querying node
   try {
-    if (!req.params.uuid) {
+    if (!uuid) {
       res.status(400).send({ ok: false, message: 'Invalid data' });
       logger.trace('No UUID FOUND');
       return;
     }
 
-    const { uuid } = req.params;
     const node = await findNodeByUuid(ensureUuidEndsWithDot(uuid));
     logger.trace({ node }, 'Retrieve Node');
 

--- a/desci-repo/src/controllers/nodes/documents.ts
+++ b/desci-repo/src/controllers/nodes/documents.ts
@@ -68,10 +68,33 @@ export const createNodeDocument = async function (req: Request, res: Response) {
 export const getLatestNodeManifest = async function (req: Request, res: Response) {
   const logger = parentLogger.child({ module: 'getLatestNodeManifest', params: req.params });
   logger.trace('getLatestNodeManifest');
-  const { uuid, documentId } = req.params;
+  const { uuid } = req.params;
+  const { documentId } = req.query;
 
-  // todo: add support for documentId params and skip querying node
+  const getDocument = async (documentId: DocumentId) => {
+    const automergeUrl = getAutomergeUrl(documentId);
+    const handle = backendRepo.find<ResearchObjectDocument>(automergeUrl as AutomergeUrl);
+    logger.trace({ uuid, automergeUrl }, 'Document Handle retrieved');
+
+    logger.trace({ uuid, automergeUrl }, 'Get DOCUMENT');
+    const document = await handle.doc();
+    logger.trace({ uuid, automergeUrl }, 'DOCUMENT Retrieved');
+    return document;
+  };
+
   try {
+    // todo: add support for documentId params and skip querying node
+    // fast track call if documentId is available
+    if (documentId) {
+      logger.trace({ documentId }, 'Fast track using documentId');
+      const document = await getDocument(documentId as DocumentId);
+      if (document) res.status(200).send({ ok: true, document });
+      logger.trace({ document: !!document }, 'Fast tracked call using documentId');
+      return;
+    }
+
+    // calls might never reach this place again now that documentId is
+    // used to fast track calls and skip database calls
     if (!uuid) {
       res.status(400).send({ ok: false, message: 'Invalid data' });
       logger.trace('No UUID FOUND');
@@ -83,7 +106,7 @@ export const getLatestNodeManifest = async function (req: Request, res: Response
 
     if (!node) {
       logger.warn({ uuid }, `Node with uuid ${uuid} not found!`);
-      res.status(400).send({ ok: false, message: `Node with uuid ${uuid} not found!` });
+      res.status(404).send({ ok: false, message: `Node with uuid ${uuid} not found!` });
       return;
     }
 
@@ -92,15 +115,22 @@ export const getLatestNodeManifest = async function (req: Request, res: Response
       'Node manifestDocumentId',
     );
 
-    const automergeUrl = getAutomergeUrl(node.manifestDocumentId as DocumentId);
-    const handle = backendRepo.find<ResearchObjectDocument>(automergeUrl as AutomergeUrl);
-    logger.trace({ uuid, automergeUrl }, 'Document Handle retrieved');
+    // const automergeUrl = getAutomergeUrl(node.manifestDocumentId as DocumentId);
+    // const handle = backendRepo.find<ResearchObjectDocument>(automergeUrl as AutomergeUrl);
+    // logger.trace({ uuid, automergeUrl }, 'Document Handle retrieved');
 
-    logger.trace({ uuid, automergeUrl }, 'Get DOCUMENT');
-    const document = await handle.doc();
-    logger.trace({ uuid, automergeUrl }, 'DOCUMENT Retrieved');
+    // logger.trace({ uuid, automergeUrl }, 'Get DOCUMENT');
+    // const document = await handle.doc();
+    // logger.trace({ uuid, automergeUrl }, 'DOCUMENT Retrieved');
 
-    logger.info({ manifest: document?.manifest, automergeUrl }, '[getLatestNodeManifest::END]');
+    if (!node.manifestDocumentId) {
+      res.status(404).send({ ok: false, message: `node: ${uuid} has no documentId: ${node.manifestDocumentId}` });
+      return;
+    }
+
+    const document = await getDocument(node.manifestDocumentId as DocumentId);
+
+    logger.info({ manifest: document?.manifest }, '[getLatestNodeManifest::END]');
     res.status(200).send({ ok: true, document });
   } catch (err) {
     logger.error({ err }, 'Error');

--- a/desci-repo/src/logger.ts
+++ b/desci-repo/src/logger.ts
@@ -90,8 +90,16 @@ function logMethodHooks(inputArgs, method) {
 }
 
 const IS_PROD = process.env.NODE_ENV === 'production';
-
+const transport = {
+  ...(!IS_PROD && {
+    transport: {
+      targets: [devTransport, fileTransport],
+    },
+  }),
+};
+console.log('[transport]', transport);
 export const logger = pino({
+  ...transport,
   level: logLevel,
   serializers: {
     files: omitBuffer,
@@ -99,13 +107,6 @@ export const logger = pino({
   hooks: {
     logMethod: logMethodHooks,
   },
-  ...(!IS_PROD
-    ? {
-        transport: {
-          targets: [devTransport, fileTransport],
-        },
-      }
-    : {}),
   redact: {
     paths: [
       'req.headers.cookie',

--- a/desci-server/src/controllers/communities/util.ts
+++ b/desci-server/src/controllers/communities/util.ts
@@ -51,7 +51,10 @@ export const resolveLatestNode = async (radar: Partial<NodeRadar>) => {
 
     logger.info({ manifest }, '[SHOW API GET LAST PUBLISHED MANIFEST]');
   } catch (err) {
-    const manifest = await repoService.getDraftManifest(uuid as NodeUuid);
+    const manifest = await repoService.getDraftManifest({
+      uuid: node.uuid as NodeUuid,
+      documentId: node.manifestDocumentId,
+    });
     radar.manifest = manifest;
     logger.error({ err, manifestUrl: discovery.manifestUrl, gatewayUrl }, 'nodes/show.ts: failed to preload manifest');
   }

--- a/desci-server/src/controllers/data/rename.ts
+++ b/desci-server/src/controllers/data/rename.ts
@@ -78,7 +78,10 @@ export const renameData = async (req: Request, res: Response<RenameResponse | Er
       updatedManifest = response.manifest;
     } catch (err) {
       logger.error({ err }, 'Source: Rename Component Path');
-      updatedManifest = await repoService.getDraftManifest(node.uuid as NodeUuid);
+      updatedManifest = await repoService.getDraftManifest({
+        uuid: node.uuid as NodeUuid,
+        documentId: node.manifestDocumentId,
+      });
       // return res.status(400).json({ error: 'failed' });
     }
 
@@ -119,7 +122,10 @@ export const renameData = async (req: Request, res: Response<RenameResponse | Er
         updatedManifest = response?.manifest;
       } catch (err) {
         logger.error({ err }, 'Source: Rename Component');
-        updatedManifest = await repoService.getDraftManifest(node.uuid as NodeUuid);
+        updatedManifest = await repoService.getDraftManifest({
+          uuid: node.uuid as NodeUuid,
+          documentId: node.manifestDocumentId,
+        });
       }
     }
 

--- a/desci-server/src/controllers/data/retrieve.ts
+++ b/desci-server/src/controllers/data/retrieve.ts
@@ -14,6 +14,7 @@ import redisClient, { getOrCache } from '../../redisClient.js';
 import { getLatestDriveTime } from '../../services/draftTrees.js';
 import { getDatasetTar } from '../../services/ipfs.js';
 import { NodeUuid, getLatestManifestFromNode } from '../../services/manifestRepo.js';
+import { showNodeDraftManifest } from '../../services/nodeManager.js';
 import { getTreeAndFill, getTreeAndFillDeprecated } from '../../utils/driveUtils.js';
 import { cleanupManifestUrl } from '../../utils/manifest.js';
 import { ensureUuidEndsWithDot } from '../../utils.js';
@@ -94,7 +95,7 @@ export const retrieveTree = async (req: Request, res: Response<RetrieveResponse 
   }
 
   try {
-    const manifest = await getLatestManifestFromNode(node);
+    const manifest = await showNodeDraftManifest(node); // getLatestManifestFromNode(node);
     const filledTree = (await getTreeAndFill(manifest, uuid, ownerId)) ?? [];
     const latestDriveClock = getLatestDriveTime(node.uuid as NodeUuid);
 

--- a/desci-server/src/controllers/nodes/bookmarks/index.ts
+++ b/desci-server/src/controllers/nodes/bookmarks/index.ts
@@ -52,13 +52,11 @@ export const listBookmarkedNodes = async (
             uuid: true,
             dpidAlias: true,
             manifestUrl: true,
+            manifestDocumentId: true,
             // Get published versions, if any
             versions: {
               where: {
-                OR: [
-                  { transactionId: { not: null }},
-                  { commitId: { not: null }},
-                ],
+                OR: [{ transactionId: { not: null } }, { commitId: { not: null } }],
               },
             },
           },
@@ -70,14 +68,12 @@ export const listBookmarkedNodes = async (
 
     if (bookmarkedNodes?.length === 0) {
       return res.status(200).json({ ok: true, bookmarkedNodes: [] });
-    };
+    }
 
     const filledBookmarkedNodes = await Promise.all(
-      bookmarkedNodes.map(async ({ shareId, node}) => {
+      bookmarkedNodes.map(async ({ shareId, node }) => {
         const latestManifest = await getLatestManifestFromNode(node);
-        const manifestDpid = latestManifest.dpid
-          ? parseInt(latestManifest.dpid.id)
-          : undefined;
+        const manifestDpid = latestManifest.dpid ? parseInt(latestManifest.dpid.id) : undefined;
         const published = node.versions.length > 0;
 
         return {

--- a/desci-server/src/controllers/nodes/draftCreate.ts
+++ b/desci-server/src/controllers/nodes/draftCreate.ts
@@ -12,6 +12,7 @@ import { Request, Response, NextFunction } from 'express';
 
 import { prisma } from '../../client.js';
 import { logger as parentLogger } from '../../logger.js';
+import { setToCache } from '../../redisClient.js';
 import { hasAvailableDataUsageForUpload } from '../../services/dataService.js';
 import {
   addBufferToIpfs,
@@ -143,6 +144,10 @@ export const draftCreate = async (req: Request, res: Response, next: NextFunctio
       documentId,
       document,
     });
+
+    // cache initial doc for a minute (60)
+    await setToCache(`node-draft-${node.uuid}`, { document, documentId }, 60);
+
     return;
   } catch (err) {
     logger.error({ err }, 'mint-err');

--- a/desci-server/src/controllers/nodes/draftCreate.ts
+++ b/desci-server/src/controllers/nodes/draftCreate.ts
@@ -129,6 +129,7 @@ export const draftCreate = async (req: Request, res: Response, next: NextFunctio
     const documentId = result.documentId;
     const document = result.document;
 
+    // attach automerge documentId to node
     await prisma.node.update({ where: { id: node.id }, data: { manifestDocumentId: documentId } });
 
     logger.info({ uuid: node.uuid, documentId }, 'Automerge document created');

--- a/desci-server/src/controllers/nodes/draftUpdate.ts
+++ b/desci-server/src/controllers/nodes/draftUpdate.ts
@@ -52,7 +52,10 @@ export const draftUpdate = async (req: Request, res: Response, next: NextFunctio
     let manifestParsed: ResearchObjectV1;
 
     try {
-      manifestParsed = await repoService.getDraftManifest(node.uuid as NodeUuid); //await getDraftManifestFromUuid(node.uuid as NodeUuid);
+      manifestParsed = await repoService.getDraftManifest({
+        uuid: node.uuid as NodeUuid,
+        documentId: node.manifestDocumentId,
+      }); //await getDraftManifestFromUuid(node.uuid as NodeUuid);
     } catch (e) {
       manifestParsed = req.body.manifest as ResearchObjectV1;
     }

--- a/desci-server/src/controllers/nodes/prepublish.ts
+++ b/desci-server/src/controllers/nodes/prepublish.ts
@@ -57,7 +57,10 @@ export const prepublish = async (req: RequestWithNode, res: Response<PrepublishR
       return res.status(403).json({ ok: false, error: 'Failed' });
     }
 
-    const manifest = await repoService.getDraftManifest(node.uuid as NodeUuid);
+    const manifest = await repoService.getDraftManifest({
+      uuid: node.uuid as NodeUuid,
+      documentId: node.manifestDocumentId,
+    });
 
     /**
      * Dagify and add DAGs to IPFS (No Files Pinned yet, just the folder structure added to IPFS (NOT PINNED!))

--- a/desci-server/src/controllers/nodes/show.ts
+++ b/desci-server/src/controllers/nodes/show.ts
@@ -8,8 +8,9 @@ import { prisma } from '../../client.js';
 import { PUBLIC_IPFS_PATH } from '../../config/index.js';
 import { logger as parentLogger } from '../../logger.js';
 import { RequestWithNode } from '../../middleware/authorisation.js';
-import { NodeUuid } from '../../services/manifestRepo.js';
-import repoService from '../../services/repoService.js';
+// import { NodeUuid } from '../../services/manifestRepo.js';
+import { showNodeDraftManifest } from '../../services/nodeManager.js';
+// import repoService from '../../services/repoService.js';
 import { cleanupManifestUrl } from '../../utils/manifest.js';
 import { ensureUuidEndsWithDot } from '../../utils.js';
 
@@ -83,33 +84,33 @@ export const show = async (req: RequestWithNode, res: Response, next: NextFuncti
       return;
     }
 
-    let gatewayUrl = discovery.manifestUrl;
+    // let gatewayUrl = discovery.manifestUrl;
     try {
-      gatewayUrl = cleanupManifestUrl(gatewayUrl, req.query?.g as string);
-      logger.trace({ gatewayUrl, uuid }, 'transforming manifest');
+      // gatewayUrl = cleanupManifestUrl(gatewayUrl, req.query?.g as string);
+      // logger.trace({ gatewayUrl, uuid }, 'transforming manifest');
 
-      // this can take >30s before it resolves or
-      // even fail after a much longer time there by causing the slow loading of nodes
-      // and a lot of failing `*.loggedIn` test in
-      (discovery as any).manifestData = transformManifestWithHistory(
-        (await axios.get(gatewayUrl, { timeout: 2000 })).data,
-        discovery,
-      );
-      // Add draft manifest document
-      const nodeUuid = ensureUuidEndsWithDot(uuid) as NodeUuid;
-      // for draft nodes we can do this asynchronously on the frontend
-      const manifest = await repoService.getDraftManifest(nodeUuid);
+      // // this can take >30s before it resolves or
+      // // even fail after a much longer time there by causing the slow loading of nodes
+      // // and a lot of failing `*.loggedIn` test in
+      // (discovery as any).manifestData = transformManifestWithHistory(
+      //   (await axios.get(gatewayUrl, { timeout: 2000 })).data,
+      //   discovery,
+      // );
+      // // Add draft manifest document
+      // const nodeUuid = ensureUuidEndsWithDot(uuid) as NodeUuid;
+      // // for draft nodes we can do this asynchronously on the frontend
+      // const manifest = await repoService.getDraftManifest(nodeUuid);
 
-      logger.info({ manifest: !!manifest }, '[SHOW API GET DRAFT MANIFEST]');
+      // logger.info({ manifest: !!manifest }, '[SHOW API GET DRAFT MANIFEST]');
 
-      if (manifest) (discovery as any).manifestData = transformManifestWithHistory(manifest, discovery);
-      delete (discovery as any).restBody;
-      logger.info({}, 'Retrive DraftManifest For /SHOW');
+      // if (manifest) (discovery as any).manifestData = transformManifestWithHistory(manifest, discovery);
+      // delete (discovery as any).restBody;
+      // logger.info({}, 'Retrive DraftManifest For /SHOW');
+      logger.trace('[showNodeDraftManifest]::START');
+      (discovery as any).manifestData = await showNodeDraftManifest(discovery, req.query?.g as string);
+      logger.trace('[showNodeDraftManifest]::END');
     } catch (err) {
-      logger.error(
-        { err, manifestUrl: discovery.manifestUrl, gatewayUrl },
-        'nodes/show.ts: failed to preload manifest',
-      );
+      logger.error({ err }, 'nodes/show.ts: failed to preload manifest');
     }
 
     res.send({ ...discovery });

--- a/desci-server/src/services/data/externalUrlProcessing.ts
+++ b/desci-server/src/services/data/externalUrlProcessing.ts
@@ -274,7 +274,9 @@ export async function processExternalUrlDataToIpfs({
       }
     }
 
-    updatedManifest = updatedManifest ?? (await repoService.getDraftManifest(ltsNode.uuid as NodeUuid));
+    updatedManifest =
+      updatedManifest ??
+      (await repoService.getDraftManifest({ uuid: ltsNode.uuid as NodeUuid, documentId: ltsNode.manifestDocumentId }));
 
     // Update existing data references, add new data references.
     const upserts = await updateDataReferences({ node, user, updatedManifest });

--- a/desci-server/src/services/data/processing.ts
+++ b/desci-server/src/services/data/processing.ts
@@ -137,7 +137,10 @@ export async function processS3DataToIpfs({
     });
 
     // const ltsManifest = await getLatestManifestFromNode(ltsNode);
-    let updatedManifest = await repoService.getDraftManifest(ltsNode.uuid as NodeUuid);
+    let updatedManifest = await repoService.getDraftManifest({
+      uuid: ltsNode.uuid as NodeUuid,
+      documentId: ltsNode.manifestDocumentId,
+    });
 
     const { filteredFiles } = filterFirstNestings(pinResult.slice(0, -1));
 

--- a/desci-server/src/services/manifestRepo.ts
+++ b/desci-server/src/services/manifestRepo.ts
@@ -1,6 +1,8 @@
 import { AutomergeUrl, DocumentId } from '@automerge/automerge-repo';
 import { Node } from '@prisma/client';
+
 import { logger } from '../logger.js';
+
 import { getManifestFromNode } from './data/processing.js';
 import repoService from './repoService.js';
 
@@ -10,11 +12,12 @@ export const getAutomergeUrl = (documentId: DocumentId): AutomergeUrl => {
   return `automerge:${documentId}` as AutomergeUrl;
 };
 
-export const getLatestManifestFromNode = async (
-  node: Pick<Node, "manifestUrl" | "uuid">
-) => {
+export const getLatestManifestFromNode = async (node: Pick<Node, 'manifestUrl' | 'uuid' | 'manifestDocumentId'>) => {
   logger.info({ uuid: node.uuid }, 'START [getLatestManifestFromNode]');
-  let manifest = await repoService.getDraftManifest(node.uuid as NodeUuid);
+  let manifest = await repoService.getDraftManifest({
+    uuid: node.uuid as NodeUuid,
+    documentId: node.manifestDocumentId,
+  });
   if (!manifest) {
     const publishedManifest = await getManifestFromNode(node);
     manifest = publishedManifest.manifest;
@@ -25,4 +28,4 @@ export const getLatestManifestFromNode = async (
 export function assertNever(value: never) {
   console.error('Unknown value', value);
   throw Error('Not Possible');
-};
+}

--- a/desci-server/src/services/nodeManager.ts
+++ b/desci-server/src/services/nodeManager.ts
@@ -482,7 +482,10 @@ export const showNodeDraftManifest = async (node: Node, ipfsFallbackUrl?: string
   // Add draft manifest document
   const nodeUuid = ensureUuidEndsWithDot(node.uuid) as NodeUuid;
   // for draft nodes we can do this asynchronously on the frontend
-  const manifest = await repoService.getDraftManifest(nodeUuid);
+  const manifest = await repoService.getDraftManifest({
+    uuid: nodeUuid,
+    documentId: node.manifestDocumentId as DocumentId,
+  });
 
   logger.trace({ nodeUuid, manifestFound: !!manifest }, '[getNodeManifest] ==> repoService.getDraftManifest');
 

--- a/desci-server/src/services/nodeManager.ts
+++ b/desci-server/src/services/nodeManager.ts
@@ -1,16 +1,21 @@
+import { DocumentId } from '@automerge/automerge-repo';
 import { PdfComponent, ResearchObjectComponentType, ResearchObjectV1 } from '@desci-labs/desci-models';
-import { DataType, Prisma, PublicDataReference, User } from '@prisma/client';
+import { DataType, Node, Prisma, PublicDataReference, User } from '@prisma/client';
 import axios from 'axios';
 
 import { prisma } from '../client.js';
 import { MEDIA_SERVER_API_KEY, MEDIA_SERVER_API_URL, PUBLIC_IPFS_PATH } from '../config/index.js';
+import { ForbiddenError, NodeUuid, NotFoundError } from '../internal.js';
 import { logger as parentLogger } from '../logger.js';
+import { getFromCache } from '../redisClient.js';
 import { getIndexedResearchObjects } from '../theGraph.js';
+import { ResearchObjectDocument } from '../types/documents.js';
 import { generateDataReferences } from '../utils/dataRefTools.js';
-import { cleanupManifestUrl } from '../utils/manifest.js';
+import { cleanupManifestUrl, transformManifestWithHistory } from '../utils/manifest.js';
 import { hexToCid, randomUUID64, asyncMap, ensureUuidEndsWithDot } from '../utils.js';
 
 import { addBufferToIpfs, downloadFilesAndMakeManifest, getSizeForCid, resolveIpfsData } from './ipfs.js';
+import repoService from './repoService.js';
 
 const ESTUARY_MIRROR_ID = 1;
 
@@ -442,4 +447,66 @@ export const cacheNodeMetadata = async (uuid: string, manifestCid: string, versi
     logger.error({ error: e }, 'Error cacheNodeMetadata');
     return false;
   }
+};
+
+export const showNodeDraftManifest = async (node: Node, ipfsFallbackUrl?: string) => {
+  logger.trace('[getNodeManifest] ==> start');
+  const timeDifferenceInSeconds = getTimeDiffInSec(node.createdAt.toString());
+  logger.trace(
+    { timeDifferenceInSeconds, uuid: node.uuid, now: Date.now(), created: node.createdAt },
+    '[getNodeManifest] ==> timeDifferenceInSeconds',
+  );
+
+  const cachedDraftMetadata = (await getFromCache(`node-draft-${node.uuid}`)) as {
+    documentId: DocumentId;
+    document: ResearchObjectDocument;
+  };
+
+  logger.trace(
+    { timeDifferenceInSeconds, uuid: node.uuid, cachedDraftMetadata: !!cachedDraftMetadata },
+    '[getNodeManifest] ==> cachedDraftMetadata',
+  );
+
+  if (timeDifferenceInSeconds <= 30 && cachedDraftMetadata) {
+    logger.trace(
+      { timeDifferenceInSeconds, uuid: node.uuid, driveClock: cachedDraftMetadata.document.driveClock },
+      '[getNodeManifest] ==> Found cachedDraftetadata',
+    );
+    return cachedDraftMetadata.document.manifest;
+  }
+
+  logger.trace(
+    { timeDifferenceInSeconds, uuid: node.uuid, cachedDraftMetadata: !!cachedDraftMetadata },
+    '[getNodeManifest] ==> Fallback to repoService.getDraftManifest',
+  );
+  // Add draft manifest document
+  const nodeUuid = ensureUuidEndsWithDot(node.uuid) as NodeUuid;
+  // for draft nodes we can do this asynchronously on the frontend
+  const manifest = await repoService.getDraftManifest(nodeUuid);
+
+  logger.trace({ nodeUuid, manifestFound: !!manifest }, '[getNodeManifest] ==> repoService.getDraftManifest');
+
+  if (manifest) return manifest;
+
+  logger.trace(
+    { uuid: node.uuid, cid: node.manifestUrl, ipfsFallbackUrl, timeout: 5000 },
+    '[getNodeManifest] ==> Fallback to IPFS Call',
+  );
+  const gatewayUrl = cleanupManifestUrl(node.manifestUrl, ipfsFallbackUrl);
+  const data = transformManifestWithHistory((await axios.get(gatewayUrl, { timeout: 5000 })).data, node);
+
+  logger.trace(
+    { uuid: node.uuid, cid: node.manifestUrl, ipfsFallbackUrl, manifest: !!data },
+    '[getNodeManifest] ==> Found manifest on IPFS',
+  );
+
+  logger.trace('[getNodeManifest] ==> end');
+  return data;
+};
+
+const getTimeDiffInSec = (date: string) => {
+  const now = Date.now();
+  const start = new Date(date).getTime();
+
+  return (now - start) / 1000;
 };

--- a/desci-server/src/services/repoService.ts
+++ b/desci-server/src/services/repoService.ts
@@ -1,6 +1,6 @@
 import { DocumentId } from '@automerge/automerge-repo';
 import { ResearchObjectV1, ManifestActions } from '@desci-labs/desci-models';
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosError, AxiosInstance } from 'axios';
 
 import { als, logger as parentLogger } from '../logger.js';
 import { ResearchObjectDocument } from '../types/documents.js';
@@ -16,6 +16,9 @@ class RepoService {
   #apiKey: string;
 
   baseUrl: string;
+
+  defaultTimeoutInMilliseconds: 5000;
+  timeoutErrorMessage = 'Timeout: Call to Repo service timed out';
 
   constructor() {
     if (!process.env.REPO_SERVICE_SECRET_KEY || !process.env.REPO_SERVER_URL)
@@ -97,7 +100,7 @@ class RepoService {
     }
   }
 
-  async getDraftDocument(arg: { uuid: NodeUuid }) {
+  async getDraftDocument(arg: { uuid: NodeUuid; timeout?: number }) {
     if (!arg.uuid) {
       logger.warn({ arg }, 'Attempt to retrieve draft manifest for empty UUID');
       return null;
@@ -110,6 +113,8 @@ class RepoService {
           headers: {
             'x-api-remote-traceid': (als.getStore() as any)?.traceId,
           },
+          timeout: arg.timeout ?? this.defaultTimeoutInMilliseconds,
+          timeoutErrorMessage: this.timeoutErrorMessage,
         },
       );
       if (response.status === 200 && response.data.ok) {
@@ -118,17 +123,19 @@ class RepoService {
         return null;
       }
     } catch (err) {
+      const error = err as AxiosError;
+      if (error?.code === 'ECONNABORTED' || error?.message?.toLowerCase().includes('timeout')) {
+        logger.error({ error }, 'REPO_SERVICE_CALL_TIMEOUT');
+      }
       logger.error({ err }, 'GET Draft Document Error');
       return null;
     }
   }
 
-  async getDraftManifest(uuid: NodeUuid) {
+  async getDraftManifest(uuid: NodeUuid, timeout?: number) {
     logger.info({ uuid }, 'Retrieve Draft Document');
-    // try {} catch (err) {}
-    // uuid = ensureUuidEndsWithDot(uuid) as NodeUuid;
     try {
-      const response = await this.getDraftDocument({ uuid });
+      const response = await this.getDraftDocument({ uuid, timeout });
       return response ? response.manifest : null;
     } catch (err) {
       logger.error({ err }, 'GET Draft manifest Error');

--- a/desci-server/src/services/repoService.ts
+++ b/desci-server/src/services/repoService.ts
@@ -100,15 +100,15 @@ class RepoService {
     }
   }
 
-  async getDraftDocument(arg: { uuid: NodeUuid; timeout?: number }) {
-    if (!arg.uuid) {
+  async getDraftDocument(arg: { uuid: NodeUuid; documentId?: string | DocumentId; timeout?: number }) {
+    if (!arg.uuid && !arg.documentId) {
       logger.warn({ arg }, 'Attempt to retrieve draft manifest for empty UUID');
       return null;
     }
     logger.info({ arg }, 'Retrieve Draft Document');
     try {
       const response = await this.#client.get<ApiResponse<{ document: ResearchObjectDocument }>>(
-        `${this.baseUrl}/v1/nodes/documents/draft/${arg.uuid}`,
+        `${this.baseUrl}/v1/nodes/documents/draft/${arg.uuid}?documentId=${arg.documentId}`,
         {
           headers: {
             'x-api-remote-traceid': (als.getStore() as any)?.traceId,
@@ -132,10 +132,18 @@ class RepoService {
     }
   }
 
-  async getDraftManifest(uuid: NodeUuid, timeout?: number) {
+  async getDraftManifest({
+    uuid,
+    timeout,
+    documentId,
+  }: {
+    uuid: NodeUuid;
+    documentId?: string | DocumentId;
+    timeout?: number;
+  }) {
     logger.info({ uuid }, 'Retrieve Draft Document');
     try {
-      const response = await this.getDraftDocument({ uuid, timeout });
+      const response = await this.getDraftDocument({ uuid, timeout, documentId });
       return response ? response.manifest : null;
     } catch (err) {
       logger.error({ err }, 'GET Draft manifest Error');

--- a/desci-server/test/integration/Attestation.test.ts
+++ b/desci-server/test/integration/Attestation.test.ts
@@ -133,7 +133,7 @@ const clearDatabase = async () => {
   await prisma.$queryRaw`TRUNCATE TABLE "Node" CASCADE;`;
 };
 
-describe.only('Attestations Service', async () => {
+describe('Attestations Service', async () => {
   let baseManifest: ResearchObjectV1;
   let baseManifestCid: string;
   let users: User[];


### PR DESCRIPTION
## Description of the Problem / Feature
- Calls to create draft, get node draft manifest and show nodes are slow and sometimes cause the tests to crash/fail

## Explanation of the solution
- Remove database calls for nodes in repo service
- In `/createDraft` cache draft node metadata for a minute to serve hot calls (non-blocking)
- Refactor `nodes#show` controller and optimize calls for retrieving draft manifest
- Refactor reposervice to pass documentId to `getDraftDocument` and `getDraftManifest` methods
- In Repo server, fast track calls to`getLatestNodeManifest` by attempting to use `documentId` query if found and fallback to uuid if not
- All calls to `getDraftManifest()` within the app are automatically optimized
- Optimize `retrieveTree` api by switching `getLatestManifestFromNode` in favor of `showNodeDraftManifest`
- Implement a new nodeManager function `showNodeDraftManifest` that optimizes request for draft manifest by using cached data if request is hot i.e `<30 secs` after node creation (hopefully tests calls benefits form this, falls back to RepoService node is cold `> 30 secs` and falls back to pulling data from ipfs using node cid.

