### PR TITLE
Minor notification bug fixes

### DIFF
--- a/desci-server/src/services/NotificationService.ts
+++ b/desci-server/src/services/NotificationService.ts
@@ -250,26 +250,29 @@ export const emitNotificationForAnnotation = async (annotationId: number) => {
     return;
   }
 
+  const dotlessUuid = node.uuid.replace(/\./g, '');
+
   const notificationData: CreateNotificationData = {
     userId: nodeOwner.id,
     type: NotificationType.COMMENTS,
     title: `${annotationAuthor?.name} commented on your research object`,
     message: `Your research object titled ${node.title}, has received a new comment.`, // TODO:: Ideally deserialize some of the message body from the annotation and show a truncated snippet
     nodeUuid: node.uuid,
-    payload: { type: NotificationType.COMMENTS, nodeUuid: node.uuid, annotationId } as CommentPayload,
+    payload: { type: NotificationType.COMMENTS, nodeUuid: dotlessUuid, annotationId } as CommentPayload,
   };
 
   await createUserNotification(notificationData);
 };
 //
 export const emitNotificationOnPublish = async (node: Node, user: User, dpid: string) => {
+  const dotlessUuid = node.uuid.replace(/\./g, '');
   const notificationData: CreateNotificationData = {
     userId: user.id,
     type: NotificationType.PUBLISH,
     title: `Your research object has been published!`,
     message: `Your research object titled "${node.title}" has been published and is now available for public access.`,
     nodeUuid: node.uuid,
-    payload: { type: NotificationType.PUBLISH, nodeUuid: node.uuid, dpid } as PublishPayload,
+    payload: { type: NotificationType.PUBLISH, nodeUuid: dotlessUuid, dpid } as PublishPayload,
   };
 
   await createUserNotification(notificationData);

--- a/desci-server/src/services/NotificationService.ts
+++ b/desci-server/src/services/NotificationService.ts
@@ -242,6 +242,7 @@ export const emitNotificationForAnnotation = async (annotationId: number) => {
   }
 
   const annotationAuthor = annotation.author;
+  const annotationAuthorName = annotationAuthor?.name || 'A user';
   const node = annotation.node || annotation.attestation?.node;
   const nodeOwner = node?.owner;
 
@@ -255,7 +256,7 @@ export const emitNotificationForAnnotation = async (annotationId: number) => {
   const notificationData: CreateNotificationData = {
     userId: nodeOwner.id,
     type: NotificationType.COMMENTS,
-    title: `${annotationAuthor?.name} commented on your research object`,
+    title: `${annotationAuthorName} commented on your research object`,
     message: `Your research object titled ${node.title}, has received a new comment.`, // TODO:: Ideally deserialize some of the message body from the annotation and show a truncated snippet
     nodeUuid: node.uuid,
     payload: { type: NotificationType.COMMENTS, nodeUuid: dotlessUuid, annotationId } as CommentPayload,


### PR DESCRIPTION
## Description of the Problem / Feature
- Send dotless node uuid in notification payloads
- Add generic user name for profiles without names in notifications to prevent 'null has commented...'
