### PR TITLE
fix: analytics time range

### DIFF
--- a/desci-server/src/controllers/admin/analytics.ts
+++ b/desci-server/src/controllers/admin/analytics.ts
@@ -354,7 +354,7 @@ export const getAggregatedAnalytics = async (req: RequestWithUser, res: Response
   const endDate = to;
   logger.trace({ fn: 'getAggregatedAnalytics', diffInDays, from, to, startDate, endDate }, 'getAggregatedAnalytics');
 
-  const selectedDates = { from: startOfDay(startDate), to: startOfDay(new Date(to)) };
+  const selectedDates = { from: startOfDay(startDate), to: endOfDay(new Date(to)) };
   const selectedDatesInterval = interval(from, to);
 
   const cacheKey = `aggregateAnalytics-${startOfDay(from).toDateString()}-${endOfDay(selectedDates.to).toDateString()}-${timeInterval}`;


### PR DESCRIPTION
Closes #<GH_issue_number>

## Description of the Problem / Feature
- I'm seeing something weird in our admin overview: The first page shows right now that we already have 6 new users today. But in the analytics view, the number of new users for today and yesterday is zero. Other charts in that view also report 0 for the last two days. I'm guessing something is broken with the analytics charts.  Can you guys check this out, please? 

## Explanation of the solution
- pull data from start to end of day of the date range
