### PR TITLE
fix: uncaught errors in sync server

### DIFF
--- a/desci-repo/src/controllers/nodes/documents.ts
+++ b/desci-repo/src/controllers/nodes/documents.ts
@@ -3,17 +3,17 @@ import os from 'os';
 import { Doc } from '@automerge/automerge';
 import { AutomergeUrl, DocHandleEphemeralMessagePayload, DocumentId, PeerId, Repo } from '@automerge/automerge-repo';
 import { ManifestActions, ResearchObjectV1 } from '@desci-labs/desci-models';
-import { json, Request, Response } from 'express';
-import WebSocket from 'isomorphic-ws';
+import { Request, Response } from 'express';
+// import WebSocket from 'isomorphic-ws';
 import { ZodError } from 'zod';
 
 import { ENABLE_PARTYKIT_FEATURE, IS_DEV, IS_TEST, PARTY_SERVER_HOST, PARTY_SERVER_TOKEN } from '../../config.js';
 import { findNodeByUuid } from '../../db/index.js';
-import { PartykitNodeWsAdapter } from '../../lib/PartykitNodeWsAdapter.js';
+// import { PartykitNodeWsAdapter } from '../../lib/PartykitNodeWsAdapter.js';
 import { logger as parentLogger } from '../../logger.js';
 import { RequestWithNode } from '../../middleware/guard.js';
 import { backendRepo, repoManager } from '../../repo.js';
-import { getAutomergeUrl, getDocumentHandle, getDocumentUpdater } from '../../services/manifestRepo.js';
+import { getAutomergeUrl, getDocumentUpdater } from '../../services/manifestRepo.js';
 import { ResearchObjectDocument } from '../../types.js';
 import { actionsSchema } from '../../validators/schema.js';
 


### PR DESCRIPTION
Closes #<GH_issue_number>

## Description of the Problem / Feature
- Sentry reports uncaught error and failed requests in sync server requests
- In cases where hyperdrive fails http requests to sync server crashes and never returns any error

## Explanation of the solution
- add proper error handling to `AutomergeClass` methods 
