### PR TITLE
WIP: Replacing need for graph node

### DIFF
--- a/desci-server/package.json
+++ b/desci-server/package.json
@@ -20,6 +20,7 @@
     "script:fix-publish": "NODE_OPTIONS='--loader ts-node/esm' debug=* node --inspect=0.0.0.0:9277 --no-warnings --enable-source-maps ./src/scripts/fixPublish.ts",
     "script:increase-base-drive-storage": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/increase-base-drive-storage.ts",
     "script:testing": "debug=* node --inspect=0.0.0.0:9277 --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/test-exec.ts",
+    "script:backfill-legacy-dpids": "debug=* node --inspect=0.0.0.0:9277 --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/fix-global-legacy-dpids.ts",
     "script:es-index-published-nodes": "debug=* node --inspect=0.0.0.0:9277 --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/index-published-nodes-elastic-search.ts",
     "script:preload-ai-api": "debug=* node --inspect=0.0.0.0:9277 --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/preload-ai-api.ts",
     "script:migrate-draft-trees": "debug=* node --no-warnings --enable-source-maps --loader ts-node/esm ./src/scripts/migrate-draft-trees.ts",

--- a/desci-server/src/scripts/fix-global-legacy-dpids.ts
+++ b/desci-server/src/scripts/fix-global-legacy-dpids.ts
@@ -6,7 +6,8 @@
  *
  *
  * Usage:
- * ts-node src/scripts/fix-global-legacy-dpids.ts   - DRY RUN
+ * npm run script:backfill-legacy-dpids - DRY RUN
+ * DO_WRITES=true npm run script:backfill-legacy-dpids - THIS WILL WRITE TO THE DB.
  *
  * The script will:
  * - Scan all nodes in the database.
@@ -25,11 +26,9 @@
 import * as readline from 'readline';
 
 import { PrismaClient } from '@prisma/client';
-import axios from 'axios';
 import * as dotenv from 'dotenv';
 
 import { getManifestByCid } from '../services/data/processing.js';
-import { cleanupManifestUrl } from '../utils/manifest.js';
 import { ensureUuidEndsWithDot } from '../utils.js';
 
 // Load environment variables
@@ -164,7 +163,7 @@ async function fixAllMissingLegacyDpids() {
 
   console.log(`\nIdentified ${nodesToFix.length} nodes for which a DPID was found and can be fixed:`);
   formatTable(
-    nodesToFix.map((n) => [n.id.toString(), n.title, n.uuid, n.dpid]),
+    nodesToFix.map((n) => [n.id.toString(), n.title.slice(0, 30), n.uuid, n.dpid]),
     ['Node ID', 'Title', 'UUID', 'DPID to Add (legacyDpid)'],
   );
 


### PR DESCRIPTION

## Description of the Problem / Feature
- Script to backfill legacyDpids for all published nodes that weren't migrated yet
- WIP: Reroute _getIndexedRO logic to use the legacy struct for retrieving history


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new npm script to facilitate running a legacy data backfill process.
- **Documentation**
  - Updated script usage instructions for improved clarity.
- **Style**
  - Improved output formatting by truncating long node titles in the display table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->