### PR TITLE
Community radar/feed API performance optimisation

### DIFF
--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -27,6 +27,7 @@
     "script:seed-community-member": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/seed-community-members.ts",
     "script:backfill-annotations": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/backfill-annotations.ts",
     "script:prune-auth-tokens": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/prune-auth-tokens.ts",
+    "script:backfill-radar": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/backfill-radar.ts",
     "build": "rimraf dist && tsc && yarn copy-files; if [ \"$SENTRY_AUTH_TOKEN\" ]; then yarn sentry:sourcemaps; else echo 'SENTRY_AUTH_TOKEN not set, sourcemaps will not upload'; fi",
     "build:worker": "cd ../sync-server && ./scripts/build.sh test",
     "copy-files": "copyfiles -u 1 src/**/*.cjs dist/",

--- a/desci-server/prisma/migrations/20250108131055_community_radar_entry/migration.sql
+++ b/desci-server/prisma/migrations/20250108131055_community_radar_entry/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable
+ALTER TABLE "NodeAttestation" ADD COLUMN     "communityRadarEntryId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "CommunityRadarEntry" (
+    "id" SERIAL NOT NULL,
+    "desciCommunityId" INTEGER NOT NULL,
+    "nodeUuid" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CommunityRadarEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CommunityRadarEntry_nodeUuid_desciCommunityId_key" ON "CommunityRadarEntry"("nodeUuid", "desciCommunityId");
+
+-- AddForeignKey
+ALTER TABLE "NodeAttestation" ADD CONSTRAINT "NodeAttestation_communityRadarEntryId_fkey" FOREIGN KEY ("communityRadarEntryId") REFERENCES "CommunityRadarEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CommunityRadarEntry" ADD CONSTRAINT "CommunityRadarEntry_desciCommunityId_fkey" FOREIGN KEY ("desciCommunityId") REFERENCES "DesciCommunity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CommunityRadarEntry" ADD CONSTRAINT "CommunityRadarEntry_nodeUuid_fkey" FOREIGN KEY ("nodeUuid") REFERENCES "Node"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -54,6 +54,7 @@ model Node {
   UserNotifications    UserNotifications[]
   Annotation           Annotation[]
   ExternalPublications ExternalPublications[]
+  CommunityRadarEntry  CommunityRadarEntry[]
 
   @@index([ownerId])
   @@index([uuid])
@@ -697,6 +698,7 @@ model DesciCommunity {
   NodeAttestation           NodeAttestation[]
   AttestationTemplate       AttestationTemplate[]
   CommunityEntryAttestation CommunityEntryAttestation[]
+  CommunityRadarEntry       CommunityRadarEntry[]
 }
 
 model CommunityMember {
@@ -799,8 +801,23 @@ model NodeAttestation {
   NodeAttestationVerification NodeAttestationVerification[]
   NodeAttestationReaction     NodeAttestationReaction[]
   OrcidPutCodes               OrcidPutCodes[]
+  CommunityRadarEntry         CommunityRadarEntry?          @relation(fields: [nodeUuid, desciCommunityId], references: [nodeUuid, desciCommunityId])
+  // communityRadarEntryId       Int?
 
   @@unique([nodeUuid, nodeVersion, attestationId, attestationVersionId])
+}
+
+model CommunityRadarEntry {
+  id               Int               @id @default(autoincrement())
+  desciCommunityId Int
+  community        DesciCommunity    @relation(fields: [desciCommunityId], references: [id])
+  nodeUuid         String
+  node             Node              @relation(fields: [nodeUuid], references: [uuid])
+  nodeAttestations NodeAttestation[]
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+
+  @@unique([nodeUuid, desciCommunityId])
 }
 
 // Deferred emails are usually used when a published node is required, e.g. unpublished attestation claims, emails are deferred until node is published.

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -801,8 +801,8 @@ model NodeAttestation {
   NodeAttestationVerification NodeAttestationVerification[]
   NodeAttestationReaction     NodeAttestationReaction[]
   OrcidPutCodes               OrcidPutCodes[]
-  CommunityRadarEntry         CommunityRadarEntry?          @relation(fields: [nodeUuid, desciCommunityId], references: [nodeUuid, desciCommunityId])
-  // communityRadarEntryId       Int?
+  CommunityRadarEntry         CommunityRadarEntry?          @relation(fields: [communityRadarEntryId], references: [id])
+  communityRadarEntryId       Int?
 
   @@unique([nodeUuid, nodeVersion, attestationId, attestationVersionId])
 }

--- a/desci-server/src/controllers/attestations/claims.ts
+++ b/desci-server/src/controllers/attestations/claims.ts
@@ -21,9 +21,11 @@ export const claimAttestation = async (req: RequestWithUser, res: Response, _nex
     nodeDpid: string;
     claimerId: number;
   };
+
+  // TODO: verify attestationVersions[0] === latest
   const attestationVersions = await attestationService.getAttestationVersions(body.attestationId);
   const latest = attestationVersions.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  const attestationVersion = latest[0];
+  const attestationVersion = attestationVersions[0];
   logger.info({ body, latest, attestationVersion }, 'CLAIM');
   const uuid = ensureUuidEndsWithDot(body.nodeUuid);
 

--- a/desci-server/src/controllers/attestations/claims.ts
+++ b/desci-server/src/controllers/attestations/claims.ts
@@ -134,7 +134,7 @@ export const removeClaim = async (req: RequestWithUser, res: Response, _next: Ne
       : await attestationService.unClaimAttestation(claim.id);
 
   // trigger update radar entry
-  await communityService.addToRadar(claim.desciCommunityId, claim.nodeUuid);
+  await communityService.removeFromRadar(claim.desciCommunityId, claim.nodeUuid);
 
   await saveInteraction(req, ActionType.REVOKE_CLAIM, body);
 
@@ -191,6 +191,8 @@ export const claimEntryRequirements = async (req: Request, res: Response, _next:
     nodeUuid: uuid,
     attestations: claims,
   });
+  // trigger update radar entry
+  await communityService.addToRadar(communityId, uuid);
 
   await saveInteraction(req, ActionType.CLAIM_ENTRY_ATTESTATIONS, {
     communityId,

--- a/desci-server/src/controllers/communities/radar.ts
+++ b/desci-server/src/controllers/communities/radar.ts
@@ -17,10 +17,6 @@ export const getCommunityRadar = async (req: Request, res: Response, next: NextF
   // THIS is necessary because the engagement signal returned from getCommunityRadar
   // accounts for only engagements on community selected attestations
   const nodes = await asyncMap(communityRadar, async (node) => {
-    // const engagements = await communityService.getNodeCommunityEngagementSignals(
-    //   parseInt(req.params.communityId),
-    //   node.nodeDpid10,
-    // );
     const engagements = await attestationService.getNodeEngagementSignals(node.nodeDpid10);
 
     const verifiedEngagements = node.NodeAttestation.reduce(

--- a/desci-server/src/controllers/communities/types.ts
+++ b/desci-server/src/controllers/communities/types.ts
@@ -1,7 +1,7 @@
 import { ResearchObjectV1 } from '@desci-labs/desci-models';
 import { Node } from '@prisma/client';
 
-import { CommunityRadarNode } from '../../services/Communities.js';
+import { CommunityRadarNode, RadarEntry } from '../../services/Communities.js';
 
 export type NodeRadarItem = {
   NodeAttestation: CommunityRadarNode[];
@@ -46,3 +46,5 @@ export type NodeRadar = NodeRadarItem & {
     verifications: number;
   };
 };
+
+export type NodeRadarEntry = RadarEntry & { node?: Partial<Node & { versions: number }>; manifest?: ResearchObjectV1 };

--- a/desci-server/src/controllers/communities/util.ts
+++ b/desci-server/src/controllers/communities/util.ts
@@ -1,9 +1,11 @@
+import { ResearchObjectV1 } from '@desci-labs/desci-models';
 import { Node, NodeVersion } from '@prisma/client';
 import axios from 'axios';
 import _ from 'lodash';
 
 import { prisma } from '../../client.js';
 import { logger } from '../../logger.js';
+import { RadarEntry } from '../../services/Communities.js';
 import { NodeUuid } from '../../services/manifestRepo.js';
 import repoService from '../../services/repoService.js';
 import { IndexedResearchObject, getIndexedResearchObjects } from '../../theGraph.js';
@@ -55,6 +57,64 @@ export const resolveLatestNode = async (radar: Partial<NodeRadar>) => {
     radar.manifest = manifest;
 
     logger.info({ manifest }, '[SHOW API GET LAST PUBLISHED MANIFEST]');
+  } catch (err) {
+    const manifest = await repoService.getDraftManifest({
+      uuid: node.uuid as NodeUuid,
+      documentId: node.manifestDocumentId,
+    });
+    radar.manifest = manifest;
+    logger.error({ err, manifestUrl: discovery.manifestUrl, gatewayUrl }, 'nodes/show.ts: failed to preload manifest');
+  }
+
+  radar.node = { ...radar.node, ...node };
+  return radar;
+};
+
+export const getCommunityNodeDetails = async (
+  radar: RadarEntry & { node?: Partial<Node & { versions: number }>; manifest?: ResearchObjectV1 },
+) => {
+  const uuid = ensureUuidEndsWithDot(radar.nodeUuid);
+
+  const discovery = await prisma.node.findFirst({
+    where: {
+      uuid,
+      isDeleted: false,
+    },
+    select: {
+      id: true,
+      manifestUrl: true,
+      ownerId: true,
+      uuid: true,
+      title: true,
+      NodeCover: true,
+    },
+  });
+
+  if (!discovery) {
+    logger.warn({ uuid }, 'uuid not found');
+  }
+
+  const selectAttributes: (keyof typeof discovery)[] = ['ownerId', 'NodeCover'];
+  const node: Partial<Node & { versions: number }> = _.pick(discovery, selectAttributes);
+  const publishedVersions =
+    (await prisma.$queryRaw`SELECT * from "NodeVersion" where "nodeId" = ${discovery.id} AND ("transactionId" IS NOT NULL or "commitId" IS NOT NULL) ORDER BY "createdAt" DESC`) as NodeVersion[];
+
+  // const nodeVersions = (await getNodeVersion
+  logger.info({ uuid: discovery.uuid, publishedVersions }, 'Resolve node');
+  node['versions'] = publishedVersions.length;
+  node['publishedDate'] = publishedVersions[0].createdAt;
+  node.manifestUrl = publishedVersions[0].manifestUrl;
+  radar.node = node;
+
+  let gatewayUrl = publishedVersions[0].manifestUrl;
+
+  try {
+    gatewayUrl = cleanupManifestUrl(gatewayUrl);
+    // logger.trace({ gatewayUrl, uuid }, 'transforming manifest');
+    const manifest = (await axios.get(gatewayUrl)).data;
+    radar.manifest = manifest;
+
+    // logger.info({ manifest }, '[SHOW API GET LAST PUBLISHED MANIFEST]');
   } catch (err) {
     const manifest = await repoService.getDraftManifest({
       uuid: node.uuid as NodeUuid,

--- a/desci-server/src/controllers/communities/util.ts
+++ b/desci-server/src/controllers/communities/util.ts
@@ -87,6 +87,7 @@ export const getCommunityNodeDetails = async (
       uuid: true,
       title: true,
       NodeCover: true,
+      dpidAlias: true,
     },
   });
 

--- a/desci-server/src/routes/v1/communities/index.ts
+++ b/desci-server/src/routes/v1/communities/index.ts
@@ -4,10 +4,15 @@ import {
   getCommunityRecommendations,
   getValidatedAttestations,
 } from '../../../controllers/attestations/recommendations.js';
-import { getAllFeeds, getCommunityDetails, getCommunityFeed } from '../../../controllers/communities/feed.js';
+import {
+  getAllFeeds,
+  getCommunityDetails,
+  getCommunityFeed,
+  listCommunityFeed,
+} from '../../../controllers/communities/feed.js';
 import { checkMemberGuard } from '../../../controllers/communities/guard.js';
 import { listCommunities } from '../../../controllers/communities/list.js';
-import { getCommunityRadar } from '../../../controllers/communities/radar.js';
+import { getCommunityRadar, listCommunityRadar } from '../../../controllers/communities/radar.js';
 import { ensureUser } from '../../../middleware/permissions.js';
 import { validate } from '../../../middleware/validator.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
@@ -32,8 +37,11 @@ router.get(
   asyncHandler(getValidatedAttestations),
 );
 
-router.get('/:communityId/feed', [validate(getCommunityFeedSchema)], asyncHandler(getCommunityFeed));
-router.get('/:communityId/radar', [validate(getCommunityFeedSchema)], asyncHandler(getCommunityRadar));
+// router.get('/:communityId/feed', [validate(getCommunityFeedSchema)], asyncHandler(getCommunityFeed));
+// router.get('/:communityId/radar', [validate(getCommunityFeedSchema)], asyncHandler(getCommunityRadar));
+
+router.get('/:communityId/feed', [validate(getCommunityFeedSchema)], asyncHandler(listCommunityFeed));
+router.get('/:communityId/radar', [validate(getCommunityFeedSchema)], asyncHandler(listCommunityRadar));
 
 router.post('/:communityId/memberGuard', [ensureUser, validate(memberGuardSchema)], asyncHandler(checkMemberGuard));
 

--- a/desci-server/src/routes/v1/communities/schema.ts
+++ b/desci-server/src/routes/v1/communities/schema.ts
@@ -10,6 +10,9 @@ export const getCommunityFeedSchema = z.object({
   params: z.object({
     communityId: z.coerce.number(),
   }),
+  query: z.object({
+    cursor: z.coerce.number().optional().default(0),
+  }),
 });
 
 export const memberGuardSchema = z.object({

--- a/desci-server/src/scripts/backfill-radar.ts
+++ b/desci-server/src/scripts/backfill-radar.ts
@@ -1,0 +1,66 @@
+import { prisma } from '../client.js';
+import { logger } from '../logger.js';
+import { communityService } from '../services/Communities.js';
+
+const main = async () => {
+  const nodeAttestations = await prisma.nodeAttestation.findMany({ where: { revoked: false } });
+  let radarCount = 0;
+  for (const nodeAttestation of nodeAttestations) {
+    const exists = await prisma.communityRadarEntry.findFirst({
+      where: { nodeUuid: nodeAttestation.nodeUuid, desciCommunityId: nodeAttestation.desciCommunityId },
+    });
+    if (exists) {
+      logger.trace(
+        {
+          node: nodeAttestation.nodeDpid10,
+          communityId: nodeAttestation.desciCommunityId,
+        },
+        'Radar exists',
+      );
+      continue;
+    }
+
+    // check if node has claimed all community entry attestations
+    const entryAttestations = await communityService.getEntryAttestations({
+      desciCommunityId: nodeAttestation.desciCommunityId,
+    });
+
+    const claimedAttestations = await prisma.nodeAttestation.findMany({
+      where: { desciCommunityId: nodeAttestation.desciCommunityId, nodeUuid: nodeAttestation.nodeUuid },
+    });
+
+    const isEntriesClaimed = entryAttestations.every((entry) =>
+      claimedAttestations.find(
+        (claimed) =>
+          claimed.attestationId === entry.attestationId && claimed.attestationVersionId === entry.attestationVersionId,
+      ),
+    );
+    if (!isEntriesClaimed) {
+      logger.info(
+        {
+          node: nodeAttestation.nodeDpid10,
+          claims: claimedAttestations.length,
+          entryAttestations: entryAttestations.length,
+          communityId: nodeAttestation.desciCommunityId,
+        },
+        'Not Qualified for Radar',
+      );
+      continue;
+    }
+    // End check if node has claimed all community entry attestations
+
+    await prisma.communityRadarEntry.create({
+      data: {
+        desciCommunityId: nodeAttestation.desciCommunityId,
+        nodeUuid: nodeAttestation.nodeUuid,
+      },
+    });
+    radarCount++;
+  }
+  logger.info({ radarCount }, 'Community radar fields: ');
+  return radarCount;
+};
+
+main()
+  .then((result) => console.log('Community backfilled', result))
+  .catch((err) => console.log('Error running script ', err));

--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -1005,6 +1005,38 @@ export class AttestationService {
     );
     return groupedEngagements;
   }
+
+  /**
+   * Returns all engagement signals for a node across all claimed attestations
+   * This verification signal is the number returned for the verification field
+   * @param dpid
+   * @returns
+   */
+  async getNodeEngagementSignalsByUuid(uuid: string) {
+    const claims = (await prisma.$queryRaw`
+      SELECT t1.*,
+      count(DISTINCT "Annotation".id)::int AS annotations,
+      count(DISTINCT "NodeAttestationReaction".id)::int AS reactions,
+      count(DISTINCT "NodeAttestationVerification".id)::int AS verifications
+      FROM "NodeAttestation" t1
+        left outer JOIN "Annotation" ON t1."id" = "Annotation"."nodeAttestationId"
+        left outer JOIN "NodeAttestationReaction" ON t1."id" = "NodeAttestationReaction"."nodeAttestationId"
+        left outer JOIN "NodeAttestationVerification" ON t1."id" = "NodeAttestationVerification"."nodeAttestationId"
+      WHERE t1."nodeUuid" = ${uuid} AND t1."revoked" = false
+        GROUP BY
+  		t1.id
+    `) as CommunityRadarNode[];
+
+    const groupedEngagements = claims.reduce(
+      (total, claim) => ({
+        reactions: total.reactions + claim.reactions,
+        annotations: total.annotations + claim.annotations,
+        verifications: total.verifications + claim.verifications,
+      }),
+      { reactions: 0, annotations: 0, verifications: 0 },
+    );
+    return groupedEngagements;
+  }
   /**
    * Returns all engagement signals for a claimed attestation
    * @param claimId

--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -233,7 +233,7 @@ export class AttestationService {
   }
 
   async getAttestationVersions(attestationId: number) {
-    return prisma.attestationVersion.findMany({ where: { attestationId } });
+    return prisma.attestationVersion.findMany({ where: { attestationId }, orderBy: { createdAt: 'desc' } });
   }
 
   async getAttestationVersion(id: number, attestationId: number) {

--- a/desci-server/src/services/Communities.ts
+++ b/desci-server/src/services/Communities.ts
@@ -518,8 +518,15 @@ export class CommunityService {
 
     if (!isEntriesClaimed) return undefined;
 
-    const radarEntry = await prisma.communityRadarEntry.create({
-      data: {
+    const radarEntry = await prisma.communityRadarEntry.upsert({
+      where: {
+        nodeUuid_desciCommunityId: { desciCommunityId, nodeUuid },
+      },
+      create: {
+        nodeUuid,
+        desciCommunityId,
+      },
+      update: {
         desciCommunityId,
         nodeUuid,
       },

--- a/desci-server/src/services/Communities.ts
+++ b/desci-server/src/services/Communities.ts
@@ -233,7 +233,7 @@ export class CommunityService {
           verifications ASC,
           cre."createdAt" DESC
       LIMIT
-          ${limit};
+          ${limit}
       OFFSET ${offset};
       `;
 

--- a/desci-server/test/integration/Attestation.test.ts
+++ b/desci-server/test/integration/Attestation.test.ts
@@ -1679,7 +1679,7 @@ describe('Attestations Service', async () => {
         .set('authorization', authHeaderVal)
         .field('communityId', desciCommunity.id);
 
-      apiResponse = res.body.data;
+      apiResponse = res.body.data.data;
       console.log(apiResponse[0]);
       console.log(apiResponse[1]);
       console.log(apiResponse[2]);
@@ -2079,7 +2079,7 @@ describe('Attestations Service', async () => {
         .get(`/v1/communities/${desciCommunity.id}/radar`)
         .set('authorization', authHeaderVal)
         .field('communityId', desciCommunity.id);
-      const radar = res1.body.data as NodeRadar[];
+      const radar = res1.body.data.data as NodeRadar[];
       expect(res1.status).to.equal(200);
       expect(radar.length).to.equal(1);
       const radarNode = radar[0];

--- a/desci-server/test/integration/Attestation.test.ts
+++ b/desci-server/test/integration/Attestation.test.ts
@@ -22,7 +22,7 @@ import request from 'supertest';
 
 import { prisma } from '../../src/client.js';
 import { NodeAttestationFragment } from '../../src/controllers/attestations/show.js';
-import { Engagement, NodeRadar, NodeRadarItem } from '../../src/controllers/communities/types.js';
+import { Engagement, NodeRadar, NodeRadarEntry, NodeRadarItem } from '../../src/controllers/communities/types.js';
 import {
   DuplicateReactionError,
   DuplicateVerificationError,
@@ -129,7 +129,7 @@ const clearDatabase = async () => {
   await prisma.$queryRaw`TRUNCATE TABLE "Node" CASCADE;`;
 };
 
-describe('Attestations Service', async () => {
+describe.only('Attestations Service', async () => {
   let baseManifest: ResearchObjectV1;
   let baseManifestCid: string;
   let users: User[];
@@ -264,6 +264,8 @@ describe('Attestations Service', async () => {
         nodeVersion,
         claimerId: author.id,
       });
+      // trigger update radar entry
+      await communityService.addToRadar(desciCommunity.id, node.uuid);
 
       // publish new node version
       nodeVersion2 = await prisma.nodeVersion.create({
@@ -1567,7 +1569,7 @@ describe('Attestations Service', async () => {
     let fairMetadataAttestationVersion: AttestationVersion;
 
     let res: request.Response;
-    let apiResponse: NodeRadar[];
+    let apiResponse: NodeRadarEntry[];
 
     before(async () => {
       node = nodes[0];
@@ -1621,6 +1623,8 @@ describe('Attestations Service', async () => {
         nodeVersion,
         claimerId: author.id,
       });
+      // trigger update radar entry
+      await communityService.addToRadar(desciCommunity.id, node.uuid);
 
       // claim all entry requirements for node 2
       [claim2, openDataAttestationClaim2] = await attestationService.claimAttestations({
@@ -1639,6 +1643,8 @@ describe('Attestations Service', async () => {
         nodeVersion,
         claimerId: author2.id,
       });
+      // trigger update radar entry
+      await communityService.addToRadar(desciCommunity.id, node2.uuid);
 
       // claim all entry requirements for node 3
       [claim3, openDataAttestationClaim3] = await attestationService.claimAttestations({
@@ -1657,6 +1663,8 @@ describe('Attestations Service', async () => {
         nodeVersion,
         claimerId: author3.id,
       });
+      // trigger update radar entry
+      await communityService.addToRadar(desciCommunity.id, node3.uuid);
 
       // verify both claims for node 1
       await attestationService.verifyClaim(claim.id, users[3].id);
@@ -1696,9 +1704,9 @@ describe('Attestations Service', async () => {
     it('should return nodes in radar in ASC order of verified engagements sorted by last submission/claim date', async () => {
       expect(res.status).to.equal(200);
       expect(apiResponse.length).to.equal(3);
-      expect(apiResponse[0].nodeDpid10).to.be.equal('2');
-      expect(apiResponse[1].nodeDpid10).to.be.equal('3');
-      expect(apiResponse[2].nodeDpid10).to.be.equal('1');
+      expect(apiResponse[0].nodeUuid).to.be.equal(node2.uuid);
+      expect(apiResponse[1].nodeUuid).to.be.equal(node3.uuid);
+      expect(apiResponse[2].nodeUuid).to.be.equal(node.uuid);
     });
   });
 
@@ -2003,6 +2011,8 @@ describe('Attestations Service', async () => {
         nodeVersion,
         claimerId: author.id,
       });
+      // trigger update radar entry
+      await communityService.addToRadar(desciCommunity.id, node.uuid);
 
       [claim2, openDataAttestationClaim2] = await attestationService.claimAttestations({
         attestations: [
@@ -2020,6 +2030,8 @@ describe('Attestations Service', async () => {
         nodeVersion,
         claimerId: author2.id,
       });
+      // trigger update radar entry
+      await communityService.addToRadar(desciCommunity.id, node2.uuid);
 
       // verify both claims for node 1
       await attestationService.verifyClaim(claim.id, users[1].id);
@@ -2074,24 +2086,26 @@ describe('Attestations Service', async () => {
       expect(communityEngagementSignal.reactions).to.equal(0);
     });
 
-    it('should remove node from radar and curated if an entry attestation claim is revoked', async () => {
+    it('should remove node from radar and curated if claim is revoked', async () => {
       const res1 = await request(app)
         .get(`/v1/communities/${desciCommunity.id}/radar`)
         .set('authorization', authHeaderVal)
         .field('communityId', desciCommunity.id);
-      const radar = res1.body.data.data as NodeRadar[];
+      console.log('radar', res1.body);
+      const radar = res1.body.data.data as NodeRadarEntry[];
       expect(res1.status).to.equal(200);
       expect(radar.length).to.equal(1);
       const radarNode = radar[0];
-      expect(radarNode.nodeDpid10).to.be.equal('2');
-      expect(radarNode.nodeuuid).to.be.equal(node2.uuid);
+      // expect(radarNode.nodeDpid10).to.be.equal('2');
+      expect(radarNode.nodeUuid).to.be.equal(node2.uuid);
 
       const res = await request(app)
         .get(`/v1/communities/${desciCommunity.id}/feed`)
         .set('authorization', authHeaderVal)
         .field('communityId', desciCommunity.id);
 
-      const curatedNodes = res.body.data as NodeRadar[];
+      console.log('feed', res.body);
+      const curatedNodes = res.body.data.data as NodeRadarEntry[];
       expect(res.status).to.equal(200);
       expect(curatedNodes.length).to.equal(0);
     });


### PR DESCRIPTION
Closes #722 

## Description of the Problem / Feature
```
- Call communityService.getCommunityRadar:
    - Largeish 4 table join to get node attestations et al
    - Takes between 1 and >2.5s depending on db cache
- async map attestationService.getNodeEngagementSignals over all nodes:
    - aggregate engagement signals for each node with a largeish join query
    - attach the aggregate signals to the node objects
- map resolveLatestNode over all nodes:
    - node discovery query
    - node versions query
    - fetch manifest over IPFS
    - fall back to repo manifest fetch
- sort resulting (node+engagement+manifest) combo by engagements and claim timestamps
```

## Explanation of the solution
```
Community radar API performance improvements
Create a new table called community-radar-entry(nodes + community joins)

When a node joins a community radar we add an entry to this table
when a node leaves we remove the entry
When the node radar engagement signal is updated we update radar-entry
the radar entry has columns for lastClaimedAt(last time an entry attestation was claimed), verifications, comments, reactions for this node
When we query we sort by verification count + lastClaimedAt column
Implement cursor pagination on table queries
Prerequisites:
Create database schema + migration
Implement script to generate entries for the community-radar-entry table from Node attestations table
```
## Instructions on making this work
After merging make sure to run this script
`yarn yarn script:backfill-radar`

## Note: PR contains database migration

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
