### PR TITLE
Optional DOI registration for submission packages

### DIFF
--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -35,6 +35,7 @@ export type PublishReqBody = {
   ceramicStream?: string;
   commitId?: string;
   useNewPublish: boolean;
+  mintDoi: boolean;
 };
 
 export type PublishRequest = Request<never, never, PublishReqBody> & {
@@ -67,7 +68,7 @@ async function updateAssociatedAttestations(nodeUuid: string, dpid: string) {
 }
 
 export const publish = async (req: PublishRequest, res: Response<PublishResBody>, _next: NextFunction) => {
-  const { uuid, cid, manifest, transactionId, ceramicStream, commitId, useNewPublish } = req.body;
+  const { uuid, cid, manifest, transactionId, ceramicStream, commitId, useNewPublish, mintDoi } = req.body;
   const email = req.user.email;
   const logger = parentLogger.child({
     // id: req.id,
@@ -169,18 +170,20 @@ export const publish = async (req: PublishRequest, res: Response<PublishResBody>
       owner.id,
     );
 
-    // trigger doi minting workflow
-    try {
-      const submission = await doiService.autoMintTrigger(node.uuid);
-      const targetDpidUrl = getTargetDpidUrl();
-      discordNotify({
-        channel: DiscordChannel.DoiMinting,
-        type: DiscordNotifyType.INFO,
-        title: 'Mint DOI',
-        message: `${targetDpidUrl}/${submission.dpid} sent a request to mint: ${submission.uniqueDoi}`,
-      });
-    } catch (err) {
-      logger.error({ err }, 'Error:  Mint DOI on Publish');
+    if (mintDoi) {
+      // trigger doi minting workflow
+      try {
+        const submission = await doiService.autoMintTrigger(node.uuid);
+        const targetDpidUrl = getTargetDpidUrl();
+        discordNotify({
+          channel: DiscordChannel.DoiMinting,
+          type: DiscordNotifyType.INFO,
+          title: 'Mint DOI',
+          message: `${targetDpidUrl}/${submission.dpid} sent a request to mint: ${submission.uniqueDoi}`,
+        });
+      } catch (err) {
+        logger.error({ err }, 'Error:  Mint DOI on Publish');
+      }
     }
 
     return res.send({

--- a/nodes-lib/package-lock.json
+++ b/nodes-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@desci-labs/nodes-lib",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@desci-labs/desci-codex-lib": "^1.1.7",

--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {
@@ -19,7 +19,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -r dist; tsc --project tsconfig.build.json",
+    "build": "rm -rf dist; tsc --project tsconfig.build.json",
     "doPublish": "npm run build && npm publish --access public",
     "test": "vitest --run --config vitest.config.ts",
     "test:debug": "npm run test -- --inspect-brk --no-file-parallelism --test-timeout 99999999",

--- a/nodes-lib/src/api.ts
+++ b/nodes-lib/src/api.ts
@@ -323,6 +323,7 @@ export type PublishResponse = {
  *
  * @param uuid - UUID of the node to publish
  * @param didOrSigner - authenticated did-session DID, or a generic signer
+ * @param mintDoi - opt-in to DOI registration
  */
 export const publishNode = async (
   uuid: string,
@@ -403,6 +404,7 @@ export type LegacyPublishResponse = {
  *
  * @param uuid - UUID of node to publish
  * @param signer - Signer to use for publish, if not set with env
+ * @param mintDoi - opt-in to DOI registration
  * @throws (@link WrongOwnerError) if signer address isn't research object token owner
  * @throws (@link DpidPublishError) if dPID couldnt be registered or updated
  * @depreated use publishNode instead, as this function uses the old on-chain registry

--- a/nodes-lib/src/api.ts
+++ b/nodes-lib/src/api.ts
@@ -301,6 +301,7 @@ type PublishParams = {
   ceramicStream?: string;
   commitId?: string;
   useNewPublish: boolean;
+  mintDoi?: boolean;
 };
 
 /** Result of publishing a draft node */
@@ -325,7 +326,8 @@ export type PublishResponse = {
  */
 export const publishNode = async (
   uuid: string,
-  didOrSigner: DID | Signer
+  didOrSigner: DID | Signer,
+  mintDoi = false
 ): Promise<PublishResponse> => {
   const publishResult = await publish(uuid, didOrSigner);
   const pubParams: PublishParams = {
@@ -335,6 +337,7 @@ export const publishNode = async (
     ceramicStream: publishResult.ceramicIDs.streamID,
     commitId: publishResult.ceramicIDs.commitID,
     useNewPublish: true,
+    mintDoi,
   };
 
   let dpid: number;
@@ -404,11 +407,17 @@ export type LegacyPublishResponse = {
  * @throws (@link DpidPublishError) if dPID couldnt be registered or updated
  * @depreated use publishNode instead, as this function uses the old on-chain registry
  */
-export const publishDraftNode = async (
-  uuid: string,
-  signer: Signer,
-  did?: DID
-): Promise<LegacyPublishResponse> => {
+export const publishDraftNode = async ({
+  uuid,
+  signer,
+  did,
+  mintDoi = false,
+}: {
+  uuid: string;
+  signer: Signer;
+  did?: DID;
+  mintDoi?: boolean;
+}): Promise<LegacyPublishResponse> => {
   const publishResult = await legacyPublish(uuid, signer, did);
 
   const pubParams: PublishParams = {
@@ -419,6 +428,7 @@ export const publishDraftNode = async (
     ceramicStream: publishResult.ceramicIDs?.streamID,
     commitId: publishResult.ceramicIDs?.commitID,
     useNewPublish: false,
+    mintDoi,
   };
 
   try {

--- a/nodes-lib/test/root.spec.ts
+++ b/nodes-lib/test/root.spec.ts
@@ -342,7 +342,7 @@ describe("nodes-lib", () => {
     beforeAll(async () => {
       const { node } = await createBoilerplateNode();
       uuid = node.uuid;
-      publishResult = await publishDraftNode(uuid, testSigner, did);
+      publishResult = await publishDraftNode({ uuid, signer: testSigner, did });
       // Wait for repo and subgraph changes to go through
       // await sleep(2_500);
     });
@@ -384,14 +384,16 @@ describe("nodes-lib", () => {
 
       test("can optionally derive DID from just a signer", async () => {
         const { node } = await createBoilerplateNode();
-        const result = await publishDraftNode(node.uuid, testSigner);
+        const result = await publishDraftNode({
+          uuid: node.uuid,
+          signer: testSigner,
+        });
         const streamState = await getRawState(result.ceramicIDs!.streamID);
         const controller = streamState.state.metadata.controllers.at(0);
         const signerAddress = (await testSigner.getAddress()).toLowerCase();
         expect(controller!.replace(/did:pkh.*:/, "")).toEqual(signerAddress);
       });
     });
-
 
     describe("node with long legacy history", async () => {
       let uuid: string;
@@ -402,7 +404,6 @@ describe("nodes-lib", () => {
         const { node } = await createBoilerplateNode();
         uuid = node.uuid;
 
-
         let updatedManifestCids = [];
         // make a dpid-only publish
         for (let i = 0; i < 5; i++) {
@@ -412,12 +413,11 @@ describe("nodes-lib", () => {
             prepubResult: { updatedManifest, updatedManifestCid },
           } = await dpidPublish(uuid, dpidExists, testSigner);
           legacyDpid = parseInt(updatedManifest.dpid!.id!);
-          updatedManifestCids.push(updatedManifestCid)
+          updatedManifestCids.push(updatedManifestCid);
         }
 
         // Allow graph node to index
         await sleep(2_500);
-
 
         // Import as legacy entry (i.e., fake migration step)
         // Publish uses this to validate history before migrating dPID
@@ -433,13 +433,13 @@ describe("nodes-lib", () => {
         );
         const tx = await aliasRegistry.importLegacyDpid(legacyDpid!, {
           owner: await testSigner.getAddress(),
-          versions: updatedManifestCids.map((cid) => ({ cid, time: 1337 }))
+          versions: updatedManifestCids.map((cid) => ({ cid, time: 1337 })),
         });
         await tx.wait();
 
         // make a regular publish
         try {
-          await publishDraftNode(uuid, testSigner)
+          await publishDraftNode({ uuid, signer: testSigner });
         } catch (e) {
           // Expect this to fail
           // To be able to test incorrect histories, we ignore the error thrown from the publish route
@@ -455,28 +455,29 @@ describe("nodes-lib", () => {
         expect(dpidHistory.versions.length).toEqual(5);
 
         // codex history has the legacy and the new update
-        const codexHistory = await getCodexHistory(
-          ceramicStream!
-        );
+        const codexHistory = await getCodexHistory(ceramicStream!);
         expect(codexHistory.length).toEqual(6);
 
-        const codexVersionsDpidResolver = await (await fetch(`http://localhost:5460/api/v2/resolve/dpid/${legacyDpid}`)).json()
+        const codexVersionsDpidResolver = await (
+          await fetch(`http://localhost:5460/api/v2/resolve/dpid/${legacyDpid}`)
+        ).json();
 
-        const cidsInDpidHistory = dpidHistory.versions.map(v => v.cid)
-        const cidsInCodex = codexVersionsDpidResolver.versions.map(v => v.manifest)
+        const cidsInDpidHistory = dpidHistory.versions.map((v) => v.cid);
+        const cidsInCodex = codexVersionsDpidResolver.versions.map(
+          (v) => v.manifest
+        );
 
         // debugger
 
-        expect(cidsInDpidHistory).toEqual(cidsInCodex)
+        expect(cidsInDpidHistory).toEqual(cidsInCodex);
       });
     });
-
 
     describe("node update", async () => {
       beforeAll(async () => {
         // async publish errors on re-publish before it finishes
         await sleep(5_000);
-        await publishDraftNode(uuid, testSigner, did);
+        await publishDraftNode({ uuid, signer: testSigner, did });
         // Allow graph node to index
         await sleep(2_500);
       });
@@ -519,7 +520,11 @@ describe("nodes-lib", () => {
         await sleep(2_500);
 
         // make a regular publish
-        const pubResult = await publishDraftNode(uuid, testSigner, did);
+        const pubResult = await publishDraftNode({
+          uuid,
+          signer: testSigner,
+          did,
+        });
 
         // Allow graph node to index
         await sleep(5_000);
@@ -542,8 +547,6 @@ describe("nodes-lib", () => {
       expect(node.manifestData.dpid).toBeUndefined();
     });
   });
-
-
 
   describe("publishing ", async () => {
     let uuid: string;
@@ -660,7 +663,6 @@ describe("nodes-lib", () => {
         const { node } = await createBoilerplateNode();
         uuid = node.uuid;
 
-
         let updatedManifestCids = [];
         // make a dpid-only publish
         for (let i = 0; i < 5; i++) {
@@ -670,12 +672,11 @@ describe("nodes-lib", () => {
             prepubResult: { updatedManifest, updatedManifestCid },
           } = await dpidPublish(uuid, dpidExists, testSigner);
           legacyDpid = parseInt(updatedManifest.dpid!.id!);
-          updatedManifestCids.push(updatedManifestCid)
+          updatedManifestCids.push(updatedManifestCid);
         }
 
         // Allow graph node to index
         await sleep(2_500);
-
 
         // Import as legacy entry (i.e., fake migration step)
         // Publish uses this to validate history before migrating dPID
@@ -691,7 +692,7 @@ describe("nodes-lib", () => {
         );
         const tx = await aliasRegistry.importLegacyDpid(legacyDpid!, {
           owner: await testSigner.getAddress(),
-          versions: updatedManifestCids.map((cid) => ({ cid, time: 1337 }))
+          versions: updatedManifestCids.map((cid) => ({ cid, time: 1337 })),
         });
         await tx.wait();
 
@@ -710,12 +711,16 @@ describe("nodes-lib", () => {
         );
         expect(codexHistory.length).toEqual(6);
 
-        const codexVersionsDpidResolver = await (await fetch(`http://localhost:5460/api/v2/resolve/dpid/${legacyDpid}`)).json()
+        const codexVersionsDpidResolver = await (
+          await fetch(`http://localhost:5460/api/v2/resolve/dpid/${legacyDpid}`)
+        ).json();
 
-        const cidsInDpidHistory = dpidHistory.versions.map(v => v.cid)
-        const cidsInCodex = codexVersionsDpidResolver.versions.map(v => v.manifest).slice(0, -1)
+        const cidsInDpidHistory = dpidHistory.versions.map((v) => v.cid);
+        const cidsInCodex = codexVersionsDpidResolver.versions
+          .map((v) => v.manifest)
+          .slice(0, -1);
 
-        expect(cidsInDpidHistory).toEqual(cidsInCodex)
+        expect(cidsInDpidHistory).toEqual(cidsInCodex);
       });
     });
     describe("node with legacy history", async () => {
@@ -1136,5 +1141,3 @@ const createBoilerplateNode = async () => {
 
   return await createDraftNode(node);
 };
-
-


### PR DESCRIPTION
## Description of the Problem / Feature
- Make DOI registration opt-in during  prepublication submission

## Explanation of the solution
- Make DOI registration opt-in during prepub flow
- Update nodes-lib to accept args
- Update desci publish api make DOI minting optional

## NODES-LIB update needs to be published
