### PR TITLE
models: use ipfs.desci.com in RO-Crate transformer gateway URLs

### DIFF
--- a/desci-models/package.json
+++ b/desci-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/desci-models",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Data models for DeSci Nodes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/desci-models/src/transformers/RoCrateTransformer.ts
+++ b/desci-models/src/transformers/RoCrateTransformer.ts
@@ -2,9 +2,6 @@ import { CreativeWork, Dataset, SoftwareSourceCode } from 'schema-dts';
 import {
   CommonComponentPayload,
   DataComponentMetadata,
-  DataComponentPayload,
-  PdfComponent,
-  PdfComponentPayload,
   ResearchObject,
   ResearchObjectComponentType,
   ResearchObjectV1,
@@ -13,12 +10,14 @@ import {
 } from '../ResearchObject';
 import { RoCrateGraph } from '../RoCrate';
 import { BaseTransformer } from './BaseTransformer';
-import { isNodeRoot, isResearchObjectComponentTypeMap } from '../trees/treeTools';
+import { isNodeRoot } from '../trees/treeTools';
 
-const IPFS_RESOLVER_HTTP = 'https://ipfs.io/ipfs/';
+const EXTERNAL_IPFS_RESOLVER_HTTP = 'https://ipfs.io/ipfs/';
 const cleanupUrlOrCid = (str: string) => {
-  return str?.replace(new RegExp(`^${IPFS_RESOLVER_HTTP}`), '');
+  return str?.replace(new RegExp(`^${EXTERNAL_IPFS_RESOLVER_HTTP}`), '');
 };
+
+const DESCI_IPFS_RESOLVER_HTTP = 'https://ipfs.desci.com/ipfs/';
 
 const formatOrcid = (str: string | undefined) => {
   if (!str) {
@@ -178,7 +177,7 @@ export class RoCrateTransformer implements BaseTransformer {
       };
       creativeWork.encodingFormat = 'application/pdf';
       (creativeWork as any)['/'] = cleanupUrlOrCid((component.payload as any).url);
-      creativeWork.url = `https://ipfs.io/ipfs/${cleanupUrlOrCid((component.payload as any).url)}`;
+      creativeWork.url = `${DESCI_IPFS_RESOLVER_HTTP}${cleanupUrlOrCid((component.payload as any).url)}`;
       creativeWork['@type'] = 'CreativeWork';
       crateComponent = creativeWork;
     } else if (component.type === ResearchObjectComponentType.CODE) {
@@ -188,7 +187,7 @@ export class RoCrateTransformer implements BaseTransformer {
       softwareSourceCode.encodingFormat = 'text/plain';
 
       (softwareSourceCode as any)['/'] = cleanupUrlOrCid(component.payload.url);
-      softwareSourceCode.url = `https://ipfs.io/ipfs/${cleanupUrlOrCid(component.payload.url)}`;
+      softwareSourceCode.url = `${DESCI_IPFS_RESOLVER_HTTP}${cleanupUrlOrCid(component.payload.url)}`;
       softwareSourceCode.discussionUrl = component.payload.externalUrl;
       softwareSourceCode['@type'] = 'SoftwareSourceCode';
       crateComponent = softwareSourceCode;
@@ -214,7 +213,7 @@ export class RoCrateTransformer implements BaseTransformer {
       }
       dataset.encodingFormat = 'application/octet-stream';
       (dataset as any)['/'] = cleanupUrlOrCid((component.payload as any).url || (component.payload as any).cid);
-      dataset.url = `https://ipfs.io/ipfs/${cleanupUrlOrCid(
+      dataset.url = `${DESCI_IPFS_RESOLVER_HTTP}${cleanupUrlOrCid(
         (component.payload as any).url || (component.payload as any).cid,
       )}`;
       dataset['@type'] = 'Dataset';

--- a/desci-models/src/transformers/RoCrateTransformer.ts
+++ b/desci-models/src/transformers/RoCrateTransformer.ts
@@ -12,9 +12,8 @@ import { RoCrateGraph } from '../RoCrate';
 import { BaseTransformer } from './BaseTransformer';
 import { isNodeRoot } from '../trees/treeTools';
 
-const EXTERNAL_IPFS_RESOLVER_HTTP = 'https://ipfs.io/ipfs/';
 const cleanupUrlOrCid = (str: string) => {
-  return str?.replace(new RegExp(`^${EXTERNAL_IPFS_RESOLVER_HTTP}`), '');
+  return str?.replace(new RegExp(`^http.*/ipfs/`), '');
 };
 
 const DESCI_IPFS_RESOLVER_HTTP = 'https://ipfs.desci.com/ipfs/';

--- a/desci-models/tests/example-data/exampleNode.json
+++ b/desci-models/tests/example-data/exampleNode.json
@@ -8,7 +8,7 @@
       "name": "Example PDF",
       "type": "pdf",
       "payload": {
-        "url": "https://ipfs.io/ipfs/bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy",
+        "url": "https://ipfs.desci.com/ipfs/bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy",
         "/": "bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy"
       }
     },
@@ -18,7 +18,7 @@
       "type": "code",
       "payload": {
         "externalUrl": "https://github.com/hubsmoke/rhapsody-in-blue",
-        "url": "https://ipfs.io/ipfs/bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i",
+        "url": "https://ipfs.desci.com/ipfs/bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i",
         "/": "bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i"
       }
     },
@@ -28,7 +28,7 @@
       "type": "data",
       "payload": {
         "cid": "bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m",
-        "url": "https://ipfs.io/ipfs/bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m",
+        "url": "https://ipfs.desci.com/ipfs/bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m",
         "/": "bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m"
       }
     }

--- a/desci-models/tests/example-data/exampleNodeToRoCrate.json
+++ b/desci-models/tests/example-data/exampleNodeToRoCrate.json
@@ -4,13 +4,21 @@
     {
       "@id": "ro-crate-metadata.json",
       "@type": "CreativeWork",
-      "about": { "@id": "./" },
-      "conformsTo": { "@id": "https://w3id.org/ro/crate/1.1" }
+      "about": {
+        "@id": "./"
+      },
+      "conformsTo": {
+        "@id": "https://w3id.org/ro/crate/1.1"
+      }
     },
     {
       "@id": "./",
       "@type": "CreativeWork",
-      "creator": [{ "@id": "https://orcid.org/0000-0001-2345-6789" }],
+      "creator": [
+        {
+          "@id": "https://orcid.org/0000-0001-2345-6789"
+        }
+      ],
       "license": "https://creativecommons.org/licenses/by/4.0/",
       "name": "Test dataset",
       "url": "https://beta.dpid.org/123"
@@ -26,7 +34,7 @@
       "@type": "CreativeWork",
       "encodingFormat": "application/pdf",
       "name": "Example PDF",
-      "url": "https://ipfs.io/ipfs/bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy"
+      "url": "https://ipfs.desci.com/ipfs/bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy"
     },
     {
       "/": "bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i",
@@ -35,7 +43,7 @@
       "discussionUrl": "https://github.com/hubsmoke/rhapsody-in-blue",
       "encodingFormat": "text/plain",
       "name": "Example Code",
-      "url": "https://ipfs.io/ipfs/bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i"
+      "url": "https://ipfs.desci.com/ipfs/bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i"
     },
     {
       "/": "bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m",
@@ -43,7 +51,7 @@
       "@type": "Dataset",
       "encodingFormat": "application/octet-stream",
       "name": "Example Data",
-      "url": "https://ipfs.io/ipfs/bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m"
+      "url": "https://ipfs.desci.com/ipfs/bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m"
     }
   ]
 }

--- a/desci-models/tests/transformers/RoCrateTransformer.test.ts
+++ b/desci-models/tests/transformers/RoCrateTransformer.test.ts
@@ -81,7 +81,7 @@ describe('RoCrateTransformer', () => {
 
     expect(pdfComponent).to.not.be.undefined;
     expect(pdfComponent.url).to.equal(
-      'https://ipfs.io/ipfs/bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy',
+      'https://ipfs.desci.com/ipfs/bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy',
     );
     expect((pdfComponent as any)['/']).to.equal('bafybeic3ach4ibambafznjsa3p446ghds3hp7742fkisldroe4wt6q5bsy');
   });
@@ -99,7 +99,7 @@ describe('RoCrateTransformer', () => {
     expect(codeComponent).to.not.be.undefined;
     expect(codeComponent['/']).to.equal('bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i');
     expect(codeComponent.url).to.equal(
-      'https://ipfs.io/ipfs/bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i',
+      'https://ipfs.desci.com/ipfs/bafybeibzxn2il4q7att4bf3lvrcc2peovcdokv3jsbzne5v6ad5tr6mi6i',
     );
   });
 
@@ -113,7 +113,7 @@ describe('RoCrateTransformer', () => {
 
     expect(dataComponent).to.not.be.undefined;
     expect(dataComponent.url).to.equal(
-      'https://ipfs.io/ipfs/bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m',
+      'https://ipfs.desci.com/ipfs/bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m',
     );
     expect(dataComponent['/']).to.equal('bafybeigzwjr6xkcdy4b7rrtzbbpwq3isx3zaesfopnpr3bqld3uddc5k3m');
   });


### PR DESCRIPTION
The generated HTTP gateway links for drive tree components doesn't resolve on ipfs.io 