### PR TITLE
skip fields in community list for faster / smaller response

### DIFF
--- a/desci-server/src/controllers/communities/list.ts
+++ b/desci-server/src/controllers/communities/list.ts
@@ -9,31 +9,43 @@ import { asyncMap } from '../../utils.js';
 const logger = parentLogger.child({ module: 'LIST COMMUNITIES' });
 
 export const listCommunities = async (_req: Request, res: Response, _next: NextFunction) => {
+  const { skip } = _req.query;
+  logger.info({ skip });
+  const skipArray = (skip as string)?.split(',') || [];
   const allCommunities = await communityService.getCommunities();
+  const skipMembers = skipArray.includes('members');
+  const skipDescription = skipArray.includes('description');
+  const skipMetrics = skipArray.includes('metrics');
+  const skipKeywords = skipArray.includes('keywords');
   const pickedCommunities = allCommunities.map((community) =>
     _.pick(community, [
       'id',
       'name',
       'subtitle',
-      'memberString',
+      ...(skipMembers ? [] : ['memberString']),
       'hidden',
       'links',
-      'description',
+      ...(skipDescription ? [] : ['description']),
       'image_url',
-      'keywords',
+      ...(skipKeywords ? [] : ['keywords']),
       'slug',
     ]),
   );
 
-  const communities = await asyncMap(pickedCommunities, async (community) => {
-    const engagements = await communityService.getCommunityEngagementSignals(community.id);
-    const verifiedEngagements = await communityService.getCommunityRadarEngagementSignal(community.id);
-    return {
-      community,
-      engagements,
-      verifiedEngagements,
-    };
-  });
+  let communities = pickedCommunities.map((community) => ({
+    community,
+  }));
+  if (!skipMetrics) {
+    communities = await asyncMap(pickedCommunities, async (community) => {
+      const engagements = await communityService.getCommunityEngagementSignals(community.id);
+      const verifiedEngagements = await communityService.getCommunityRadarEngagementSignal(community.id);
+      return {
+        community,
+        engagements,
+        verifiedEngagements,
+      };
+    });
+  }
   logger.info({ communities: communities.length });
 
   new SuccessResponse(communities).send(res);


### PR DESCRIPTION
## Description of the Problem / Feature
Communities list response is bloated sometimes unnecessarily taking up to 1-2s to load

## Explanation of the solution
add a skip querystring option

http://localhost:5420/v1/communities/list?skip=description,members,keywords,metrics

## Instructions on making this work
add skip param to web requests that don't need all fields