### PR TITLE
openalex: use SQL array for works_authorships.institution_ids

### DIFF
--- a/openalex-importer/README.md
+++ b/openalex-importer/README.md
@@ -107,7 +107,7 @@ npm run migrate
 
 ### Introspect Remote OpenAlex Schema
 
-> [!WARNING]  
+> [!WARNING]
 > This overwrites the `schema.ts` file, which has multiple change to indices and keys.
 > Only do this to reset the base state, and be ready to rebuild the migrations directory.
 
@@ -136,7 +136,7 @@ schema by setting it to `text_ops`.
 
 ### Manually generate batches migration
 
-> [!NOTE]  
+> [!NOTE]
 > This shouldn't be necessary now that `drizzle.config.ts` includes both schemas.
 
 ```bash
@@ -239,7 +239,7 @@ Not all OA datatypes are fully supported, the table below shows the status of ea
 | works_primary_locations | ✅      |                                       |
 | works_locations         | ✅      | no unique constraint available        |
 | works_best_oa_locations | ✅      |                                       |
-| works_authorships       | ❌      |                                       |
+| works_authorships       | ✅      | institution_ids accumulated in array  |
 | works_topics            | ✅      | maps work -> topic ID                 |
 | works_concepts          | ✅      | maps work -> concept ID               |
 | works_ids               | ✅      |                                       |

--- a/openalex-importer/drizzle/migrations/0010_nappy_dormammu.sql
+++ b/openalex-importer/drizzle/migrations/0010_nappy_dormammu.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "openalex"."works_authorships" ADD COLUMN "institution_ids" text[] DEFAULT '{}';--> statement-breakpoint
+ALTER TABLE "openalex"."works_authorships" DROP COLUMN "institution_id";

--- a/openalex-importer/drizzle/migrations/meta/0010_snapshot.json
+++ b/openalex-importer/drizzle/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2008 @@
+{
+  "id": "93eb937d-cf30-42ec-b4eb-70a198ca9681",
+  "prevId": "f0aa00fa-9bba-4514-b291-4e2ca8d33ceb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "openalex.authors": {
+      "name": "authors",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "orcid": {
+          "name": "orcid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_alternatives": {
+          "name": "display_name_alternatives",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_institution": {
+          "name": "last_known_institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.authors_counts_by_year": {
+      "name": "authors_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authors_counts_by_year_author_id_year_pk": {
+          "name": "authors_counts_by_year_author_id_year_pk",
+          "columns": [
+            "author_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.authors_ids": {
+      "name": "authors_ids",
+      "schema": "openalex",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orcid": {
+          "name": "orcid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopus": {
+          "name": "scopus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts": {
+      "name": "concepts",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_thumbnail_url": {
+          "name": "image_thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descriptions_embeddings": {
+          "name": "descriptions_embeddings",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_embeddings": {
+          "name": "name_embeddings",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_ancestors": {
+      "name": "concepts_ancestors",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ancestor_id": {
+          "name": "ancestor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_counts_by_year": {
+      "name": "concepts_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "concepts_counts_by_year_concept_id_year_pk": {
+          "name": "concepts_counts_by_year_concept_id_year_pk",
+          "columns": [
+            "concept_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_ids": {
+      "name": "concepts_ids",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "umls_aui": {
+          "name": "umls_aui",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "umls_cui": {
+          "name": "umls_cui",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_related_concepts": {
+      "name": "concepts_related_concepts",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_concept_id": {
+          "name": "related_concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "concepts_related_concepts_concept_id_related_concept_id_pk": {
+          "name": "concepts_related_concepts_concept_id_related_concept_id_pk",
+          "columns": [
+            "concept_id",
+            "related_concept_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions": {
+      "name": "institutions",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ror": {
+          "name": "ror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_thumbnail_url": {
+          "name": "image_thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_acronyms": {
+          "name": "display_name_acronyms",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_alternatives": {
+          "name": "display_name_alternatives",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_associated_institutions": {
+      "name": "institutions_associated_institutions",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "associated_institution_id": {
+          "name": "associated_institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "institutions_associated_institutions_institution_id_associated_institution_id_pk": {
+          "name": "institutions_associated_institutions_institution_id_associated_institution_id_pk",
+          "columns": [
+            "institution_id",
+            "associated_institution_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_counts_by_year": {
+      "name": "institutions_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "institutions_counts_by_year_institution_id_year_pk": {
+          "name": "institutions_counts_by_year_institution_id_year_pk",
+          "columns": [
+            "institution_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_geo": {
+      "name": "institutions_geo",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geonames_city_id": {
+          "name": "geonames_city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_ids": {
+      "name": "institutions_ids",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ror": {
+          "name": "ror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grid": {
+          "name": "grid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.publishers": {
+      "name": "publishers",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternate_titles": {
+          "name": "alternate_titles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_codes": {
+          "name": "country_codes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_level": {
+          "name": "hierarchy_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_publisher": {
+          "name": "parent_publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources_api_url": {
+          "name": "sources_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.publishers_counts_by_year": {
+      "name": "publishers_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "publishers_counts_by_year_publisher_id_year_pk": {
+          "name": "publishers_counts_by_year_publisher_id_year_pk",
+          "columns": [
+            "publisher_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.publishers_ids": {
+      "name": "publishers_ids",
+      "schema": "openalex",
+      "columns": {
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ror": {
+          "name": "ror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.sources": {
+      "name": "sources",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issn_l": {
+          "name": "issn_l",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_in_doaj": {
+          "name": "is_in_doaj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.sources_counts_by_year": {
+      "name": "sources_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sources_counts_by_year_source_id_year_pk": {
+          "name": "sources_counts_by_year_source_id_year_pk",
+          "columns": [
+            "source_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.sources_ids": {
+      "name": "sources_ids",
+      "schema": "openalex",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn_l": {
+          "name": "issn_l",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fatcat": {
+          "name": "fatcat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.topics": {
+      "name": "topics",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subfield_id": {
+          "name": "subfield_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subfield_display_name": {
+          "name": "subfield_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_display_name": {
+          "name": "field_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_display_name": {
+          "name": "domain_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia_id": {
+          "name": "wikipedia_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siblings": {
+          "name": "siblings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works": {
+      "name": "works",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_year": {
+          "name": "publication_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_retracted": {
+          "name": "is_retracted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_paratext": {
+          "name": "is_paratext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_api_url": {
+          "name": "cited_by_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abstract_inverted_index": {
+          "name": "abstract_inverted_index",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_authorships": {
+      "name": "works_authorships",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_position": {
+          "name": "author_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_ids": {
+          "name": "institution_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "raw_affiliation_string": {
+          "name": "raw_affiliation_string",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_authorships_work_id_author_id_pk": {
+          "name": "works_authorships_work_id_author_id_pk",
+          "columns": [
+            "work_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_best_oa_locations": {
+      "name": "works_best_oa_locations",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landing_page_url": {
+          "name": "landing_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_biblio": {
+      "name": "works_biblio",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue": {
+          "name": "issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_page": {
+          "name": "first_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_page": {
+          "name": "last_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_concepts": {
+      "name": "works_concepts",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_concepts_work_id_concept_id_pk": {
+          "name": "works_concepts_work_id_concept_id_pk",
+          "columns": [
+            "work_id",
+            "concept_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_ids": {
+      "name": "works_ids",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pmcid": {
+          "name": "pmcid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_locations": {
+      "name": "works_locations",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landing_page_url": {
+          "name": "landing_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "locations_work_id_idx": {
+          "name": "locations_work_id_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_mesh": {
+      "name": "works_mesh",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descriptor_ui": {
+          "name": "descriptor_ui",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descriptor_name": {
+          "name": "descriptor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifier_ui": {
+          "name": "qualifier_ui",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifier_name": {
+          "name": "qualifier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_major_topic": {
+          "name": "is_major_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_mesh_work_id_descriptor_ui_qualifier_ui_pk": {
+          "name": "works_mesh_work_id_descriptor_ui_qualifier_ui_pk",
+          "columns": [
+            "work_id",
+            "descriptor_ui",
+            "qualifier_ui"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_open_access": {
+      "name": "works_open_access",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_status": {
+          "name": "oa_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_url": {
+          "name": "oa_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "any_repository_has_fulltext": {
+          "name": "any_repository_has_fulltext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "works_open_access_is_oa_idx": {
+          "name": "works_open_access_is_oa_idx",
+          "columns": [
+            {
+              "expression": "is_oa",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_primary_locations": {
+      "name": "works_primary_locations",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landing_page_url": {
+          "name": "landing_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_referenced_works": {
+      "name": "works_referenced_works",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenced_work_id": {
+          "name": "referenced_work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_referenced_works_work_id_referenced_work_id_pk": {
+          "name": "works_referenced_works_work_id_referenced_work_id_pk",
+          "columns": [
+            "work_id",
+            "referenced_work_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_related_works": {
+      "name": "works_related_works",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_work_id": {
+          "name": "related_work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_related_works_work_id_related_work_id_pk": {
+          "name": "works_related_works_work_id_related_work_id_pk",
+          "columns": [
+            "work_id",
+            "related_work_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_topics": {
+      "name": "works_topics",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_topics_work_id_topic_id_pk": {
+          "name": "works_topics_work_id_topic_id_pk",
+          "columns": [
+            "work_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.batch": {
+      "name": "batch",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_from": {
+          "name": "query_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_to": {
+          "name": "query_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_batch": {
+      "name": "works_batch",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "works_batch_work_id_works_id_fk": {
+          "name": "works_batch_work_id_works_id_fk",
+          "tableFrom": "works_batch",
+          "tableTo": "works",
+          "schemaTo": "openalex",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "works_batch_batch_id_batch_id_fk": {
+          "name": "works_batch_batch_id_batch_id_fk",
+          "tableFrom": "works_batch",
+          "tableTo": "batch",
+          "schemaTo": "openalex",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "works_batch_work_id_batch_id_pk": {
+          "name": "works_batch_work_id_batch_id_pk",
+          "columns": [
+            "work_id",
+            "batch_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "openalex": "openalex"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/openalex-importer/drizzle/migrations/meta/_journal.json
+++ b/openalex-importer/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1747128189825,
       "tag": "0009_amusing_wilson_fisk",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1747667888986,
+      "tag": "0010_nappy_dormammu",
+      "breakpoints": true
     }
   ]
 }

--- a/openalex-importer/drizzle/schema.ts
+++ b/openalex-importer/drizzle/schema.ts
@@ -329,11 +329,19 @@ export const concepts_counts_by_yearInOpenalex = openalex.table('concepts_counts
   primaryKey({ columns: [table.concept_id, table.year] }),
 ]);
 
+/**
+ * This differs from the suggested OA database schema in that it accumulates all institution ids for a given work/author pair.
+ * The reason is a combination of:
+ * - Need to prevent duplicates
+ * - Cannot use institution_id in the PK because it's nullable in the source data set
+ * - Can't ignore it, because we'll get multiple rows conflicting the work/author PK within the same insert statement, which postgres doesn't support
+ *   - Plus we might need it to map author relations
+ */
 export const works_authorshipsInOpenalex = openalex.table('works_authorships', {
   work_id: text(),
   author_position: text(),
   author_id: text(),
-  institution_id: text(),
+  institution_ids: text().array().default([]),
   raw_affiliation_string: text(),
 }, (table) => [
   primaryKey({ columns: [table.work_id, table.author_id] }),

--- a/openalex-importer/src/db/index.ts
+++ b/openalex-importer/src/db/index.ts
@@ -344,7 +344,10 @@ const updateWorksAuthorships = async (tx: pgPromise.ITask<any>, data: DataModels
       acc[key] = curr;
       return acc;
     } else {
-      acc[key].institution_ids!.push(...curr.institution_ids!);
+      acc[key].institution_ids = Array.from(new Set([
+        ...acc[key].institution_ids!,
+        ...curr.institution_ids!
+      ]));
     }
     return acc;
   }, {} as Record<string, DataModels['works_authorships'][number]>);

--- a/openalex-importer/src/db/index.ts
+++ b/openalex-importer/src/db/index.ts
@@ -79,6 +79,7 @@ const {
   works_conceptsInOpenalex,
   works_meshInOpenalex,
   works_topicsInOpenalex,
+  works_authorshipsInOpenalex,
 } = openAlexSchema;
 
 logger.info(
@@ -118,6 +119,9 @@ export const saveData = async (tx: pgPromise.ITask<any>, batchId: number, models
     lap = Date.now();
     await updateAuthorIds(tx, models['authors_ids']);
     logger.info({  table: 'authorIds',  duration: Date.now() - lap }, 'Table inserts done');
+    lap = Date.now();
+    await updateWorksAuthorships(tx, models['works_authorships']);
+    logger.info({  table: 'worksAuthorships',  duration: Date.now() - lap }, 'Table inserts done');
     lap = Date.now();
     await updateWorkIds(tx, models['works_id']);
     logger.info({  table: 'workIds',  duration: Date.now() - lap }, 'Table inserts done');
@@ -317,6 +321,40 @@ const updateAuthorIds = async (tx: pgPromise.ITask<any>, data: DataModels['autho
   const query = pgp.helpers.insert(data.sort(sortAuthorIds), columns) +
     ' ON CONFLICT (author_id) DO UPDATE SET ' +
     columns.assignColumns({ from: 'EXCLUDED', skip: 'author_id' });
+
+  await tx.none(query);
+};
+
+const sortWorksAuthorships = (a: DataModels['works_authorships'][number], b: DataModels['works_authorships'][number]) => {
+  if (a.work_id! < b.work_id!) return -1;
+  if (a.work_id! > b.work_id!) return 1;
+
+  if (a.author_id! < b.author_id!) return -1;
+  if (a.author_id! > b.author_id!) return 1;
+
+  return 0;
+};
+
+const updateWorksAuthorships = async (tx: pgPromise.ITask<any>, data: DataModels['works_authorships']) => {
+  if (!data.length) return;
+
+  const merged = data.reduce((acc, curr) => {
+    const key = `${curr.work_id!}-${curr.author_id!}`;
+    if (!acc[key]) {
+      acc[key] = curr;
+      return acc;
+    } else {
+      acc[key].institution_ids!.push(...curr.institution_ids!);
+    }
+    return acc;
+  }, {} as Record<string, DataModels['works_authorships'][number]>);
+
+  const sorted = Object.values(merged).sort(sortWorksAuthorships);
+
+  const columns = getColumnSet(works_authorshipsInOpenalex);
+  const query = pgp.helpers.insert(sorted, columns) +
+    ' ON CONFLICT (work_id, author_id) DO UPDATE SET ' +
+    columns.assignColumns({ from: 'EXCLUDED', skip: ['work_id', 'author_id'] });
 
   await tx.none(query);
 };

--- a/openalex-importer/src/transformers.ts
+++ b/openalex-importer/src/transformers.ts
@@ -16,10 +16,6 @@ import type {
   works_referenced_worksInOpenalex,
   works_related_worksInOpenalex,
   works_topicsInOpenalex,
-  WorksBestOaLocation,
-  WorksId,
-  WorksLocation,
-  WorksPrimaryLocation,
 } from './db/index.js';
 import type { Institution } from './types/institutions.js';
 import type { Work } from './types/works.js';
@@ -93,15 +89,19 @@ export const transformDataModel = (data: Work[]) => {
     const institutions: Institution[] = [];
 
     for (const authorship of work.authorships) {
+      const authorshipData = {
+        work_id: oaUrlToId(work.id),
+        author_position: authorship.author_position,
+        author_id: oaUrlToId(authorship.author.id),
+        institution_ids: [] as string[],
+      };
+
       for (const institution of authorship.institutions) {
-        works_authorships.push({
-          work_id: oaUrlToId(work.id),
-          author_position: authorship.author_position,
-          author_id: oaUrlToId(authorship.author.id),
-          institution_id: oaUrlToId(institution.id),
-        });
+        authorshipData.institution_ids.push(oaUrlToId(institution.id));
         institutions.push(institution);
       }
+
+      works_authorships.push(authorshipData);
     }
 
     return { authors, authors_ids, works_authorships, institutions };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced support for multiple institution affiliations per authorship, allowing each authorship to be linked to several institutions instead of just one.

- **Bug Fixes**
  - Improved handling of institution data to prevent duplicate entries and ensure accurate representation of authorship affiliations.

- **Chores**
  - Updated database schema and data import processes to support the new institution affiliations structure.
  - Updated documentation to reflect support for multiple institution IDs in authorship records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->