### PR TITLE
Optional attestation publish during update

### DIFF
--- a/desci-server/src/routes/v1/admin/communities/schema.ts
+++ b/desci-server/src/routes/v1/admin/communities/schema.ts
@@ -67,6 +67,7 @@ export const addAttestationSchema = z.object({
 
 export const updateAttestationSchema = addAttestationSchema.extend({
   params: z.object({ attestationId: z.coerce.number(), communityId: z.coerce.number() }),
+  body: z.object({ publishNew: z.coerce.boolean().optional() }),
 });
 
 export const addMemberSchema = z.object({

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -34,8 +34,8 @@ services:
         condition: service_healthy
       nodes_test_ipfs:
         condition: service_started
-      nodes_test_repo_service:
-        condition: service_healthy
+      # nodes_test_repo_service:
+      #   condition: service_healthy
     links:
       - nodes_test_db
     container_name: "nodes_backend_test"


### PR DESCRIPTION
## Description of the Problem / Feature
- Updating an attestation affects old claims on the older attestation version and makes them disappear from the community Radar

## Explanation of the solution
- Make publishing new attestation version opt-in on the admin dashboard and Api level