### PR TITLE
Debug Migration order bug

### DIFF
--- a/nodes-lib/.vscode/launch.json
+++ b/nodes-lib/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Nodes Lib Tests",
+      "type": "node",
+      "request": "attach",
+      "restart": true,
+      "port": 9229,
+      "address": "localhost",
+      "localRoot": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
## Description of the Problem / Feature
- To rule out the current migration logic having issues we need tests that focus on the ordering of versions for legacy published nodes -> ceramic nodes
## Explanation of the solution
- Added tests for multiple version legacy nodes migrating to a ceramic stream

