### PR TITLE
Es Published nodes indexing bug fix

### DIFF
--- a/desci-server/src/services/ElasticNodesService.ts
+++ b/desci-server/src/services/ElasticNodesService.ts
@@ -156,6 +156,7 @@ async function fillAuthorData(manifestAuthors: ResearchObjectV1Author[]) {
       const firstHit = hits?.[0];
       return {
         ...firstHit?._source,
+        author_id: firstHit?._id,
       };
     });
 


### PR DESCRIPTION
## Description of the Problem / Feature
Author ID had a different field name compared to how the OA works are indexed, preventing an author filter from catching native nodes.
## Explanation of the solution
- Made the id field consistent with oa works
