### PR TITLE
Optimize get submissions api

### DIFF
--- a/desci-server/src/controllers/communities/submissions.ts
+++ b/desci-server/src/controllers/communities/submissions.ts
@@ -73,6 +73,7 @@ export const getCommunitySubmissions = async (req: RequestWithUser, res: Respons
     limit: queryLimit,
     offset: queryOffset,
   });
+  logger.trace({ submissions }, 'SUBMISSIONS');
 
   // Get total count
   const totalCount = await communityService.getCommunitySubmissionsCount({
@@ -151,7 +152,15 @@ export const updateSubmissionStatus = async (req: RequestWithUser, res: Response
     // send user rejection email
     sendEmail({
       type: EmailTypes.RejectedSubmission,
-      payload: { dpid: dpid.toString(), reason, recipient, submission },
+      payload: {
+        dpid: dpid.toString(),
+        reason,
+        recipient,
+        communityName: submission.community.name,
+        communitySlug: submission.community.slug,
+        nodeVersion: submission.nodeVersion,
+        nodeDpid: dpid.toString(),
+      },
     });
   }
 

--- a/desci-server/src/controllers/communities/submissions.ts
+++ b/desci-server/src/controllers/communities/submissions.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { prisma } from '../../client.js';
 import { BadRequestError, ForbiddenError } from '../../core/ApiError.js';
 import { CreatedSuccessResponse, SuccessMessageResponse, SuccessResponse } from '../../core/ApiResponse.js';
+import { logger } from '../../logger.js';
 import { RequestWithNode, RequestWithUser } from '../../middleware/authorisation.js';
 import {
   createSubmissionSchema,
@@ -63,11 +64,14 @@ export const getCommunitySubmissions = async (req: RequestWithUser, res: Respons
 
   // logger.trace({ isMember }, 'isMember');
   // Get submissions
+  const queryLimit = limit ? Number(limit) : 10;
+  const queryOffset = offset !== undefined ? Number(offset) : undefined;
+  logger.trace({ queryLimit, queryOffset, isMember }, 'QUERY');
   const submissions = await communityService.getCommunitySubmissions({
     communityId: Number(communityId),
     status: isMember ? status : Submissionstatus.ACCEPTED,
-    limit: limit ? Number(limit) : 10,
-    offset: offset ? Number(offset) : undefined,
+    limit: queryLimit,
+    offset: queryOffset,
   });
 
   // Get total count
@@ -77,10 +81,10 @@ export const getCommunitySubmissions = async (req: RequestWithUser, res: Respons
   });
 
   const data = await asyncMap(submissions, async (submission) => {
-    const node = await getNodeDetails(submission.nodeId);
+    const node = await getNodeDetails(submission.node);
     return { ...submission, node: { ...submission.node, ...node } };
   });
-  new SuccessResponse({ submissions: data, totalCount }).send(res);
+  new SuccessResponse({ submissions: data, meta: { totalCount, offset: queryOffset, limit: queryLimit } }).send(res);
 };
 
 export const getUserSubmissions = async (req: RequestWithUser, res: Response) => {
@@ -101,10 +105,7 @@ export const updateSubmissionStatus = async (req: RequestWithUser, res: Response
   const { status, reason } = req.body as z.infer<typeof rejectSubmissionSchema>['body'];
 
   // Get submission and check if it exists
-  const submission = await prisma.communitySubmission.findUnique({
-    where: { id: Number(submissionId) },
-    include: { community: true },
-  });
+  const submission = await communityService.getSubmission(Number(submissionId));
 
   if (!submission) {
     throw new BadRequestError('Submission not found');
@@ -154,8 +155,8 @@ export const updateSubmissionStatus = async (req: RequestWithUser, res: Response
     });
   }
 
-  const node = await getNodeDetails(submission.nodeId);
-  new SuccessResponse({ ...updatedSubmission, ...node }).send(res);
+  const node = await getNodeDetails(submission.node);
+  new SuccessResponse({ ...updatedSubmission, node: { ...updatedSubmission.node, ...node } }).send(res);
 };
 
 export const getSubmission = async (req: RequestWithUser, res: Response) => {
@@ -180,9 +181,9 @@ export const getSubmission = async (req: RequestWithUser, res: Response) => {
     throw new ForbiddenError('Unauthorized to view this submission');
   }
 
-  const node = await getNodeDetails(submission.nodeId);
+  const node = await getNodeDetails(submission.node);
 
-  new SuccessResponse({ ...submission, ...node }).send(res);
+  new SuccessResponse({ ...submission, node: { ...submission.node, ...node } }).send(res);
 };
 
 export const cancelUserSubmission = async (req: RequestWithUser, res: Response) => {

--- a/desci-server/src/services/Communities.ts
+++ b/desci-server/src/services/Communities.ts
@@ -935,7 +935,18 @@ export class CommunityService {
         ...(status && { status: status as Submissionstatus }),
       },
       include: {
-        node: { select: { id: true, uuid: true, title: true, ownerId: true, dpidAlias: true } },
+        node: {
+          select: {
+            id: true,
+            uuid: true,
+            title: true,
+            ownerId: true,
+            dpidAlias: true,
+            legacyDpid: true,
+            manifestUrl: true,
+            manifestDocumentId: true,
+          },
+        },
         // community: { select: { id: true, name: true, image_url: true, description: true } },
       },
       orderBy: {
@@ -964,7 +975,18 @@ export class CommunityService {
         ...(status && { status: status as Submissionstatus }),
       },
       include: {
-        node: { select: { id: true, uuid: true, title: true, ownerId: true, dpidAlias: true } },
+        node: {
+          select: {
+            id: true,
+            uuid: true,
+            title: true,
+            ownerId: true,
+            dpidAlias: true,
+            legacyDpid: true,
+            manifestUrl: true,
+            manifestDocumentId: true,
+          },
+        },
         community: { select: { id: true, name: true, image_url: true, description: true } },
       },
     });
@@ -988,7 +1010,18 @@ export class CommunityService {
         // ...(status && { status: status as Submissionstatus }),
       },
       include: {
-        node: { select: { id: true, uuid: true, title: true, ownerId: true, dpidAlias: true } },
+        node: {
+          select: {
+            id: true,
+            uuid: true,
+            title: true,
+            ownerId: true,
+            dpidAlias: true,
+            legacyDpid: true,
+            manifestUrl: true,
+            manifestDocumentId: true,
+          },
+        },
         community: { select: { id: true, name: true, image_url: true, description: true } },
       },
     });
