### PR TITLE
Graph fix

### DIFF
--- a/desci-server/src/theGraph.ts
+++ b/desci-server/src/theGraph.ts
@@ -82,7 +82,10 @@ export const getIndexedResearchObjects = async (
   */
   const dpidLookupMap: Record<number, string> = nodeRes.reduce(
     (acc, n) => {
-      acc[n.dpidAlias ?? n.legacyDpid] = n.uuid;
+      const dpid = n.dpidAlias ?? n.legacyDpid;
+      if (dpid != null) {
+        acc[dpid] = n.uuid;
+      }
       return acc;
     },
     {} as Record<number, string>,


### PR DESCRIPTION
DON'T MERGE UNTIL WE BACKFILL LEGACY DPIDS

This replaces the source of history for legacy nodes that haven't been migrated to directly use the dpid resolver that utilizes the legacy structs instead of the graph node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way research objects are indexed and retrieved, streamlining the process for greater reliability and consistency.
- **Chores**
  - Removed deprecated internal logic related to legacy identifiers, resulting in a cleaner and more maintainable system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->