### PR TITLE
Fix/void search

### DIFF
--- a/desci-server/src/controllers/users/search.ts
+++ b/desci-server/src/controllers/users/search.ts
@@ -50,7 +50,7 @@ export const searchProfiles = async (req: SearchProfilesRequest, res: Response<S
           include: { userOrganizations: { include: { organization: { select: { name: true } } } } },
         })
       : await prisma.user.findMany({
-          where: { name: { contains: name as string, mode: 'insensitive' } },
+          where: { name: { contains: name as string, mode: 'insensitive', not: null } },
           include: { userOrganizations: { include: { organization: { select: { name: true } } } } },
         });
 

--- a/desci-server/src/routes/v1/doi.ts
+++ b/desci-server/src/routes/v1/doi.ts
@@ -13,7 +13,7 @@ import {
 
 const router = Router();
 
-router.post('/check/:uuid', [ensureUser, ensureNodeAccess], asyncHandler(checkMintability));
+router.get('/check/:uuid', [ensureUser, ensureNodeAccess], asyncHandler(checkMintability));
 router.post('/mint/:uuid', [ensureUser, ensureNodeAccess], asyncHandler(mintDoi));
 router.get('/', [validate(retrieveDoiSchema)], asyncHandler(retrieveDoi));
 

--- a/desci-server/src/services/Doi.ts
+++ b/desci-server/src/services/Doi.ts
@@ -108,7 +108,13 @@ export class DoiService {
 
     // check if node has claimed doi already
     // check with dpid instead or dpid/path/to/manuscript or dpid/path/to/file
-    await this.assertIsFirstDoi(latestManifest.dpid.id);
+    const node = await this.dbClient.node.findFirst({
+      where: { uuid: ensureUuidEndsWithDot(nodeUuid) },
+      select: { dpidAlias: true },
+    });
+    const dpid = latestManifest?.dpid?.id || node?.dpidAlias.toString();
+    if (!dpid) logger.trace({ dpid }, 'No DPID found');
+    await this.assertIsFirstDoi(dpid);
 
     // extract manuscripts
     const manuscripts = latestManifest.components.filter(
@@ -117,7 +123,6 @@ export class DoiService {
         component.name.endsWith('.pdf') ||
         component.payload?.path?.endsWith('.pdf'),
     ) as PdfComponent[];
-    logger.info(manuscripts, 'MANUSCRIPTS');
 
     if (manuscripts.length > 0) {
       const existingDois = manuscripts.filter((doc) => doc.payload?.doi && doc.payload.doi.length > 0);


### PR DESCRIPTION
## Description of the Problem / Feature
- filter empty out user with no names in search api result 
- fix checkMintability service logic crash when dpid is not attached to manifest
