### PR TITLE
Add resolution attempts to DOI submission queue to limit retries

### DIFF
--- a/desci-server/prisma/migrations/20250320105957_doi_queue_attempts/migration.sql
+++ b/desci-server/prisma/migrations/20250320105957_doi_queue_attempts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DoiSubmissionQueue" ADD COLUMN     "attempts" INTEGER DEFAULT 0;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -985,6 +985,7 @@ model DoiSubmissionQueue {
   doi          DoiRecord? @relation(fields: [doiRecordId], references: [id])
   notification Json?
   status       DoiStatus  @default(PENDING)
+  attempts     Int?       @default(0)
   uniqueDoi    String     @unique
   uuid         String
   node         Node       @relation(fields: [uuid], references: [uuid])

--- a/desci-server/src/services/Doi.ts
+++ b/desci-server/src/services/Doi.ts
@@ -327,6 +327,7 @@ export class DoiService {
       {
         status: DoiStatus.SUCCESS,
         doiRecordId: doiRecord.id,
+        attempts: submission.attempts + 1,
       },
     );
 

--- a/desci-server/src/workers/doiSubmissionQueue.ts
+++ b/desci-server/src/workers/doiSubmissionQueue.ts
@@ -61,6 +61,15 @@ export const onTick = async () => {
             },
           });
         }
+      } else {
+        // mark doi task as failed after 10 attempts
+        await doiService.updateSubmission(
+          { id: job.id },
+          {
+            attempts: job.attempts + 1,
+            status: job.attempts > 9 ? 'FAILED' : job.status,
+          },
+        );
       }
       return { doi: job.uniqueDoi, jobId: job.id, isResolved };
     } catch (err) {


### PR DESCRIPTION
## Description of the Problem / Feature
- We have a lot of failed DOI resolution attempts from calls to DOIs that might never be resolved in the DOI submission queue

## Explanation of the solution
- Add a database column to track the number of attempts
- Mark DOI status as failed after 5 attempts

## Note: PR has pending database migrations