### PR TITLE
repo-server: reduce default logginess

### DIFF
--- a/desci-repo/kubernetes/deployment_dev.yaml
+++ b/desci-repo/kubernetes/deployment_dev.yaml
@@ -49,7 +49,7 @@ spec:
           export DATABASE_URL={{ .Data.DATABASE_URL }}
           export IPFS_RESOLVER_OVERRIDE={{ .Data.IPFS_RESOLVER_OVERRIDE }}
           export DESCI_SERVER_URL={{ .Data.DESCI_SERVER_URL }}
-
+          export PINO_LOG_LEVEL=info
           {{- end -}}
       labels:
         App: DesciRepoServerDev

--- a/desci-repo/kubernetes/deployment_prod.yaml
+++ b/desci-repo/kubernetes/deployment_prod.yaml
@@ -50,7 +50,7 @@ spec:
           export DATABASE_URL={{ .Data.DATABASE_URL }}
           export IPFS_RESOLVER_OVERRIDE={{ .Data.IPFS_RESOLVER_OVERRIDE }}
           export DESCI_SERVER_URL={{ .Data.DESCI_SERVER_URL }}
-
+          export PINO_LOG_LEVEL=info
           {{- end -}}
       labels:
         App: DesciRepoServerProd

--- a/desci-repo/kubernetes/deployment_staging.yaml
+++ b/desci-repo/kubernetes/deployment_staging.yaml
@@ -50,7 +50,7 @@ spec:
           export DATABASE_URL={{ .Data.DATABASE_URL }}
           export IPFS_RESOLVER_OVERRIDE={{ .Data.IPFS_RESOLVER_OVERRIDE }}
           export DESCI_SERVER_URL={{ .Data.DESCI_SERVER_URL }}
-
+          export PINO_LOG_LEVEL=info
           {{- end -}}
       labels:
         App: DesciRepoServerStaging

--- a/desci-server/src/controllers/admin/debug.ts
+++ b/desci-server/src/controllers/admin/debug.ts
@@ -78,9 +78,9 @@ export const debugAllNodesHandler = async (
     // Most recent first
     n2[event].getTime() - n1[event].getTime()
   );
-  
+
   const endTime = new Date();
-  const duration = Math.round(endTime.getTime() - startTime.getTime());
+  const duration = Math.round((endTime.getTime() - startTime.getTime()) / 1000);
 
   const result = {
     info: {
@@ -250,7 +250,7 @@ const debugIndexer = async (
     return { error: shouldExist, result: null };
   };
 
-  return { error: false, nVersions: result.versions.length , result };
+  return { error: false, nVersions: result.versions.length, result };
 };
 
 const debugDb = async (


### PR DESCRIPTION
## Description of the Problem / Feature
>2M loglines per day from repo service

## Explanation of the solution
@shadrach-tayo did a pass on logs, skipping trace and debug by default should be okay. 
