### PR TITLE
Bug when revoking claimed attestation and pruning node from communityRadarEntry

### DIFF
--- a/desci-server/src/controllers/nodes/comments.ts
+++ b/desci-server/src/controllers/nodes/comments.ts
@@ -18,11 +18,6 @@ export const getGeneralComments = async (req: RequestWithNode, res: Response, _n
 
   const restrictVisibility = node.ownerId !== req?.user?.id;
 
-  // if (cursor) {
-  //   /// intentional delay
-  //   await new Promise((resolve) => setTimeout(resolve, 1500));
-  // }
-
   const count = await attestationService.countComments({
     uuid: ensureUuidEndsWithDot(uuid),
     ...(restrictVisibility && { visible: true }),

--- a/desci-server/src/services/Communities.ts
+++ b/desci-server/src/services/Communities.ts
@@ -838,6 +838,10 @@ export class CommunityService {
       },
     });
 
+    logger.trace({ entry }, 'removeFromRadar');
+
+    if (!entry) return null;
+
     await prisma.$transaction(
       claimedAttestations.map((claim) =>
         prisma.nodeAttestation.update({ where: { id: claim.id }, data: { communityRadarEntryId: null } }),


### PR DESCRIPTION
## Description of the Problem / Feature
- Quick fix for the bug in title

## Explanation of the solution
- Strict null check on database call response