### PR TITLE
fix: peg analytics interval to start of selected date

### DIFF
--- a/desci-server/src/controllers/admin/analytics.ts
+++ b/desci-server/src/controllers/admin/analytics.ts
@@ -514,7 +514,9 @@ export const getAggregatedAnalytics = async (req: RequestWithUser, res: Response
             : null;
       }
     };
+
     const allDatesInInterval = getIntervals();
+    logger.trace({ allDatesInInterval }, 'allDatesInInterval');
 
     aggregatedData = allDatesInInterval.map((period) => {
       const selectedDatesInterval =
@@ -551,8 +553,13 @@ export const getAggregatedAnalytics = async (req: RequestWithUser, res: Response
       const badgeVerificationsAgg = badgeVerifications.filter((log) =>
         isWithinInterval(log.createdAt, selectedDatesInterval),
       );
+
+      const peggedPeriod = isWithinInterval(period, interval(selectedDates.from, selectedDates.to))
+        ? period
+        : selectedDates.from;
+
       return {
-        date: period,
+        date: peggedPeriod,
         newUsers: newUsersAgg.length,
         newOrcidUsers: newOrcidUsersAgg.length,
         activeUsers: activeUsersAgg.length,


### PR DESCRIPTION
Closes #<GH_issue_number>

## Description of the Problem / Feature
- Triple check admin dashboard stats accuracy, add some backend tests
    - Preceding Period is always 0 or close to 0, seems wrong
    - Current week (latest week) seems to be 0 most times, which is wrong. If you switch to daily it looks better, but often the last day is 0
    
## Explanation of the solution
- For all analytics interval report, the start of the period should not be less than the start date queried

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of date values in aggregated analytics output for admin users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->