### PR TITLE
Submission Rejection reason

### DIFF
--- a/desci-models/package.json
+++ b/desci-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/desci-models",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Data models for DeSci Nodes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/desci-models/src/actions.ts
+++ b/desci-models/src/actions.ts
@@ -83,4 +83,6 @@ export enum AvailableUserActionLogTypes {
   publishCheckPermissionsError = 'publishCheckPermissionsError',
   automergeError = 'automergeError',
   publishError = 'publishError',
+  rejectCommunitySubmission = 'rejectCommunitySubmission',
+  declineAttestationClaim = 'declineAttestationClaim',
 }

--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -67,7 +67,7 @@
     "@aws-sdk/client-s3": "^3.537.0",
     "@desci-labs/desci-codex-lib": "^1.1.7",
     "@desci-labs/desci-contracts": "^0.2.7",
-    "@desci-labs/desci-models": "^0.2.22",
+    "@desci-labs/desci-models": "^0.2.24",
     "@elastic/elasticsearch": "^8.14.0",
     "@honeycombio/opentelemetry-node": "^0.3.2",
     "@ipld/dag-pb": "^4.0.0",

--- a/desci-server/prisma/migrations/20250326110833_rejection_reason/migration.sql
+++ b/desci-server/prisma/migrations/20250326110833_rejection_reason/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CommunitySubmission" ADD COLUMN     "rejectionReason" TEXT;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -850,19 +850,20 @@ model CommunityRadarEntry {
 }
 
 model CommunitySubmission {
-  id          Int              @id @default(autoincrement())
-  communityId Int
-  community   DesciCommunity   @relation(fields: [communityId], references: [id])
-  nodeId      String
-  node        Node             @relation(fields: [nodeId], references: [uuid])
-  nodeVersion Int?
-  userId      Int
-  user        User             @relation(fields: [userId], references: [id])
-  status      Submissionstatus @default(PENDING)
-  acceptedAt  DateTime?
-  rejectedAt  DateTime?
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
+  id              Int              @id @default(autoincrement())
+  communityId     Int
+  community       DesciCommunity   @relation(fields: [communityId], references: [id])
+  nodeId          String
+  node            Node             @relation(fields: [nodeId], references: [uuid])
+  nodeVersion     Int?
+  userId          Int
+  user            User             @relation(fields: [userId], references: [id])
+  status          Submissionstatus @default(PENDING)
+  rejectionReason String?
+  acceptedAt      DateTime?
+  rejectedAt      DateTime?
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
 
   @@unique([nodeId, communityId])
 }

