### PR TITLE
Notifications adjustments

### DIFF
--- a/desci-server/prisma/migrations/20241125141101_user_unseen_notif_count/migration.sql
+++ b/desci-server/prisma/migrations/20241125141101_user_unseen_notif_count/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "unseenNotificationCount" INTEGER NOT NULL DEFAULT 0;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -156,6 +156,7 @@ model User {
   pseudonym                   String?                       @unique
   orcid                       String?                       @unique
   notificationSettings        Json?
+  unseenNotificationCount     Int                           @default(0)
   // rorPid                     String[]              @default([])
   // organization               String[]              @default([])
   isAdmin                     Boolean                       @default(false)

--- a/desci-server/src/controllers/notifications/create.ts
+++ b/desci-server/src/controllers/notifications/create.ts
@@ -14,7 +14,7 @@ export const CreateNotificationSchema = z.object({
   payload: z.record(z.unknown()).optional(),
 });
 
-interface AuthenticatedRequest extends Request {
+export interface AuthenticatedRequest extends Request {
   user: User;
 }
 

--- a/desci-server/src/controllers/notifications/notificationCount.ts
+++ b/desci-server/src/controllers/notifications/notificationCount.ts
@@ -1,0 +1,63 @@
+import { Response } from 'express';
+import { z } from 'zod';
+
+import { logger as parentLogger } from '../../logger.js';
+import { getUnseenNotificationCount, resetUnseenNotificationCount } from '../../services/NotificationService.js';
+
+import { AuthenticatedRequest } from './create.js';
+
+export interface ErrorResponse {
+  error: string;
+}
+
+export const getNotificationCount = async (
+  req: AuthenticatedRequest,
+  res: Response<{ unseenNotificationCount: number } | ErrorResponse>,
+) => {
+  const logger = parentLogger.child({
+    module: 'UserNotifications::getNotificationCount',
+    userId: req.user?.id,
+  });
+
+  logger.trace('Getting notification count');
+  try {
+    if (!req.user) {
+      logger.warn('Unauthorized, check middleware');
+      return res.status(401).json({ error: 'Unauthorized' } as ErrorResponse);
+    }
+    const user = req.user;
+    const unseenNotificationCount = await getUnseenNotificationCount({ user });
+
+    logger.info({ unseenNotificationCount }, 'Successfully retrieved notification count');
+    return res.status(201).json({ unseenNotificationCount });
+  } catch (error) {
+    logger.error({ error }, 'Error retrieving unseenNotificationCount');
+    return res.status(500).json({ error: 'Internal server error' } as ErrorResponse);
+  }
+};
+
+export const resetNotificationCount = async (
+  req: AuthenticatedRequest,
+  res: Response<{ message: string } | ErrorResponse>,
+) => {
+  const logger = parentLogger.child({
+    module: 'UserNotifications::resetNotificationCount',
+    userId: req.user?.id,
+  });
+
+  logger.trace('Resetting notification count');
+  try {
+    if (!req.user) {
+      logger.warn('Unauthorized, check middleware');
+      return res.status(401).json({ error: 'Unauthorized' } as ErrorResponse);
+    }
+    const user = req.user;
+    const unseenNotificationCount = await resetUnseenNotificationCount({ userId: user.id });
+
+    logger.info({ unseenNotificationCount }, 'Successfully reset notification count');
+    return res.status(201).json({ message: 'Successfully reset notification count' });
+  } catch (error) {
+    logger.error({ error }, 'Error creating user notification');
+    return res.status(500).json({ error: 'Internal server error' } as ErrorResponse);
+  }
+};

--- a/desci-server/src/controllers/notifications/update.ts
+++ b/desci-server/src/controllers/notifications/update.ts
@@ -1,4 +1,5 @@
 import { User, UserNotifications } from '@prisma/client';
+import { all } from 'axios';
 import { Request, Response } from 'express';
 import { z } from 'zod';
 
@@ -10,6 +11,7 @@ const UpdateDataSchema = z.object({
 });
 
 const BatchUpdateSchema = z.object({
+  all: z.boolean().optional(),
   notificationIds: z.array(z.number()),
   updateData: UpdateDataSchema,
 });
@@ -56,8 +58,8 @@ export const updateNotification = async (
       return res.status(200).json(updatedNotification);
     } else {
       // Batch update
-      const { notificationIds, updateData } = BatchUpdateSchema.parse(req.body);
-      const count = await batchUpdateUserNotifications(notificationIds, userId, updateData);
+      const { notificationIds, updateData, all } = BatchUpdateSchema.parse(req.body);
+      const count = await batchUpdateUserNotifications({ notificationIds, userId, updateData, all });
       logger.info({ count }, 'Successfully batch updated user notifications');
       return res.status(200).json({ count });
     }

--- a/desci-server/src/routes/v1/notifications.ts
+++ b/desci-server/src/routes/v1/notifications.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import { createNotification } from '../../controllers/notifications/create.js';
 import { listUserNotifications } from '../../controllers/notifications/index.js';
+import { getNotificationCount, resetNotificationCount } from '../../controllers/notifications/notificationCount.js';
 import { updateNotification } from '../../controllers/notifications/update.js';
 import { updateSettings } from '../../controllers/notifications/updateSettings.js';
 import { ensureUser } from '../../middleware/permissions.js';
@@ -9,9 +10,11 @@ import { ensureUser } from '../../middleware/permissions.js';
 const router = Router();
 
 router.get('/', [ensureUser], listUserNotifications);
+router.get('/unseen', [ensureUser], getNotificationCount);
 router.post('/', [ensureUser], createNotification);
 router.patch('/', [ensureUser], updateNotification); // Batch update route
 router.patch('/settings', [ensureUser], updateSettings);
+router.patch('/unseen', [ensureUser], resetNotificationCount);
 router.patch('/:notificationId', [ensureUser], updateNotification);
 
 export default router;

--- a/desci-server/src/services/NotificationService.ts
+++ b/desci-server/src/services/NotificationService.ts
@@ -200,16 +200,22 @@ export const updateUserNotification = async (
   return updatedNotification;
 };
 
-export const batchUpdateUserNotifications = async (
-  notificationIds: number[],
-  userId: number,
-  updateData: NotificationUpdateData,
-): Promise<number> => {
+export const batchUpdateUserNotifications = async ({
+  notificationIds,
+  userId,
+  updateData,
+  all,
+}: {
+  notificationIds: number[];
+  userId: number;
+  updateData: NotificationUpdateData;
+  all?: boolean;
+}): Promise<number> => {
   logger.info({ notificationIds, userId, updateData }, 'Batch updating user notifications');
 
   const result = await prisma.userNotifications.updateMany({
     where: {
-      id: { in: notificationIds },
+      ...(all ? {} : { id: { in: notificationIds } }),
       userId: userId,
     },
     data: updateData,

--- a/desci-server/src/services/NotificationService.ts
+++ b/desci-server/src/services/NotificationService.ts
@@ -165,6 +165,7 @@ export const createUserNotification = async (
 
   // Emit websocket push notification
   emitWebsocketEvent(data.userId, { type: WebSocketEventType.NOTIFICATION, data: 'invalidate-cache' });
+  incrementUnseenNotificationCount({ userId: data.userId });
 
   return notification;
 };
@@ -453,12 +454,18 @@ export const emitNotificationOnDoiIssuance = async ({
   await createUserNotification(notificationData);
 };
 
-export const getUnseenNotificationCount = async ({ userId }: { userId: number }) => {
-  const { unseenNotificationCount } = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { unseenNotificationCount: true },
-  });
-  return unseenNotificationCount;
+export const getUnseenNotificationCount = async ({ userId, user }: { userId?: number; user?: User }) => {
+  if (!userId && !user) {
+    throw new Error('Missing userId or user');
+  }
+  if (!user || !user.unseenNotificationCount) {
+    const { unseenNotificationCount } = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { unseenNotificationCount: true },
+    });
+    return unseenNotificationCount;
+  }
+  return user.unseenNotificationCount;
 };
 
 export const incrementUnseenNotificationCount = async ({ userId }: { userId: number }) => {
@@ -468,7 +475,7 @@ export const incrementUnseenNotificationCount = async ({ userId }: { userId: num
   });
 };
 
-export const resetUnseenNotificationCount = async ({ userId }) => {
+export const resetUnseenNotificationCount = async ({ userId }: { userId: number }) => {
   await prisma.user.update({
     where: { id: userId },
     data: { unseenNotificationCount: 0 },

--- a/desci-server/src/services/NotificationService.ts
+++ b/desci-server/src/services/NotificationService.ts
@@ -452,3 +452,25 @@ export const emitNotificationOnDoiIssuance = async ({
 
   await createUserNotification(notificationData);
 };
+
+export const getUnseenNotificationCount = async ({ userId }: { userId: number }) => {
+  const { unseenNotificationCount } = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { unseenNotificationCount: true },
+  });
+  return unseenNotificationCount;
+};
+
+export const incrementUnseenNotificationCount = async ({ userId }: { userId: number }) => {
+  await prisma.user.update({
+    where: { id: userId },
+    data: { unseenNotificationCount: { increment: 1 } },
+  });
+};
+
+export const resetUnseenNotificationCount = async ({ userId }) => {
+  await prisma.user.update({
+    where: { id: userId },
+    data: { unseenNotificationCount: 0 },
+  });
+};

--- a/desci-server/test/integration/notifications.test.ts
+++ b/desci-server/test/integration/notifications.test.ts
@@ -35,10 +35,10 @@ describe('Notification Service', () => {
         message: 'This is a test notification',
       });
 
-      expect(notification.userId).to.equal(user.id);
-      expect(notification.type).to.equal(NotificationType.PUBLISH);
-      expect(notification.title).to.equal('Test Notification');
-      expect(notification.message).to.equal('This is a test notification');
+      expect(notification?.userId).to.equal(user.id);
+      expect(notification?.type).to.equal(NotificationType.PUBLISH);
+      expect(notification?.title).to.equal('Test Notification');
+      expect(notification?.message).to.equal('This is a test notification');
     });
 
     it('should throw an error when creating a notification for a disabled type', async () => {
@@ -89,7 +89,7 @@ describe('Notification Service', () => {
         message: 'This is a test notification',
       });
 
-      const updatedNotification = await updateUserNotification(notification.id, user.id, { dismissed: true });
+      const updatedNotification = await updateUserNotification(notification!.id, user.id, { dismissed: true });
 
       expect(updatedNotification.dismissed).to.be.true;
     });
@@ -120,7 +120,7 @@ describe('Notification Service', () => {
       ]);
 
       const updatedCount = await batchUpdateUserNotifications({
-        notificationIds: notifications.map((n) => n.id),
+        notificationIds: notifications.map((n) => n!.id),
         userId: user.id,
         updateData: { dismissed: true },
       });
@@ -128,7 +128,7 @@ describe('Notification Service', () => {
       expect(updatedCount).to.equal(2);
 
       const updatedNotifications = await prisma.userNotifications.findMany({
-        where: { id: { in: notifications.map((n) => n.id) } },
+        where: { id: { in: notifications.map((n) => n!.id) } },
       });
 
       expect(updatedNotifications.every((n) => n.dismissed)).to.be.true;
@@ -142,7 +142,7 @@ describe('Notification Service', () => {
       });
 
       const updatedUser = await prisma.user.findUnique({ where: { id: user.id } });
-      const settings = updatedUser.notificationSettings as Partial<Record<NotificationType, boolean>>;
+      const settings = updatedUser?.notificationSettings as Partial<Record<NotificationType, boolean>>;
       expect(settings[NotificationType.PUBLISH]).to.be.false;
     });
   });

--- a/desci-server/test/integration/notifications.test.ts
+++ b/desci-server/test/integration/notifications.test.ts
@@ -119,11 +119,11 @@ describe('Notification Service', () => {
         }),
       ]);
 
-      const updatedCount = await batchUpdateUserNotifications(
-        notifications.map((n) => n.id),
-        user.id,
-        { dismissed: true },
-      );
+      const updatedCount = await batchUpdateUserNotifications({
+        notificationIds: notifications.map((n) => n.id),
+        userId: user.id,
+        updateData: { dismissed: true },
+      });
 
       expect(updatedCount).to.equal(2);
 


### PR DESCRIPTION
Closes # https://github.com/desci-labs/nodes-web-v2/issues/1021

## Description of the Problem / Feature
- The logic for the seen/dismissing notifications has changed, these 2 actions are decoupled
- Added new endpoints for maintaining the unseen count of notifications, fetching/resetting
## Instructions on making this work
- DB Migrations needed!
