### PR TITLE
Feat: Implement attestations search Api

### DIFF
--- a/desci-server/src/routes/v1/attestations/index.ts
+++ b/desci-server/src/routes/v1/attestations/index.ts
@@ -32,11 +32,13 @@ import {
   showCommunityClaimsSchema,
   showNodeAttestationsSchema,
   claimEntryAttestationsSchema,
+  searchAttestationsSchema,
 } from './schema.js';
 
 const router = Router();
 
-router.get('/suggestions/all', [], asyncHandler(getAllRecommendations));
+// router.get('/', [validate(searchAttestationsSchema)], asyncHandler(searchAttestations));
+router.get('/suggestions/all', [validate(searchAttestationsSchema)], asyncHandler(getAllRecommendations));
 router.get('/suggestions/protected', [], asyncHandler(getValidatedRecommendations));
 router.get(
   '/claims/:communityId/:dpid',

--- a/desci-server/src/routes/v1/attestations/schema.ts
+++ b/desci-server/src/routes/v1/attestations/schema.ts
@@ -206,3 +206,9 @@ export const removeClaimSchema = z.object({
     claimId: z.coerce.number(),
   }),
 });
+
+export const searchAttestationsSchema = z.object({
+  query: z.object({
+    search: z.string().optional(),
+  }),
+});

--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -905,8 +905,9 @@ export class AttestationService {
     return queryResult;
   }
 
-  async getRecommendedAttestations() {
+  async getRecommendedAttestations(filter?: Prisma.CommunityEntryAttestationFindManyArgs) {
     const attestations = await prisma.communityEntryAttestation.findMany({
+      ...filter,
       include: {
         attestation: { select: { community: true } },
         attestationVersion: {
@@ -918,11 +919,8 @@ export class AttestationService {
         },
         desciCommunity: { select: { name: true, hidden: true, image_url: true } },
       },
-      where: {
-        desciCommunity: {
-          hidden: false,
-        },
-      },
+      where: filter?.where ?? { desciCommunity: { hidden: false } },
+      take: filter ? 50 : 5,
     });
 
     return attestations;


### PR DESCRIPTION
## Description of the Problem / Feature
- We need a way to search attestations as the list keeps growing

## Explanation of the solution
- Extend the `attestations/suggestions/all` api to support search queries
- Limit response to `5` if not search query is passed to request