### PR TITLE
Try v2 aws-cli in build/push image GHA flow

### DIFF
--- a/.github/workflows/build-server.yaml
+++ b/.github/workflows/build-server.yaml
@@ -93,7 +93,7 @@ jobs:
       - id: install-aws-cli
         uses: unfor19/install-aws-cli-action@v1
         with:
-          version: 1
+          version: 2
 
       - uses: prepor/action-aws-iam-authenticator@master
       - run: aws-iam-authenticator version


### PR DESCRIPTION
## Description of the Problem / Feature
- Deployments failing, likely due to some version shift down the line.
## Explanation of the solution
- Try a newer version of install-aws-cli-action, which is failing currently

