### PR TITLE
Logout Adjustment - Remove old domain scoped cookies

### DIFF
--- a/desci-server/kubernetes/deployment_dev.yaml
+++ b/desci-server/kubernetes/deployment_dev.yaml
@@ -41,6 +41,7 @@ spec:
           export JWT_EXPIRATION=15m
           export SESSION_KEY={{ .Data.SESSION_KEY }}
           export COOKIE_DOMAIN={{ .Data.COOKIE_DOMAIN }}
+          export OLD_COOKIE_DOMAINS={{ .Data.OLD_COOKIE_DOMAINS }}
           export ORCID_API_DOMAIN={{ .Data.ORCID_API_DOMAIN }}
           export DPID_URL_OVERRIDE={{ .Data.DPID_URL_OVERRIDE }}
           export ORCID_CLIENT_ID={{ .Data.ORCID_CLIENT_ID }}

--- a/desci-server/kubernetes/deployment_prod.yaml
+++ b/desci-server/kubernetes/deployment_prod.yaml
@@ -40,6 +40,7 @@ spec:
           export JWT_EXPIRATION=15m
           export SESSION_KEY={{ .Data.SESSION_KEY }}
           export COOKIE_DOMAIN={{ .Data.COOKIE_DOMAIN }}
+          export OLD_COOKIE_DOMAINS={{ .Data.OLD_COOKIE_DOMAINS }}
           export ORCID_API_DOMAIN={{ .Data.ORCID_API_DOMAIN }}
           export ORCID_CLIENT_ID={{ .Data.ORCID_CLIENT_ID }}
           export ORCID_CLIENT_SECRET={{ .Data.ORCID_CLIENT_SECRET }}

--- a/desci-server/kubernetes/deployment_staging.yaml
+++ b/desci-server/kubernetes/deployment_staging.yaml
@@ -52,6 +52,7 @@ spec:
           export JWT_EXPIRATION=15m
           export SESSION_KEY={{ .Data.SESSION_KEY }}
           export COOKIE_DOMAIN={{ .Data.COOKIE_DOMAIN }}
+          export OLD_COOKIE_DOMAINS={{ .Data.OLD_COOKIE_DOMAINS }}
           export ORCID_API_DOMAIN={{ .Data.ORCID_API_DOMAIN }}
           export ORCID_CLIENT_ID={{ .Data.ORCID_CLIENT_ID }}
           export ORCID_CLIENT_SECRET={{ .Data.ORCID_CLIENT_SECRET }}

--- a/desci-server/src/controllers/auth/logout.ts
+++ b/desci-server/src/controllers/auth/logout.ts
@@ -1,40 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 
-import { AUTH_COOKIE_FIELDNAME } from '../../utils/sendCookie.js';
+import { AUTH_COOKIE_FIELDNAME, removeCookie } from '../../utils/sendCookie.js';
 
 export const logout = async (req: Request, res: Response, next: NextFunction) => {
-  // req.session.destroy((err) => {
-  // if you send data here it gives an error and kills the process lol
-  // });
-  res.cookie(AUTH_COOKIE_FIELDNAME, 'unset', {
-    maxAge: 0,
-    httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
-    secure: process.env.NODE_ENV === 'production',
-    domain: process.env.NODE_ENV === 'production' ? '.desci.com' : 'localhost',
-    sameSite: 'none',
-    path: '/',
-  });
-
-  (process.env.COOKIE_DOMAIN?.split(',') || [undefined]).map((domain) => {
-    res.cookie(AUTH_COOKIE_FIELDNAME, 'unset', {
-      maxAge: 0,
-      httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response
-      secure: process.env.NODE_ENV === 'production',
-      domain: process.env.NODE_ENV === 'production' ? domain || '.desci.com' : 'localhost',
-      sameSite: 'none',
-      path: '/',
-    });
-  });
-
-  if (process.env.SERVER_URL === 'https://nodes-api-dev.desci.com') {
-    // insecure cookie for local dev, should only be used for testing
-    res.cookie(AUTH_COOKIE_FIELDNAME, 'unset', {
-      maxAge: 0,
-      httpOnly: true,
-      sameSite: 'none',
-      path: '/',
-    });
-  }
-
+  removeCookie(res, AUTH_COOKIE_FIELDNAME);
   res.send('Logged out successfully');
+  return;
 };

--- a/desci-server/src/utils/sendCookie.ts
+++ b/desci-server/src/utils/sendCookie.ts
@@ -16,6 +16,10 @@ const AUTH_COOKIE_DOMAIN_MAPPING = {
 // auth, auth-stage, auth-dev
 export const AUTH_COOKIE_FIELDNAME = AUTH_COOKIE_DOMAIN_MAPPING[process.env.SERVER_URL] || 'auth';
 const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || 'localhost';
+const OLD_COOKIE_DOMAINS = process.env.OLD_COOKIE_DOMAINS || '';
+
+// We remove old cookie domains, as they were sub-domain scoped and can prevent log out.
+const REMOVE_COOKIE_DOMAINS = [COOKIE_DOMAIN.split(','), OLD_COOKIE_DOMAINS.split(',')].flat().filter(Boolean);
 
 export const sendCookie = (res: Response, token: string, isDevMode: boolean, cookieName = AUTH_COOKIE_FIELDNAME) => {
   if (isDevMode && process.env.SERVER_URL === 'https://nodes-api-dev.desci.com') {
@@ -53,7 +57,7 @@ export const removeCookie = (res: Response, cookieName: string) => {
     path: '/',
   });
 
-  (COOKIE_DOMAIN.split(',') || [undefined]).map((domain) => {
+  REMOVE_COOKIE_DOMAINS?.map((domain) => {
     res.cookie(cookieName, 'unset', {
       maxAge: 0,
       httpOnly: true, // Ineffective whilst we still return the bearer token to the client in the response


### PR DESCRIPTION
## Description of the Problem / Feature
- Cookie domains were adjusted to only scope to the top domain
- Users logged in with sub-domain scoped cookies would have a hard time logging out if the logout route no longer clears the removed domains
## Explanation of the solution
- Added env to preserve old domains that will also be included in the cookie delete endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for removing authentication cookies from legacy domains during logout to prevent stale cookies from persisting.
- **Chores**
  - Updated deployment configurations to include a new environment variable for legacy cookie domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->