### PR TITLE
Fix ORCID wallet duplicate message grammar

### DIFF
--- a/desci-server/src/controllers/users/associateWallet.ts
+++ b/desci-server/src/controllers/users/associateWallet.ts
@@ -61,7 +61,9 @@ export const associateOrcidWallet = async (req: Request, res: Response, next: Ne
         },
       })) > 0;
     if (doesExist) {
-      res.status(400).send({ err: 'orcid DID already register to some other' });
+      res
+        .status(400)
+        .send({ err: 'orcid DID already registered to another user' });
       return;
     }
 


### PR DESCRIPTION
## Summary
- fix grammar in ORCID wallet association error message

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_683ed19a7e7883209c7349f76302b574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the clarity of the error message shown when an ORCID DID is already registered to another user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->