@@ -1019,7 +1052,18 @@ export class CommunityService {
     return prisma.communitySubmission.findUnique({
       where: { id: submissionId },
       include: {
-        node: { select: { id: true, uuid: true, title: true, ownerId: true, dpidAlias: true } },
+        node: {
+          select: {
+            id: true,
+            uuid: true,
+            title: true,
+            ownerId: true,
+            dpidAlias: true,
+            legacyDpid: true,
+            manifestUrl: true,
+            manifestDocumentId: true,
+          },
+        },
         community: { select: { id: true, name: true, image_url: true, description: true } },
       },
     });

--- a/desci-server/src/services/email.ts
+++ b/desci-server/src/services/email.ts
@@ -1,4 +1,4 @@
-import { CommunitySubmission, DesciCommunity, User } from '@prisma/client';
+import { CommunitySubmission, DesciCommunity, Node, User } from '@prisma/client';
 import sgMail from '@sendgrid/mail';
 
 import { logger as parentLogger } from '../logger.js';
@@ -33,7 +33,8 @@ type RejectSubmissionPayload = {
       name: string;
     };
     submission: CommunitySubmission & {
-      community: DesciCommunity;
+      community: Partial<DesciCommunity>;
+      node: Partial<Node>;
     };
   };
 };

--- a/desci-server/src/services/email.ts
+++ b/desci-server/src/services/email.ts
@@ -32,10 +32,14 @@ type RejectSubmissionPayload = {
       email: string;
       name: string;
     };
