### PR TITLE
fix: setting response header being sent to client

### DIFF
--- a/desci-server/src/controllers/auth/login.ts
+++ b/desci-server/src/controllers/auth/login.ts
@@ -11,6 +11,7 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
 export const check = async (req: RequestWithUser, res: Response, next: NextFunction) => {
   if (req.user) {
     res.status(200).send({ ok: true });
+    return;
   }
 
   res.send({ ok: false });


### PR DESCRIPTION
## Description of the Problem / Feature
Api calls to `/auth/check` api crashes

## Explanation of the solution
- add missing return statement 
