### PR TITLE
make node doi query api public

### DIFF
--- a/desci-server/src/routes/v1/nodes.ts
+++ b/desci-server/src/routes/v1/nodes.ts
@@ -120,7 +120,7 @@ router.post('/distribution', preparePublishPackage);
 router.post('/distribution/preview', [ensureUser], frontmatterPreview);
 
 // Doi api routes
-router.get('/:identifier/doi', [ensureUser], asyncHandler(retrieveNodeDoi));
+router.get('/:identifier/doi', [], asyncHandler(retrieveNodeDoi));
 router.post(
   '/:uuid/automate-metadata',
   [ensureUser, ensureNodeAccess, validate(automateMetadataSchema)],


### PR DESCRIPTION
## Description of the Problem / Feature
- Make Nodes DOI retrieve api public

## Explanation of the solution
This is because Published nodes with DOI need to show it on the Nodes home even when the client is not authenticated.