### PR TITLE
fix: sending duplicate internal error response

### DIFF
--- a/desci-server/src/controllers/doi/check.ts
+++ b/desci-server/src/controllers/doi/check.ts
@@ -67,5 +67,4 @@ export const retrieveDoi = async (req: Request, res: Response, _next: NextFuncti
     logger.warn({ doiQuery, error: e }, 'Error fetching DOI metadata from openAlex');
     new InternalErrorResponse('Error fetching DOI metadata from openAlex').send(res);
   }
-  new InternalErrorResponse('Error fetching DOI metadata from openAlex').send(res);
 };


### PR DESCRIPTION
## Description of the Problem / Feature
- Duplicate http `response.send` accounts for `>1.1k` errors from sentry report

[Sentry Issue](https://desci-labs.sentry.io/issues/6076488528/?notification_uuid=9d43d283-ebda-4f2a-8772-2a4761e135f3&project=6619754&referrer=weekly_report)
