### PR TITLE
feat: cache external pub, send email notifications and return default

### DIFF
--- a/desci-repo/src/lib/automerge-repo-network-websocket/PartykitWsServerAdapter.ts
+++ b/desci-repo/src/lib/automerge-repo-network-websocket/PartykitWsServerAdapter.ts
@@ -1,15 +1,13 @@
-// import WebSocket from 'isomorphic-ws';
-// import { type WebSocketServer } from 'isomorphic-ws';
-
-import debug from 'debug';
-const log = debug('WebsocketServer');
-
 import { cbor as cborHelpers, NetworkAdapter, type PeerMetadata, type PeerId } from '@automerge/automerge-repo/slim';
+import debug from 'debug';
+import { Connection as WebSocket } from 'partyserver';
+
+import { assert } from './assert.js';
 import { FromClientMessage, FromServerMessage, isJoinMessage, isLeaveMessage } from './messages.js';
 import { ProtocolV1, ProtocolVersion } from './protocolVersion.js';
-import { assert } from './assert.js';
 import { toArrayBuffer } from './toArrayBuffer.js';
-import { Connection as WebSocket } from 'partyserver';
+
+const log = debug('WebsocketServer');
 // import { handleChunked, sendChunked } from './chunking.js';
 
 const { encode, decode } = cborHelpers;

--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -29,6 +29,7 @@
     "script:backfill-annotations": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/backfill-annotations.ts",
     "script:prune-auth-tokens": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/prune-auth-tokens.ts",
     "script:backfill-radar": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/backfill-radar.ts",
+    "script:pruneExternalPublications": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/pruneExternalPublications.ts",
     "build": "rimraf dist && tsc && yarn copy-files; if [ \"$SENTRY_AUTH_TOKEN\" ]; then yarn sentry:sourcemaps; else echo 'SENTRY_AUTH_TOKEN not set, sourcemaps will not upload'; fi",
     "build:worker": "cd ../sync-server && ./scripts/build.sh test",
     "copy-files": "copyfiles -u 1 src/**/*.cjs dist/",

--- a/desci-server/prisma/migrations/20250124124412_is_verified_publication/migration.sql
+++ b/desci-server/prisma/migrations/20250124124412_is_verified_publication/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ExternalPublications" ADD COLUMN     "isVerified" BOOLEAN NOT NULL DEFAULT true;

--- a/desci-server/prisma/migrations/20250127072323_externalpub_verified_at/migration.sql
+++ b/desci-server/prisma/migrations/20250127072323_externalpub_verified_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ExternalPublications" ADD COLUMN     "verifiedAt" TIMESTAMP(3);

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -986,16 +986,18 @@ model PublishStatus {
 }
 
 model ExternalPublications {
-  id          Int      @id @default(autoincrement())
+  id          Int       @id @default(autoincrement())
   uuid        String
-  node        Node     @relation(fields: [uuid], references: [uuid])
+  node        Node      @relation(fields: [uuid], references: [uuid])
   score       Float
   doi         String
   publisher   String
   publishYear String
   sourceUrl   String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  isVerified  Boolean   @default(true)
+  verifiedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   // @@unique([uuid, publisher])
 }

--- a/desci-server/src/controllers/nodes/externalPublications.ts
+++ b/desci-server/src/controllers/nodes/externalPublications.ts
@@ -8,9 +8,11 @@ import { NotFoundError } from '../../core/ApiError.js';
 import { SuccessMessageResponse, SuccessResponse } from '../../core/ApiResponse.js';
 import { logger as parentLogger } from '../../logger.js';
 import { RequestWithNode } from '../../middleware/authorisation.js';
-import { crossRefClient } from '../../services/index.js';
-import { NodeUuid } from '../../services/manifestRepo.js';
-import repoService from '../../services/repoService.js';
+import { redisClient } from '../../redisClient.js';
+import {
+  getExternalPublications,
+  sendExternalPublicationsNotification,
+} from '../../services/crossRef/externalPublication.js';
 import { ensureUuidEndsWithDot } from '../../utils.js';
 
 const logger = parentLogger.child({ module: 'ExternalPublications' });
@@ -36,140 +38,64 @@ export const addExternalPublicationsSchema = z.object({
   }),
 });
 
