### PR TITLE
Graph deployment race condition

### DIFF
--- a/desci-contracts/scripts/startTestChain.sh
+++ b/desci-contracts/scripts/startTestChain.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 trap "catch" ERR
 catch() {
-    "[startTestChain] script failed!"
+    echo "[startTestChain] script failed!"
     exit 1
 }
 
@@ -70,7 +70,11 @@ npx ganache \
   --wallet.mnemonic="${MNEMONIC}" \
   --database.dbPath="/data" \
   | grep --line-buffered -v '^eth_.*$' &
-GANACHE_PID=$(pgrep -P $$ ganache)
+
+# Wait for ganache process to be findable
+until GANACHE_PID=$(pgrep -P $$ ganache); do
+  sleep 0.1
+done
 
 until curl -s -o /dev/null -w '' http://localhost:8545; do
   sleep 1


### PR DESCRIPTION
## Description of the Problem / Feature
- In the graph/ganache startup script we ran the graph deployment first in the background and immediately after started ganache, with some arbitrary timeouts to let ganache start up, this worked fine for most machines however on some the graph deployment instance would spin up quickly and it relied upon ganache being ready, resulting in a race condition causing it to fail
## Explanation of the solution
- Started up ganache first in the background, and added a snippet to wait for ganache to be ready to take reqs first before proceeding with the graph deployment
