### PR TITLE
fix: Legacy dpid check breaks orcid work record integration

### DIFF
--- a/desci-server/src/controllers/attestations/verification.ts
+++ b/desci-server/src/controllers/attestations/verification.ts
@@ -106,7 +106,7 @@ export const addVerification = async (
      */
     const node = await prisma.node.findFirst({ where: { uuid: ensureUuidEndsWithDot(claim.nodeUuid) } });
     const owner = await prisma.user.findFirst({ where: { id: node.ownerId } });
-    if (owner.orcid) await orcidApiService.postWorkRecord(node.uuid, owner.orcid);
+    if (owner.orcid) await orcidApiService.postWorkRecord(node.uuid, owner.orcid, node.dpidAlias.toString());
     await saveInteractionWithoutReq(ActionType.UPDATE_ORCID_RECORD, {
       ownerId: owner.id,
       orcid: owner.orcid,


### PR DESCRIPTION
## Description of the Problem / Feature
- Orcid work record integration breaks due to legacy dpid use

## Explanation of the solution
- fallback on node dpidAlias