-    submission: CommunitySubmission & {
-      community: Partial<DesciCommunity>;
-      node: Partial<Node>;
-    };
+    communityName: string;
+    communitySlug: string;
+    nodeVersion: number;
+    nodeDpid: string;
+    // submission: CommunitySubmission & {
+    //   community: Partial<DesciCommunity>;
+    //   node: Partial<Node>;
+    // };
   };
 };
 
@@ -80,19 +84,27 @@ async function sendDoiRequested(payload: DoiRequestedPayload['payload']) {
   //
 }
 
-async function sendRejectSubmissionEmail({ submission, dpid, reason, recipient }: RejectSubmissionPayload['payload']) {
+async function sendRejectSubmissionEmail({
+  communityName,
+  communitySlug,
+  nodeVersion,
+  nodeDpid,
+  dpid,
+  reason,
+  recipient,
+}: RejectSubmissionPayload['payload']) {
   const message = {
     to: recipient.email,
     from: 'no-reply@desci.com',
-    subject: `[nodes.desci.com] Your submission to ${submission.community.name} for DPID://${dpid}/v${submission.nodeVersion} was rejected `,
-    text: `Hi ${recipient.name}, your submission to ${submission.community.name} was rejected.`,
+    subject: `[nodes.desci.com] Your submission to ${communityName} for DPID://${nodeDpid}/v${nodeVersion} was rejected `,
+    text: `Hi ${recipient.name}, your submission to ${communityName} was rejected.`,
     html: RejectedSubmissionEmailHtml({
       reason,
       dpid: dpid.toString(),
-      communityName: submission.community.name,
+      communityName,
       userName: recipient.name,
-      dpidPath: `${process.env.DAPP_URL}/dpid/${dpid}/v${submission.nodeVersion}/badges`,
-      communityPage: `${process.env.DAPP_URL}/community/${submission.community.slug}?tab=mysubmissions`,
+      dpidPath: `${process.env.DAPP_URL}/dpid/${dpid}/v${nodeVersion}/badges`,
+      communityPage: `${process.env.DAPP_URL}/community/${communitySlug}?tab=mysubmissions`,
     }),
   };
 

--- a/desci-server/src/services/node.ts
+++ b/desci-server/src/services/node.ts
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import { prisma } from '../client.js';
 import { logger as parentLogger } from '../logger.js';
+import { getFromCache, setToCache } from '../redisClient.js';
 import { cleanupManifestUrl } from '../utils/manifest.js';
 import { ensureUuidEndsWithDot } from '../utils.js';
 
@@ -121,35 +122,31 @@ export const countPublishedNodesInRange = async (range: { from: Date; to: Date }
   return publishes;
 };
 
-export const getNodeDetails = async (nodeUuid: string) => {
+const NODE_DETAILS_CACHE_KEY = `NODE_DETAILS_CACHE_KEY`;
+
+export interface NodeDetails {
+  versions?: number;
+  publishedDate?: Date;
+  manifestUrl?: string;
+  dpid?: number;
+  dpidAlias?: number;
+  authors?: any[];
+}
+
+export const getNodeDetails = async (discovery: Partial<Node>) => {
+  if (!discovery) return {};
+
   const logger = parentLogger.child({ module: 'getNodeDetails' });
-  const uuid = ensureUuidEndsWithDot(nodeUuid);
 
-  const discovery = await prisma.node.findFirst({
-    where: {
-      uuid,
-      isDeleted: false,
-    },
-    select: {
-      id: true,
-      manifestUrl: true,
-      ownerId: true,
-      uuid: true,
-      title: true,
-      NodeCover: true,
-      dpidAlias: true,
-      legacyDpid: true,
-      manifestDocumentId: true,
-    },
-  });
+  const cacheKey = `${NODE_DETAILS_CACHE_KEY}_${discovery.id}`;
 
-  if (!discovery) {
-    logger.warn({ uuid }, 'uuid not found');
-  }
+  const cachedDetails = await getFromCache<NodeDetails>(cacheKey);
+  logger.trace({ cacheKey, hit: !!cachedDetails }, 'CACHE check');
+  if (cachedDetails) return cachedDetails;
 
   const selectAttributes: (keyof typeof discovery)[] = [
+    'uuid',
     'ownerId',
-    'NodeCover',
     'dpidAlias',
     'manifestDocumentId',
     'legacyDpid',
@@ -158,32 +155,34 @@ export const getNodeDetails = async (nodeUuid: string) => {
   const publishedVersions =
     (await prisma.$queryRaw`SELECT * from "NodeVersion" where "nodeId" = ${discovery.id} AND ("transactionId" IS NOT NULL or "commitId" IS NOT NULL) ORDER BY "createdAt" DESC`) as NodeVersion[];
 
-  const data: { [key: string]: any } = {};
+  const data: Record<string, any> = {};
   logger.info({ uuid: discovery.uuid, publishedVersions }, 'Resolve node');
+
   data['versions'] = publishedVersions.length;
-  data['publishedDate'] = publishedVersions[0].createdAt;
-  node.manifestUrl = publishedVersions[0].manifestUrl;
-  // data.node = node;
+  data['publishedDate'] = publishedVersions?.[0].createdAt;
+  data.manifestUrl = publishedVersions?.[0].manifestUrl;
   data.dpid = node.dpidAlias || node.legacyDpid;
   data.dpidAlias = node.dpidAlias || node.legacyDpid; // Ensure dpidAlias is set using legacy dpid if not present
 
-  let gatewayUrl = publishedVersions[0].manifestUrl;
-
   try {
     const manifest = await repoService.getDraftManifest({
-      uuid: uuid as NodeUuid,
+      uuid: node.uuid as NodeUuid,
       documentId: node.manifestDocumentId,
     });
     logger.info({ manifestFound: !!manifest }, '[SHOW API GET LAST PUBLISHED MANIFEST]');
     data.authors = manifest.authors;
   } catch (err) {
-    gatewayUrl = cleanupManifestUrl(gatewayUrl);
-    // logger.trace({ gatewayUrl, uuid }, 'transforming manifest');
-    const manifest = (await axios.get(gatewayUrl)).data;
-    data.authors = manifest.authors;
-
+    let gatewayUrl = publishedVersions?.[0].manifestUrl;
+    if (gatewayUrl !== undefined) {
+      gatewayUrl = cleanupManifestUrl(gatewayUrl);
+      // logger.trace({ gatewayUrl, uuid }, 'transforming manifest');
+      const manifest = (await axios.get(gatewayUrl)).data;
+      data.authors = manifest.authors;
+    }
     logger.error({ err, manifestUrl: discovery.manifestUrl, gatewayUrl }, 'nodes/show.ts: failed to preload manifest');
   }
+
+  await setToCache(cacheKey, data);
   return data;
 };
 


### PR DESCRIPTION
## Description of the Problem / Feature
- the way community submissions API is implemented is slow because there is an asyncMap that does a database call for each node, instead you should do a DB join if you can

## Explanation of the solution
- Optimize db calls
- cache calls t getNodeDetails
- refactor code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Community submissions responses now include enhanced pagination metadata (`totalCount`, `offset`, `limit`).
  - Additional node details (`legacyDpid`, `manifestUrl`, `manifestDocumentId`) are now available in community and user submission data.

- **Improvements**
  - Node detail retrieval is more consistent and now leverages caching for better performance.
  - Logging added for query parameters and membership status in community submissions.
  - Rejection emails now include specific community and node information for clarity.

- **Bug Fixes**
  - Improved handling and nesting of node details in API responses.

- **Chores**
  - Updated type definitions and email payloads to use explicit community and node properties instead of nested objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->