### PR TITLE
Published nodes api & email link

### DIFF
--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -1343,13 +1343,13 @@ export class AttestationService {
       to: member.user.email,
       from: 'no-reply@desci.com',
       subject: `[nodes.desci.com] ${versionedAttestation.name} claimed on DPID://${nodeDpid}/v${nodeVersion + 1}`,
-      text: `${user.name} just claimed ${versionedAttestation.name} on ${process.env.DAPP_URL}/dpid/${nodeDpid}/v${nodeVersion + 1}/attestations/${nodeAttestation.id}`,
+      text: `${user.name} just claimed ${versionedAttestation.name} on ${process.env.DAPP_URL}/dpid/${nodeDpid}/v${nodeVersion + 1}/badges`,
       html: AttestationClaimedEmailHtml({
         dpid: nodeDpid,
         attestationName: versionedAttestation.name,
         communityName: versionedAttestation.name,
         userName: user.name,
-        dpidPath: `${process.env.DAPP_URL}/dpid/${nodeDpid}/v${nodeVersion + 1}/attestations/${nodeAttestation.id}`,
+        dpidPath: `${process.env.DAPP_URL}/dpid/${nodeDpid}/v${nodeVersion + 1}/badges`,
       }),
     }));
 

--- a/desci-server/src/utils/manifest.ts
+++ b/desci-server/src/utils/manifest.ts
@@ -9,7 +9,7 @@ import axios from 'axios';
 
 import { PUBLIC_IPFS_PATH } from '../config/index.js';
 import { logger as parentLogger } from '../logger.js';
-import { getOrCache } from '../redisClient.js';
+import { DEFAULT_TTL, getFromCache, getOrCache, ONE_WEEK_TTL, setToCache } from '../redisClient.js';
 import { hexToCid, isCid } from '../utils.js';
 
 const IPFS_RESOLVER_OVERRIDE = process.env.IPFS_RESOLVER_OVERRIDE;
@@ -70,6 +70,29 @@ export const cachedGetDpidFromManifest = async (cid: string, gateway?: string) =
   } else {
     return manifestDpid;
   }
+};
+
+export const cachedGetManifest = async (cid: string, gateway?: string) => {
+  let manifest = (await getFromCache(`manifest-${cid}`)) as ResearchObjectV1;
+
+  if (!manifest) {
+    manifest = (await resolveNodeManifest(cid, gateway)) as ResearchObjectV1;
+    await setToCache(`manifest-${cid}`, manifest, DEFAULT_TTL);
+  }
+  return manifest;
+};
+
+export const cachedGetManifestAndDpid = async (cid: string, gateway?: string) => {
+  const manifest = await cachedGetManifest(cid, gateway);
+  if (!manifest) return undefined;
+
+  let manifestDpid = manifest.dpid ? parseInt(manifest.dpid.id) : -1;
+
+  if (manifestDpid === -1) {
+    manifestDpid = await getFromCache(`manifest-dpid-${cid}`);
+    await setToCache(`manifest-dpid-${cid}`, manifest, DEFAULT_TTL);
+  }
+  return { manifest, dpid: manifestDpid };
 };
 
 export const zeropad = (data: string) => (data.length < 2 ? `0${data}` : data);


### PR DESCRIPTION
Closes #<GH_issue_number>

## Description of the Problem / Feature
- Published nodes list api uses draft manifest title 
- Emails notifying members of badges claim is outdated, it looks like this: https://nodes-dev.desci.com/dpid/1091/v1/attestations/open-data Instead it should look like this: https://nodes-dev.desci.com/dpid/1091/v1/badges