+export const verifyExternalPublicationSchema = z.object({
+  params: z.object({
+    // quickly disqualify false uuid strings
+    uuid: z.string().min(10),
+  }),
+  body: z.object({
+    verify: z.boolean(),
+    id: z.coerce.number(),
+  }),
+});
+
 export const externalPublications = async (req: RequestWithNode, res: Response, _next: NextFunction) => {
   const { uuid } = req.params as z.infer<typeof externalPublicationsSchema>['params'];
   const node = await prisma.node.findFirst({ where: { uuid: ensureUuidEndsWithDot(uuid) } });
   if (!node) throw new NotFoundError(`Node ${uuid} not found`);
 
-  const userIsNodeOwner = req.user?.id === node?.ownerId;
-
-  logger.trace({ uuid, userIsNodeOwner });
-
-  const externalPublication = await prisma.externalPublications.findMany({
+  const userIsOwner = node.ownerId === req?.user?.id;
+  const externalPublications = await prisma.externalPublications.findMany({
     where: { uuid: ensureUuidEndsWithDot(uuid) },
   });
 
-  if (externalPublication.length > 0) return new SuccessResponse(externalPublication).send(res);
+  logger.trace({ externalPublications }, 'externalPublications');
+  if (externalPublications.length == 1 && !externalPublications[0].verifiedAt)
+    return new SuccessResponse(externalPublications).send(res);
 
-  // return empty list if user is not node owner
-  if (!userIsNodeOwner) return new SuccessResponse([]).send(res);
+  const nonVerified = externalPublications.every((pub) => !pub.isVerified);
+  if (nonVerified && !userIsOwner) return new SuccessResponse(externalPublications).send(res);
 
-  const manifest = await repoService.getDraftManifest({ uuid: uuid as NodeUuid, documentId: node.manifestDocumentId });
-  const data = await crossRefClient.searchWorks({ queryTitle: manifest?.title });
+  if (externalPublications.length > 1)
+    return new SuccessResponse(externalPublications.filter((pub) => pub.isVerified)).send(res);
 
-  if (data.length > 0) {
-    const titleSearcher = new Searcher(data, { keySelector: (entry) => entry.title });
-    const titleResult = titleSearcher.search(manifest.title, { returnMatchData: true });
-    logger.trace(
-      {
-        data: titleResult.map((data) => ({
-          title: data.item.title,
-          publisher: data.item.publisher,
-          source_url: data.item?.resource?.primary?.URL || data.item.URL || '',
-          doi: data.item.DOI,
-          key: data.key,
-          match: data.match,
-          score: data.score,
-        })),
-      },
-      'Title search result',
-    );
+  const isChecked = await redisClient.get(`external-pub-checked-${ensureUuidEndsWithDot(uuid)}`);
+  if (isChecked === 'true') return new SuccessResponse(externalPublications).send(res);
 
-    const descSearcher = new Searcher(data, { keySelector: (entry) => entry?.abstract ?? '' });
-    const descResult = descSearcher.search(manifest.description ?? '', { returnMatchData: true });
-    logger.trace(
-      {
-        data: descResult.map((data) => ({
-          title: data.item.title,
-          key: data.key,
-          match: data.match,
-          score: data.score,
-        })),
-      },
-      'Abstract search result',
-    );
+  const publications = await getExternalPublications(node);
 
-    const authorsSearchScores = data.map((work) => {
-      const authorSearcher = new Searcher(work.author, { keySelector: (entry) => `${entry.given} ${entry.family}` });
+  await redisClient.set(`external-pub-checked-${ensureUuidEndsWithDot(uuid)}`, 'true');
 
-      const nodeAuthorsMatch = manifest.authors.map((author) =>
-        authorSearcher.search(author.name, { returnMatchData: true }),
-      );
-      return {
-        publisher: work.publisher,
-        score: nodeAuthorsMatch.flat().reduce((total, match) => (total += match.score), 0) / manifest.authors.length,
-        match: nodeAuthorsMatch.flat().map((data) => ({
-          key: data.key,
-          match: data.match,
-          score: data.score,
-          author: data.item,
-          publisher: work.publisher,
-          doi: work.DOI,
-        })),
-      };
-    });
+  const entries = await prisma.$transaction(
+    publications.map((pub) =>
+      prisma.externalPublications.upsert({
+        update: {},
+        where: {},
+        create: {
+          doi: pub.doi,
+          score: pub.score,
+          sourceUrl: pub.sourceUrl,
+          publisher: pub.publisher,
+          publishYear: pub.publishYear,
+          uuid: ensureUuidEndsWithDot(node.uuid),
+          isVerified: false,
+        },
+      }),
+    ),
+  );
 
-    logger.trace(
-      {
-        data: descResult.map((data) => ({
-          title: data.item.title,
-          key: data.key,
-          match: data.match,
-          score: data.score,
-        })),
-      },
-      'Authors search result',
-    );
-
-    const publications = data
-      .map((data) => ({
-        publisher: data.publisher,
-        sourceUrl: data?.resource?.primary?.URL || data.URL || '',
-        doi: data.DOI,
-        'is-referenced-by-count': data['is-referenced-by-count'] ?? 0,
-        publishYear:
-          data.published['date-parts']?.[0]?.[0].toString() ??
-          data.license
-            .map((licence) => licence.start['date-parts']?.[0]?.[0])
-            .filter(Boolean)?.[0]
-            .toString(),
-        title: titleResult
-          .filter((res) => res.item.publisher === data.publisher)
-          .map((data) => ({
-            title: data.item.title,
-            key: data.key,
-            match: data.match,
-            score: data.score,
-          }))?.[0],
-        abstract: descResult
-          .filter((res) => res.item.publisher === data.publisher)
-          .map((data) => ({
-            key: data.key,
-            match: data.match,
-            score: data.score,
-            abstract: data.item?.abstract ?? '',
-          }))?.[0],
-        authors: authorsSearchScores
-          .filter((res) => res.publisher === data.publisher)
-          .map((data) => ({
-            score: data.score,
-            authors: data.match,
-          }))?.[0],
-      }))
-      .map((publication) => ({
-        ...publication,
-        score:
-          ((publication.title?.score ?? 0) + (publication.abstract?.score ?? 0) + (publication.authors?.score ?? 0)) /
-          3,
-      }))
-      .filter((entry) => entry.score >= 0.8);
-
-    logger.trace({ publications, uuid }, 'externalPublications');
-
-    if (publications.length > 0) return new SuccessResponse(publications).send(res);
-  }
-
-  return new SuccessResponse([]).send(res);
+  sendExternalPublicationsNotification(node);
+  return new SuccessResponse(entries).send(res);
 };
 
 export const addExternalPublication = async (req: RequestWithNode, res: Response, _next: NextFunction) => {
@@ -186,8 +112,23 @@ export const addExternalPublication = async (req: RequestWithNode, res: Response
   if (exists) return new SuccessMessageResponse().send(res);
 
   const entry = await prisma.externalPublications.create({
-    data: { doi, score, sourceUrl, publisher, publishYear, uuid: ensureUuidEndsWithDot(uuid) },
+    data: { doi, score, sourceUrl, publisher, publishYear, uuid: ensureUuidEndsWithDot(uuid), isVerified: true },
   });
 
   return new SuccessResponse(entry).send(res);
+};
+
+export const verifyExternalPublication = async (req: RequestWithNode, res: Response, _next: NextFunction) => {
+  const { uuid } = req.params as z.infer<typeof verifyExternalPublicationSchema>['params'];
+  const { verify, id } = req.body as z.infer<typeof verifyExternalPublicationSchema>['body'];
+
+  const node = await prisma.node.findFirst({ where: { uuid: ensureUuidEndsWithDot(uuid) } });
+  if (!node) throw new NotFoundError(`Node ${uuid} not found`);
+
+  await prisma.externalPublications.update({
+    where: { id: parseInt(id.toString()) },
+    data: { isVerified: verify, verifiedAt: new Date() },
+  });
+
+  return new SuccessMessageResponse().send(res);
 };

--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -8,6 +8,7 @@ import { logger as parentLogger } from '../../logger.js';
 import { delFromCache } from '../../redisClient.js';
 import { attestationService } from '../../services/Attestation.js';
 import { directStreamLookup } from '../../services/ceramic.js';
+import { sendExternalPublicationsNotification } from '../../services/crossRef/externalPublication.js';
 import { getManifestByCid } from '../../services/data/processing.js';
 import { getTargetDpidUrl } from '../../services/fixDpid.js';
 import { doiService } from '../../services/index.js';
@@ -182,6 +183,9 @@ export const publish = async (req: PublishRequest, res: Response<PublishResBody>
         });
       }
     }
