### PR TITLE
Community get submissions api route auth removal

### DIFF
--- a/desci-server/src/controllers/communities/submissions.ts
+++ b/desci-server/src/controllers/communities/submissions.ts
@@ -55,7 +55,7 @@ export const getCommunitySubmissions = async (req: RequestWithUser, res: Respons
   // Check if user is a member of the community
   const isMember = await prisma.communityMember.findFirst({
     where: {
-      userId: req.user.id,
+      userId: req?.user?.id,
       communityId: Number(communityId),
     },
   });

--- a/desci-server/src/routes/v1/communities/index.ts
+++ b/desci-server/src/routes/v1/communities/index.ts
@@ -15,6 +15,7 @@ import { checkMemberGuard } from '../../../controllers/communities/guard.js';
 import { listCommunities } from '../../../controllers/communities/list.js';
 import { getCommunityRadar, listCommunityRadar } from '../../../controllers/communities/radar.js';
 import { getCommunitySubmissions } from '../../../controllers/communities/submissions.js';
+import { attachUser } from '../../../middleware/attachUser.js';
 import { ensureUser } from '../../../middleware/permissions.js';
 import { validate } from '../../../middleware/validator.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
@@ -26,7 +27,6 @@ import {
   memberGuardSchema,
 } from './schema.js';
 import { getCommunitySubmissionsSchema } from './submissions-schema.js';
-import submissionsRouter from './submissions.js';
 
 const router = Router();
 
@@ -56,7 +56,7 @@ router.post('/:communityId/memberGuard', [ensureUser, validate(memberGuardSchema
 
 router.get(
   '/:communityId/submissions',
-  [ensureUser, validate(getCommunitySubmissionsSchema)],
+  [attachUser, validate(getCommunitySubmissionsSchema)],
   asyncHandler(getCommunitySubmissions),
 );
 


### PR DESCRIPTION
Closes #<GH_issue_number>

## Description of the Problem / Feature
- when not logged in, none of community research page loads
## Explanation of the solution
- fix: remove user auth requirement for community submission api route
## Instructions on making this work

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
