### PR TITLE
Fix ext-cid failing

### DIFF
--- a/desci-server/src/services/data/externalCidProcessing.ts
+++ b/desci-server/src/services/data/externalCidProcessing.ts
@@ -81,7 +81,7 @@ export async function processExternalCidDataToIpfs({
       for (const extCid of externalCids) {
         const { isDirectory, size } = await getExternalCidSizeAndType(extCid.cid);
         if (size !== undefined && isDirectory !== undefined) {
-          cidTypesSizes[extCid.cid] = { size, isDirectory };
+          cidTypesSizes[extCid.cid] = { size: Number(size), isDirectory };
         } else {
           throw new Error(`Failed to get size and type of external CID: ${extCid}`);
         }


### PR DESCRIPTION
## Description of the Problem / Feature
Sizes returned in the newer kubo API were returned in Big Ints, schema saved sizes in reg ints
## Explanation of the solution
Parsed sizes to regular ints