+
+    // trigger external publications email if any
+    sendExternalPublicationsNotification(node);
 
     return res.send({
       ok: true,

--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -8,7 +8,10 @@ import { logger as parentLogger } from '../../logger.js';
 import { delFromCache } from '../../redisClient.js';
 import { attestationService } from '../../services/Attestation.js';
 import { directStreamLookup } from '../../services/ceramic.js';
-import { sendExternalPublicationsNotification } from '../../services/crossRef/externalPublication.js';
+import {
+  checkExternalPublications,
+  sendExternalPublicationsNotification,
+} from '../../services/crossRef/externalPublication.js';
 import { getManifestByCid } from '../../services/data/processing.js';
 import { getTargetDpidUrl } from '../../services/fixDpid.js';
 import { doiService } from '../../services/index.js';
@@ -185,7 +188,7 @@ export const publish = async (req: PublishRequest, res: Response<PublishResBody>
     }
 
     // trigger external publications email if any
-    sendExternalPublicationsNotification(node);
+    checkExternalPublications(node).then((_) => sendExternalPublicationsNotification(node));
 
     return res.send({
       ok: true,

--- a/desci-server/src/routes/v1/nodes.ts
+++ b/desci-server/src/routes/v1/nodes.ts
@@ -24,6 +24,8 @@ import {
   addExternalPublicationsSchema,
   externalPublications,
   externalPublicationsSchema,
+  verifyExternalPublication,
+  verifyExternalPublicationSchema,
 } from '../../controllers/nodes/externalPublications.js';
 import { feed } from '../../controllers/nodes/feed.js';
 import { frontmatterPreview } from '../../controllers/nodes/frontmatterPreview.js';
@@ -172,6 +174,11 @@ router.post(
   '/:uuid/external-publications',
   [validate(addExternalPublicationsSchema), ensureUser, ensureNodeAccess],
   asyncHandler(addExternalPublication),
+);
+router.post(
+  '/:uuid/verify-publication',
+  [validate(verifyExternalPublicationSchema), ensureUser, ensureNodeAccess],
+  asyncHandler(verifyExternalPublication),
 );
 
 router.get('/:uuid/comments', [ensureUser, validate(getCommentsSchema)], asyncHandler(getGeneralComments));

--- a/desci-server/src/scripts/pruneExternalPublications.ts
+++ b/desci-server/src/scripts/pruneExternalPublications.ts
@@ -1,0 +1,13 @@
+import { prisma } from '../client.js';
+
+const main = async () => {
+  const rows = await prisma.externalPublications.deleteMany({
+    // where: { verifiedAt: null },
+  });
+
+  return rows;
+};
+
+main()
+  .then((result) => console.log('ExternalPublications Pruned', result))
+  .catch((err) => console.log('Error running script ', err));

--- a/desci-server/src/services/crossRef/definitions.ts
+++ b/desci-server/src/services/crossRef/definitions.ts
@@ -51,6 +51,12 @@ export interface Work {
       URL: string; // 'http://onlinelibrary.wiley.com/termsAndConditions#vor';
     },
   ];
+  type: 'journal-article' | 'posted-content';
+  'short-container-title'?: string[];
+  'container-title'?: string[];
+  institution?: Array<{
+    name: string;
+  }>;
 }
 
 export interface Author {

--- a/desci-server/src/services/crossRef/externalPublication.ts
+++ b/desci-server/src/services/crossRef/externalPublication.ts
@@ -1,0 +1,196 @@
+import { ResearchObjectV1 } from '@desci-labs/desci-models';
+import { Node } from '@prisma/client';
+import sgMail from '@sendgrid/mail';
+import { Searcher } from 'fast-fuzzy';
+
+import { prisma } from '../../client.js';
+import { logger } from '../../logger.js';
+import { ExternalPublicationsEmailHtml } from '../../templates/emails/utils/emailRenderer.js';
+import { ensureUuidEndsWithDot } from '../../utils.js';
+import { crossRefClient } from '../index.js';
+import { NodeUuid } from '../manifestRepo.js';
+import repoService from '../repoService.js';
+
+import { Work } from './definitions.js';
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+const getPublisherTitle = (data: Work): string =>
+  data?.['container-title']?.[0] ||
+  data?.['short-container-title']?.[0] ||
+  data?.institution?.[0]?.name ||
+  data?.publisher;
+
+export const getExternalPublications = async (node: Node) => {
+  const manifest = await repoService.getDraftManifest({
+    uuid: node.uuid as NodeUuid,
+    documentId: node.manifestDocumentId,
+  });
+  let data = await crossRefClient.searchWorks({ queryTitle: manifest?.title });
+
+  data = data?.filter((works) => works.type === 'journal-article');
+
+  if (!data || data.length === 0) return [];
+
+  const titleSearcher = new Searcher(data, { keySelector: (entry) => entry.title });
+  const titleResult = titleSearcher.search(manifest.title, { returnMatchData: true });
+  // logger.trace(
+  //   {
+  //     data: titleResult.map((data) => ({
+  //       title: data.item.title,
+  //       publisher: data.item.publisher,
+  //       source_url: data.item?.resource?.primary?.URL || data.item.URL || '',
+  //       doi: data.item.DOI,
+  //       key: data.key,
+  //       match: data.match,
+  //       score: data.score,
+  //     })),
+  //   },
+  //   'Title search result',
+  // );
+
+  const descSearcher = new Searcher(data, { keySelector: (entry) => entry?.abstract ?? '' });
+  const descResult = descSearcher.search(manifest.description ?? '', { returnMatchData: true });
+  // logger.trace(
+  //   {
+  //     data: descResult.map((data) => ({
+  //       title: data.item.title,
+  //       key: data.key,
+  //       match: data.match,
+  //       score: data.score,
+  //       publisher: data.item.publisher,
+  //     })),
+  //   },
+  //   'Abstract search result',
+  // );
+
+  const authorsSearchScores = data.map((work) => {
+    const authorSearcher = new Searcher(work.author, { keySelector: (entry) => `${entry.given} ${entry.family}` });
+
+    const nodeAuthorsMatch = manifest.authors.map((author) =>
+      authorSearcher.search(author.name, { returnMatchData: true }),
+    );
+    return {
+      publisher: getPublisherTitle(work),
+      score: nodeAuthorsMatch.flat().reduce((total, match) => (total += match.score), 0) / manifest.authors.length,
+      match: nodeAuthorsMatch.flat().map((data) => ({
+        key: data.key,
+        match: data.match,
+        score: data.score,
+        author: data.item,
+        publisher: getPublisherTitle(work),
+        doi: work.DOI,
+      })),
+    };
+  });
+
+  // logger.trace(
+  //   {
+  //     data: descResult.map((data) => ({
+  //       title: data.item.title,
+  //       key: data.key,
+  //       match: data.match,
+  //       score: data.score,
+  //       publisher: data.item.publisher,
+  //     })),
+  //   },
+  //   'Authors search result',
+  // );
+
+  const publications = data
+    .map((data) => ({
+      publisher: getPublisherTitle(data),
+      sourceUrl: data?.resource?.primary?.URL || data.URL || '',
+      doi: data.DOI,
+      isVerified: false,
+      'is-referenced-by-count': data['is-referenced-by-count'] ?? 0,
+      publishYear:
+        data.published['date-parts']?.[0]?.[0].toString() ??
+        data.license
+          .map((licence) => licence.start['date-parts']?.[0]?.[0])
+          .filter(Boolean)?.[0]
+          .toString(),
+      title: titleResult
+        .filter((res) => getPublisherTitle(res.item) === getPublisherTitle(data))
+        .map((data) => ({
+          title: data.item.title,
+          key: data.key,
+          match: data.match,
+          score: data.score,
+        }))?.[0],
+      abstract: descResult
+        .filter((res) => getPublisherTitle(res.item) === getPublisherTitle(data))
+        .map((data) => ({
+          key: data.key,
+          match: data.match,
+          score: data.score,
+          abstract: data.item?.abstract ?? '',
+        }))?.[0],
+      authors: authorsSearchScores
+        .filter((res) => res.publisher === getPublisherTitle(data))
+        .map((data) => ({
+          score: data.score,
+          authors: data.match,
+        }))?.[0],
+    }))
+    .map((publication) => ({
+      ...publication,
+      score:
+        ((publication.title?.score ?? 0) + (publication.abstract?.score ?? 0) + (publication.authors?.score ?? 0)) / 3,
+    }))
+    .filter((entry) => entry.score >= 0.8);
+
+  logger.trace({ publications }, 'externalPublications');
+
+  return publications;
+};
+
+export const sendExternalPublicationsNotification = async (node: Node) => {
+  const publications = await getExternalPublications(node);
+
+  if (!publications.length) return;
+
+  await prisma.externalPublications.createMany({
+    skipDuplicates: true,
+    data: publications.map((pub) => ({
+      doi: pub.doi,
+      score: pub.score,
+      sourceUrl: pub.sourceUrl,
+      publisher: pub.publisher,
+      publishYear: pub.publishYear,
+      uuid: ensureUuidEndsWithDot(node.uuid),
+      isVerified: false,
+    })),
+  });
+
+  // send email to node owner about potential publications
+  const user = await prisma.user.findFirst({ where: { id: node.ownerId } });
+  const message = {
+    to: user.email,
+    from: 'no-reply@desci.com',
+    subject: `[nodes.desci.com] Verify your external publications`,
+    text: `${
+      publications.length > 1
+        ? `We found a similar publications to ${node.title}, View your publication to verify external publications`
+        : `We linked ${publications.length} external publications from publishers like ${publications[0].publisher} to your node, open your node to verify the external publication.`
+    }`,
+    html: ExternalPublicationsEmailHtml({
+      dpid: node.dpidAlias.toString(),
+      dpidPath: `${process.env.DAPP_URL}/dpid/${node.dpidAlias}`,
+      publisherName: publications[0].publisher,
+      multiple: publications.length > 1,
+    }),
+  };
+
+  try {
+    logger.info({ message, NODE_ENV: process.env.NODE_ENV }, '[EMAIL]:: ExternalPublications EMAIL');
+    if (process.env.SHOULD_SEND_EMAIL) {
+      const response = await sgMail.send(message);
+      logger.info(response, '[EMAIL]:: Response');
+    } else {
+      logger.info({ nodeEnv: process.env.NODE_ENV }, message.subject);
+    }
+  } catch (err) {
+    logger.info({ err }, '[ExternalPublications EMAIL]::ERROR');
+  }
+};

--- a/desci-server/src/templates/emails/ExternalPublications.tsx
+++ b/desci-server/src/templates/emails/ExternalPublications.tsx
@@ -1,0 +1,87 @@
+import {
+  Body,
+  Container,
+  Column,
+  Head,
+  Heading,
+  Html,
+  Preview,
+  Row,
+  Text,
+  Button,
+  Section,
+  render,
+} from '@react-email/components';
+import * as React from 'react';
+
+import MainLayout from './MainLayout.js';
+
+export interface ExternalPublicationsEmailProps {
+  dpid: string;
+  dpidPath: string;
+  publisherName: string;
+  multiple: boolean;
+}
+
+export const ExternalPublicationsEmail = ({
+  dpid,
+  dpidPath,
+  publisherName,
+  multiple,
+}: ExternalPublicationsEmailProps) => (
+  <MainLayout footerMsg="">
+    <Html>
+      <Head />
+      <Preview>
+        External publication{multiple ? `s` : ``} found DPID://{dpid}
+      </Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Heading style={h1} className="text-center !text-black">
+            {multiple
+              ? `View your publication to verify external publications`
+              : `We linked an external publication from ${publisherName} to your node`}
+          </Heading>
+          <Section className="mx-auto w-fit my-5 bg-[#dadce0] rounded-md px-14 py-3" align="center">
+            <Button
+              href={dpidPath}
+              className="backdrop-blur-2xl rounded-sm"
+              style={{
+                color: 'white',
+                padding: '10px 20px',
+                marginRight: '10px',
+                // backdropFilter: 'blur(20px)',
+                background: '#28aac4',
+                // backgroundOpacity: '0.5',
+              }}
+            >
+              View Node
+            </Button>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  </MainLayout>
+);
+
+export default ExternalPublicationsEmail;
+
+const main = {
+  backgroundColor: '#ffffff',
+  margin: '0 auto',
+  fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+
+const container = {
+  margin: '0 auto',
+  padding: '0px 20px',
+};
+
+const h1 = {
+  // color: '#000000',
+  fontSize: '30px',
+  fontWeight: '700',
+  margin: '30px 0',
+  padding: '0',
+  lineHeight: '42px',
+};

--- a/desci-server/src/templates/emails/utils/emailRenderer.tsx
+++ b/desci-server/src/templates/emails/utils/emailRenderer.tsx
@@ -3,6 +3,7 @@ import { render } from '@react-email/components';
 import AttestationClaimedEmail, { AttestationClaimedEmailProps } from '../AttestationClaimed.js';
 import ContributorInvite, { ContributorInviteEmailProps } from '../ContributorInvite.js';
 import DoiMintedEmail, { DoiMintedEmailProps } from '../DoiMinted.js';
+import ExternalPublications, { ExternalPublicationsEmailProps } from '../ExternalPublications.js';
 import MagicCodeEmail, { MagicCodeEmailProps } from '../MagicCode.js';
 import NodeUpdated, { NodeUpdatedEmailProps } from '../NodeUpdated.js';
 import SubmissionPackage, { SubmissionPackageEmailProps } from '../SubmissionPackage.js';
@@ -25,5 +26,8 @@ export const AttestationClaimedEmailHtml = (props: AttestationClaimedEmailProps)
 export const NodeUpdatedEmailHtml = (props: NodeUpdatedEmailProps) => render(NodeUpdated(props));
 
 export const SubmissionPackageEmailHtml = (props: SubmissionPackageEmailProps) => render(SubmissionPackage(props));
+
+export const ExternalPublicationsEmailHtml = (props: ExternalPublicationsEmailProps) =>
+  render(ExternalPublications(props));
 
 export const DoiMintedEmailHtml = (props: DoiMintedEmailProps) => render(DoiMintedEmail(props));

--- a/sync-server/src/index.ts
+++ b/sync-server/src/index.ts
@@ -141,7 +141,7 @@ export class AutomergeServer extends PartyServer {
   }
 
   async onRequest(request: Request) {
-    console.log('Incoming Request', request.url);
+    console.log('Incoming Request', request.method, request.url);
 
     if (request.headers.get('x-api-key') != this.env.API_TOKEN) {
       console.log('[Error]::Api key error', { api: this.env.API_TOKEN, key: request.headers.get('x-api-key') });
@@ -157,7 +157,7 @@ export class AutomergeServer extends PartyServer {
       return this.getLatestDocument(request);
     }
 
-    return new Response('Method not allowed', { status: 405 });
+    return new Response('Method not allowed', { status: 404 });
   }
 
   onMessage(connection: Connection, message: WSMessage): void | Promise<void> {
@@ -179,7 +179,7 @@ export class AutomergeServer extends PartyServer {
 
   async getLatestDocument(request) {
     const documentId = request.url.split('/').pop() as DocumentId;
-    console.log('getLatestDocument: ', { documentId });
+    console.log(`getLatestDocument: ${documentId}`, { documentId });
     if (!documentId) {
       console.error('No DocumentID found');
       return new Response(JSON.stringify({ ok: false, message: 'Invalid body' }), { status: 400 });
@@ -263,7 +263,7 @@ async function handleCreateDocument(request: Request, env: Env) {
 
 export default {
   fetch(request: Request, env) {
-    console.log('Fetch handler: ', env, 'request api key: ', request.headers.get('x-api'));
+    console.log('Fetch handler: ', request.url, env);
     if (request.url.includes('/api/documents') && request.method.toLowerCase() === 'post')
       return handleCreateDocument(request, env);
 


### PR DESCRIPTION
Closes #<GH_issue_number>

### Note: DB migrations and `pruneExternalPublications`

## Description of the Problem / Feature
- Dispatch external publication check and Send email notification to publisher after a publish flow
- Cache external pub check
## Explanation of the solution

## Instructions on making this work

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
