### PR TITLE
Add keywords field to research object

### DIFF
--- a/desci-models/src/ResearchObject.ts
+++ b/desci-models/src/ResearchObject.ts
@@ -43,6 +43,8 @@ export interface ResearchObjectV1 extends ResearchObject {
   dpid?: ResearchObjectV1Dpid;
   /** Research fields relevant for the publication */
   researchFields?: string[];
+  /** Keywords associated with the research object */
+  keywords?: string[];
   /** Contributors to this publication */
   authors?: ResearchObjectV1Author[];
 


### PR DESCRIPTION
## Description of the Problem / Feature
Need a keywords field in the research object interface to store keywords in the manifest.

## Explanation of the solution
Added a `keywords` optional field taking an array of strings which makes it flexible for manually adding keywords.

The `researchFields` field is suitable for "topics" therefore no additional field has been added for topics.