### PR TITLE
Prepub futuristic date bug

### DIFF
--- a/desci-server/src/services/PublishPackage.ts
+++ b/desci-server/src/services/PublishPackage.ts
@@ -71,9 +71,10 @@ class PublishPackageService {
     let nodeUuid = ensureUuidEndsWithDot(node.uuid);
     nodeUuid = nodeUuid.slice(0, -1);
     // const paddedTimestamp = unixTimestamp.padEnd(13, '0');
+
     const publishTime = demoMode
       ? Date.now().toString().slice(0, 10)
-      : await publishServices.retrieveBlockTimeByManifestCid(nodeUuid, usedManifestCid);
+      : (await publishServices.retrieveBlockTimeByManifestCid(nodeUuid, usedManifestCid)).slice(0, 10);
 
     const publishDate = PublishPackageService.convertUnixTimestampToDate(publishTime);
     const authors = manifest.authors?.map((author) => author.name);


### PR DESCRIPTION
## Description of the Problem / Feature
- Unix timestamp for un-anchored ROs was retrieved using the current date, which was to higher precision than what was on ceramic, this inconsistency caused issues when passed into the formatting function and gave odd futuristic dates on the initial publish.
## Explanation of the solution
- Small adjustment to make the precision consistent, should fix it.

