### PR TITLE
fix: author id is missing from metadata extraction automation

### DIFF
--- a/desci-server/src/controllers/nodes/doi.ts
+++ b/desci-server/src/controllers/nodes/doi.ts
@@ -10,6 +10,7 @@ import {
 import { NextFunction, Response } from 'express';
 import { Request } from 'express';
 import _ from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
 import { BadRequestError, NotFoundError, UnProcessableRequestError } from '../../core/ApiError.js';
@@ -182,6 +183,7 @@ export const automateManuscriptDoi = async (req: RequestWithNode, res: Response,
       actions.push({
         type: 'Set Contributors',
         contributors: authors.map((author) => ({
+          id: uuidv4(),
           name: author.name,
           role: ResearchObjectV1AuthorRole.AUTHOR,
           ...(author.affiliations.length > 0 && { organizations: author.affiliations }),

--- a/desci-server/src/services/AutomatedMetadata.ts
+++ b/desci-server/src/services/AutomatedMetadata.ts
@@ -4,6 +4,7 @@ import { DocumentId } from '@automerge/automerge-repo';
 import { ManifestActions, ResearchObjectV1Author, ResearchObjectV1AuthorRole } from '@desci-labs/desci-models';
 import axios from 'axios';
 import FormData from 'form-data';
+import { v4 as uuidv4 } from 'uuid';
 
 import { logger as parentLogger } from '../logger.js';
 import { ONE_DAY_TTL, getFromCache, setToCache } from '../redisClient.js';
@@ -314,6 +315,7 @@ export class AutomatedMetadataClient {
         contributors: metadata.authors.map(
           (author) =>
             ({
+              id: uuidv4(),
               name: author.name,
               role: ResearchObjectV1AuthorRole.AUTHOR,
               ...(author.affiliations.length > 0 && { organizations: author.affiliations }),


### PR DESCRIPTION
## Description of the Problem / Feature
- Contributor entries have no unique uuid https://nodes.desci.com/dpid/282/contributors which breaks verification/invite flow

## Explanation of the solution
- Add generated unique id to each author entries from metadata extraction