--- a/desci-server/src/controllers/attestations/show.ts
+++ b/desci-server/src/controllers/attestations/show.ts
@@ -40,6 +40,7 @@ export const showNodeAttestations = async (
   let attestations = await attestationService.getAllNodeAttestations(uuid);
   attestations = attestations.map((att) => ({
     ...att,
+    community: { ...att.community, CommunityMember: undefined, members: att.community.CommunityMember },
     revokedAt: undefined,
     _count: undefined,
     node: undefined,

--- a/desci-server/src/routes/v1/communities/submissions-schema.ts
+++ b/desci-server/src/routes/v1/communities/submissions-schema.ts
@@ -46,3 +46,14 @@ export const getSubmissionSchema = z.object({
     submissionId: z.coerce.number(),
   }),
 });
+
+// Schema for getting a single submission
+export const rejectSubmissionSchema = z.object({
+  params: z.object({
+    submissionId: z.coerce.number(),
+  }),
+  body: z.object({
+    reason: z.string().optional(),
+    status: z.enum([Submissionstatus.PENDING, Submissionstatus.ACCEPTED, Submissionstatus.REJECTED]),
+  }),
+});

--- a/desci-server/src/services/Attestation.ts
+++ b/desci-server/src/services/Attestation.ts
@@ -329,7 +329,16 @@ export class AttestationService {
     return prisma.nodeAttestation.findMany({
       where: { nodeUuid: ensureUuidEndsWithDot(uuid), revoked: false },
       include: {
-        community: { select: { name: true, description: true, keywords: true, image_url: true } },
+        community: {
+          select: {
+            name: true,
+            description: true,
+            slug: true,
+            keywords: true,
+            image_url: true,
+            CommunityMember: { select: { id: true, role: true, user: { select: { id: true, name: true } } } },
+          },
+        },
         attestation: { select: { protected: true, verified_image_url: true } },
         attestationVersion: { select: { name: true, description: true, image_url: true } },
         node: { select: { ownerId: true } },

--- a/desci-server/src/services/Communities.ts
+++ b/desci-server/src/services/Communities.ts
@@ -879,6 +879,8 @@ export class CommunityService {
         data: {
           status: Submissionstatus.PENDING,
           nodeVersion,
+          rejectedAt: null,
+          rejectionReason: null,
         },
         select: {
           id: true,
@@ -974,13 +976,13 @@ export class CommunityService {
     });
   }
 
-  async updateSubmissionStatus(id: number, status: Submissionstatus) {
+  async updateSubmissionStatus(id: number, status: Submissionstatus, rejectionReason?: string) {
     return await prisma.communitySubmission.update({
       where: { id },
       data: {
         status: status as Submissionstatus,
         ...(status === 'ACCEPTED' ? { acceptedAt: new Date() } : {}),
-        ...(status === 'REJECTED' ? { rejectedAt: new Date() } : {}),
+        ...(status === 'REJECTED' ? { rejectedAt: new Date(), rejectionReason } : {}),
       },
       include: {
         node: { select: { id: true, uuid: true, title: true, ownerId: true, dpidAlias: true } },

--- a/desci-server/src/services/email.ts
+++ b/desci-server/src/services/email.ts
@@ -1,11 +1,13 @@
+import { CommunitySubmission, DesciCommunity, User } from '@prisma/client';
 import sgMail from '@sendgrid/mail';
 
 import { logger as parentLogger } from '../logger.js';
-import { DoiMintedEmailHtml } from '../templates/emails/utils/emailRenderer.js';
+import { DoiMintedEmailHtml, RejectedSubmissionEmailHtml } from '../templates/emails/utils/emailRenderer.js';
 
 export enum EmailTypes {
   DoiMinted,
   DOI_REGISTRATION_REQUESTED,
+  RejectedSubmission,
 }
 
 type DoiRegisteredPayload = {
@@ -18,7 +20,24 @@ type DoiRequestedPayload = {
   payload: { to: string; subject: string; name: string };
 };
 
-export type EmailProps = DoiRegisteredPayload | DoiRequestedPayload;
+type RejectSubmissionPayload = {
+  type: EmailTypes.RejectedSubmission;
+  payload: {
+    // to: string;
+    // subject: string;
+    // name: string;
+    dpid: string;
+    recipient: {
+      email: string;
+      name: string;
+    };
+    submission: CommunitySubmission & {
+      community: DesciCommunity;
+    };
+  };
+};
+
+export type EmailProps = DoiRegisteredPayload | DoiRequestedPayload | RejectSubmissionPayload;
 
 const logger = parentLogger.child({ module: 'EmailService' });
 
@@ -59,12 +78,41 @@ async function sendDoiRequested(payload: DoiRequestedPayload['payload']) {
   //
 }
 
+async function sendRejectSubmissionEmail({ submission, dpid, recipient }: RejectSubmissionPayload['payload']) {
+  const message = {
+    to: recipient.email,
+    from: 'no-reply@desci.com',
+    subject: `[nodes.desci.com] Your submission to ${submission.community.name} for DPID://${dpid}/v${submission.nodeVersion} was rejected `,
+    text: `Hi ${recipient.name}, your submission to ${submission.community.name} was rejected.`,
+    html: RejectedSubmissionEmailHtml({
+      dpid: dpid.toString(),
+      communityName: submission.community.name,
+      userName: recipient.name,
+      dpidPath: `${process.env.DAPP_URL}/dpid/${dpid}/v${submission.nodeVersion}/badges`,
+      communityPage: `${process.env.DAPP_URL}/community/${submission.community.slug}?tab=mysubmissions`,
+    }),
+  };
+
+  try {
+    if (process.env.NODE_ENV === 'production') {
+      const response = await sgMail.send(message);
+      logger.trace(response, '[EMAIL]:: Response');
+    } else {
+      logger.info({ nodeEnv: process.env.NODE_ENV }, message.subject);
+    }
+  } catch (err) {
+    logger.error({ err }, '[ERROR]:: RejectedSubmission EMAIL');
+  }
+}
+
 export const sendEmail = async (props: EmailProps) => {
   switch (props.type) {
     case EmailTypes.DoiMinted:
       return sendDoiRegisteredEmail(props.payload);
     case EmailTypes.DOI_REGISTRATION_REQUESTED:
       return sendDoiRequested(props.payload);
+    case EmailTypes.RejectedSubmission:
+      return sendRejectSubmissionEmail(props.payload);
     default:
       assertNever(props);
   }

--- a/desci-server/src/templates/emails/RejectSubmission.tsx
+++ b/desci-server/src/templates/emails/RejectSubmission.tsx
@@ -1,0 +1,87 @@
+import { Body, Container, Head, Heading, Html, Preview, Text, Button, Section } from '@react-email/components';
+import * as React from 'react';
+
+import MainLayout from './MainLayout.js';
+
+export interface RejectSubmissionEmailProps {
+  dpid: string;
+  dpidPath: string;
+  userName: string;
+  communityName: string;
+  reason?: string;
+  communityPage: string;
+}
+
+export const RejectSubmissionEmail = ({
+  dpid,
+  dpidPath,
+  userName,
+  reason,
+  communityName,
+  communityPage,
+}: RejectSubmissionEmailProps) => (
+  <MainLayout footerMsg="">
+    <Html>
+      <Head />
+      <Preview>
+        Your submission to {communityName} for DPID://{dpid} was rejected
+      </Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Heading style={h1} className="text-center !text-black">
+            Hi {userName}, your submission to {communityName} was rejected.
+          </Heading>
+          <Section className="mx-auto w-fit my-5 bg-[#dadce0] rounded-md px-14 py-3" align="center">
+            <Text>Reason for submission: {reason ? reason : 'Not stated'}</Text>
+            <Button
+              href={dpidPath}
+              className="backdrop-blur-2xl rounded-sm"
+              style={{
+                color: 'white',
+                padding: '10px 20px',
+                marginRight: '10px',
+                background: '#28aac4',
+              }}
+            >
+              View Node
+            </Button>
+            <Button
+              href={communityPage}
+              className="backdrop-blur-2xl rounded-sm"
+              style={{
+                color: 'white',
+                padding: '10px 20px',
+                marginRight: '10px',
+                background: '#28aac4',
+              }}
+            >
+              View Submission
+            </Button>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  </MainLayout>
+);
+
+export default RejectSubmissionEmail;
+
+const main = {
+  backgroundColor: '#ffffff',
+  margin: '0 auto',
+  fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+
+const container = {
+  margin: '0 auto',
+  padding: '0px 20px',
+};
+
+const h1 = {
+  // color: '#000000',
+  fontSize: '30px',
+  fontWeight: '700',
+  margin: '30px 0',
+  padding: '0',
+  lineHeight: '42px',
+};

--- a/desci-server/src/templates/emails/utils/emailRenderer.tsx
+++ b/desci-server/src/templates/emails/utils/emailRenderer.tsx
@@ -6,6 +6,7 @@ import DoiMintedEmail, { DoiMintedEmailProps } from '../DoiMinted.js';
 import ExternalPublications, { ExternalPublicationsEmailProps } from '../ExternalPublications.js';
 import MagicCodeEmail, { MagicCodeEmailProps } from '../MagicCode.js';
 import NodeUpdated, { NodeUpdatedEmailProps } from '../NodeUpdated.js';
+import RejectSubmissionEmail, { RejectSubmissionEmailProps } from '../RejectSubmission.js';
 import SubmissionPackage, { SubmissionPackageEmailProps } from '../SubmissionPackage.js';
 
 export const ContributorInviteEmailHtml = ({
@@ -31,3 +32,5 @@ export const ExternalPublicationsEmailHtml = (props: ExternalPublicationsEmailPr
   render(ExternalPublications(props));
 
 export const DoiMintedEmailHtml = (props: DoiMintedEmailProps) => render(DoiMintedEmail(props));
+
+export const RejectedSubmissionEmailHtml = (props: RejectSubmissionEmailProps) => render(RejectSubmissionEmail(props));

--- a/desci-server/yarn.lock
+++ b/desci-server/yarn.lock
@@ -2021,10 +2021,10 @@
   resolved "https://registry.yarnpkg.com/@desci-labs/desci-contracts/-/desci-contracts-0.2.7.tgz#4047e52e405c361f0c1723bb966364ccc2dfb865"
   integrity sha512-T5XhH0qn7z93jb9MlGd68i4mf0tJP+ppfyWKfFBjp+dCUC4GeTMM3Z/6eqaD8QXsBpvRfi+cvb0or3BY47MR2A==
 
-"@desci-labs/desci-models@^0.2.22":
-  version "0.2.22"
-  resolved "https://registry.yarnpkg.com/@desci-labs/desci-models/-/desci-models-0.2.22.tgz#d380d80a2593f4d5ce23e933a54bdae04f83a995"
-  integrity sha512-CALUEXxCvqSgzn+KeyiUJ+ohEMeJxYRxZUcIQbTT/1NdFg9SSsToZx/HNwhp6JD+XdJ8yzn4I8rSimvfYHa0yg==
+"@desci-labs/desci-models@^0.2.24":
+  version "0.2.24"
+  resolved "https://registry.yarnpkg.com/@desci-labs/desci-models/-/desci-models-0.2.24.tgz#f0befb9f14e37bd56e186dcedab643e38e4a3972"
+  integrity sha512-jzv+WxoA/NCjCGRmALDef9otTye9Qc1yhKpuhYp1Iv24ehUQkoLfDpM27rKRYXcHA9KLqAhMYrN4xHTOtQB0rg==
   dependencies:
     jsonld "^8.1.1"
     schema-dts "^1.1.2"


### PR DESCRIPTION
Closes #842 

## Description of the Problem / Feature
- Update to endpoint to add message before rejecting community submission
- Extend payload for community object(add slug & communityMembers array) in attestation endpoint

## Explanation of the solution
- Update api logic for rejection submission
- Add rejection reason to db schema
- Add email service for notifying users of rejection
- Update attestations endpoint response shape include slug and members)

## Instructions on making this work
- Run database migrations