### PR TITLE
Proxy object/stat endpoint

### DIFF
--- a/desci-server/src/controllers/proxy/ipfsReadGateway.ts
+++ b/desci-server/src/controllers/proxy/ipfsReadGateway.ts
@@ -2,34 +2,37 @@ import axios from 'axios';
 import { Request, Response } from 'express';
 
 import { logger as parentLogger } from '../../logger.js';
+import { BlockMetadata, getCidMetadata } from '../../services/ipfs.js';
 
 /**
- * Proxy for the read only IPFS gateway, to allow the isolated media server to access IPFS content, without writability.
+ * Proxy for obtaining CID metadata
+ * Temporarily used until we upgrade kubo on the priv swarm node
  */
-export const ipfsReadGatewayProxy = async (req: Request, res: Response) => {
+export const ipfsReadGatewayProxy = async (
+  req: Request<{ cid: string }, any, any, { external?: boolean }>,
+  res: Response<BlockMetadata | { error: string }>,
+) => {
+  const logger = parentLogger.child({
+    module: 'PROXY::ipfsMetadataProxyController',
+    cid: req.params.cid,
+    external: req.query.external,
+  });
+  logger.trace('Fetching CID metadata');
   try {
-    const logger = parentLogger.child({
-      module: 'PROXY::ipfsReadGatewayProxyController',
-      cid: req.params.cid,
-    });
     const { cid } = req.params;
-    if (!process.env.IPFS_READ_ONLY_GATEWAY_SERVER) {
-      logger.error('IPFS_READ_ONLY_GATEWAY_SERVER is not defined in environment variables');
-      return res.status(500).send('Unable to connect to IPFS gateway');
-    }
-    const url = `${process.env.IPFS_READ_ONLY_GATEWAY_SERVER}/${cid}`;
+    const { external } = req.query;
+    const externalFlag = !!external;
 
     // Forward the request to the IPFS gateway
-    const response = await axios.get(url, { responseType: 'stream' });
+    const metadata = await getCidMetadata(cid, externalFlag);
 
-    // Forward headers
-    res.set('Content-Type', response.headers['content-type']);
-
-    // Stream the response back to the client
-    response.data.pipe(res);
+    if (metadata) {
+      return res.status(200).json(metadata);
+    } else {
+      return res.status(404).json({ error: 'Metadata not found' });
+    }
   } catch (error) {
-    console.error('Error forwarding IPFS request:', error);
-    return res.status(500).send('Error forwarding IPFS request');
+    logger.info('Error fetching CID metadata:', error);
+    return res.status(500).json({ error: 'Error fetching metadata' });
   }
-  return res.status(200);
 };

--- a/desci-server/src/routes/v1/index.ts
+++ b/desci-server/src/routes/v1/index.ts
@@ -69,7 +69,7 @@ router.get('/nft/:id', nft);
 router.use('/referral', referral);
 router.get('/researchFields', [ensureUser], queryResearchFields);
 router.get('/ror', [ensureUser], queryRor);
-router.get('/ipfs/:cid', ipfsReadGatewayProxy);
+router.get('/cidmd/:cid', ipfsReadGatewayProxy);
 
 // potential notification fallback catch
 router.post(

--- a/desci-server/src/services/ipfs.ts
+++ b/desci-server/src/services/ipfs.ts
@@ -1103,3 +1103,29 @@ export async function checkCidSrc(cid: string, assumeExternal = false) {
   }
   return false;
 }
+
+export type BlockMetadata = {
+  Hash: { '/': string };
+  NumLinks: number;
+  BlockSize: number;
+  LinkSize: number;
+  DataSize: number;
+  CumulativeSize: number;
+};
+export async function getCidMetadata(cid: string, external?: boolean): Promise<BlockMetadata | null> {
+  /*
+   ** External handling should be added once our pub node is properly configured
+   */
+  try {
+    // const metadata: BlockMetadata = await client.block.stat(CID.parse(cid), { timeout: INTERNAL_IPFS_TIMEOUT });
+    const metadata: BlockMetadata = await client.object.stat(CID.parse(cid), { timeout: INTERNAL_IPFS_TIMEOUT });
+    // let localResolver = process.env.IPFS_RESOLVER_OVERRIDE;
+    // if (localResolver.endsWith('/ipfs')) localResolver = localResolver.slice(0, -5);
+    // const url = `${localResolver}/api/v0/object/stat?arg=${cid}`;
+    // const metadata = await axios.get(url).then((res) => res.data);
+    return metadata;
+  } catch (e) {
+    logger.trace({ fn: 'getCidMetadata', cid, e }, 'Failed to get CID metadata');
+    return null;
+  }
+}


### PR DESCRIPTION
## Description of the Problem / Feature
- Reused old unused proxy ipfs route to fetch metadata for a CID using object/stat for the old kubo node, this endpoint is temporary and can be removed in the future when the kubo nodes are reconfigured. 

