### PR TITLE
Misc C1 node fixes

### DIFF
--- a/ceramic-k8s/dev/recon_dev.yaml
+++ b/ceramic-k8s/dev/recon_dev.yaml
@@ -16,7 +16,7 @@ data:
   CERAMIC_ONE_STORE_DIR: "/data/ceramic-one"
   CERAMIC_ONE_P2P_KEY_DIR: "/data/ceramic-one"
   CERAMIC_ONE_BIND_ADDRESS: "0.0.0.0:5101"
-  CERAMIC_ONE_SWARM_ADDRESSES: "/ip4/0.0.0.0/tcp/4101,/ip4/0.0.0.0/udp/4101/quic-v1"
+  CERAMIC_ONE_SWARM_ADDRESSES: "/ip4/0.0.0.0/tcp/4101,/ip4/0.0.0.0/udp/4102/quic-v1"
   CERAMIC_ONE_METRICS_BIND_ADDRESS: "0.0.0.0:9465"
   CERAMIC_ONE_LOCAL_NETWORK_ID: "0"
   CERAMIC_ONE_NETWORK: "testnet-clay"
@@ -26,76 +26,8 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: js-ceramic-env
-data:
-  NODE_ENV: "production"
-  CERAMIC_NETWORK: "testnet-clay"
-  CERAMIC_STATE_STORE_PATH: "/js-ceramic-data/statestore"
-  CERAMIC_CORS_ALLOWED_ORIGINS: ".*"
-  CERAMIC_LOG_LEVEL: "2"
-  CERAMIC_IPFS_HOST: "http://localhost:5101"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: ceramic-init
 data:
-  # TODO: add anchor.authMethod and node.privateSeedUrl to config when duplicating for prod
-  daemon-config.json: |
-    {
-      "anchor": {
-        "ethereum-rpc-url": "${ANCHOR_RPC_URL}"
-      },
-      "http-api": {
-          "cors-allowed-origins": [
-              "${CERAMIC_CORS_ALLOWED_ORIGINS}"
-          ],
-          "admin-dids": [
-              "${CERAMIC_ADMIN_DID}"
-          ]
-      },
-      "ipfs": {
-          "mode": "remote",
-          "host": "${CERAMIC_IPFS_HOST}"
-      },
-      "logger": {
-          "log-level": ${CERAMIC_LOG_LEVEL},
-          "log-to-files": false
-      },
-      "metrics": {
-          "metrics-exporter-enabled": false,
-          "prometheus-exporter-enabled": true,
-          "prometheus-exporter-port": 9464
-      },
-      "network": {
-          "name": "${CERAMIC_NETWORK}"
-      },
-      "node": {},
-      "state-store": {
-          "mode": "fs",
-          "local-directory": "${CERAMIC_STATE_STORE_PATH}"
-      },
-      "indexing": {
-          "db": "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/${POSTGRES_DB}",
-          "allow-queries-before-historical-sync": true
-      }
-    }
-
-  js-ceramic-init.sh: |
-    #!/bin/bash
-
-    set -eo pipefail
-
-    source /vault/secrets/config
-
-    export CERAMIC_ADMIN_DID=$(composedb did:from-private-key ${CERAMIC_ADMIN_PRIVATE_KEY})
-
-    envsubst \
-      < /ceramic-init/daemon-config.json \
-      > /config/daemon-config.json
-
-    echo "Config file generated successfully"
-
   get-external-multiaddr.sh: |
     #!/bin/bash
 
@@ -107,7 +39,7 @@ data:
     
     LB_DOMAIN=$(curl -s --header "Authorization: Bearer $TOKEN" \
         --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-        https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/services/ceramic-recon-dev-$MY_POD_INDEX-public \
+        https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/services/ceramic-recon-dev-$MY_POD_INDEX-swarm\
       | grep -oE "k8s-.*.elb.*.amazonaws.com")
 
     if [ -z "$LB_DOMAIN" ]; then
@@ -115,12 +47,12 @@ data:
       exit 1
     fi
 
-    EXTERNAL_MULTIADDR="/dns4/${LB_DOMAIN}/tcp/4101,/dns4/${LB_DOMAIN}/udp/4101/quic-v1"
+    EXTERNAL_MULTIADDR="/dns4/${LB_DOMAIN}/tcp/4101,/dns4/${LB_DOMAIN}/udp/4102/quic-v1"
     echo -n "$EXTERNAL_MULTIADDR" > /config/external-multiaddr
     echo "Wrote $EXTERNAL_MULTIADDR to /config/external-multiaddr"
 ---
 
-# Stateful set for pairs of js-ceramic & ceramic-one
+# Stateful set to manage container and volume in pairs
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -155,61 +87,13 @@ spec:
     spec:
       serviceAccountName: "vault-auth"
       containers:
-        - name: js-ceramic
-          image: ceramicnetwork/js-ceramic:6.5.0
-          command:
-            - /js-ceramic/packages/cli/bin/ceramic.js
-            - daemon
-            - --config
-            - /config/daemon-config.json
-          env:
-            - name: BASH_ENV
-              value: /vault/secrets/config
-          envFrom:
-            - configMapRef:
-                name: js-ceramic-env
-          ports:
-            - name: http-api
-              containerPort: 7007
-              protocol: TCP
-            - name: metrics
-              containerPort: 9464
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 2
-              memory: 4Gi
-            requests:
-              cpu: 1
-              memory: 4Gi
-          livenessProbe:
-            httpGet:
-              path: /api/v0/node/healthcheck
-              port: http-api
-              scheme: HTTP
-            failureThreshold: 3
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /api/v0/node/healthcheck
-              port: http-api
-              scheme: HTTP
-            failureThreshold: 3
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            timeoutSeconds: 10
-          volumeMounts:
-            - mountPath: /config
-              name: config-volume
-            - mountPath: /js-ceramic-data
-              name: js-ceramic-data
-
         - name: ceramic-one
-          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:0.39.0
+          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:0.54.1
           command: [ "bash", "-c" ]
-          args: [ 'ceramic-one daemon --external-swarm-addresses="$(< /config/external-multiaddr)"']
+          args:
+            # - echo "Container idling..."; tail --follow /dev/null
+            - ceramic-one daemon
+              --external-swarm-addresses="$(< /config/external-multiaddr)"
           env:
             - name: BASH_ENV
               value: /vault/secrets/config
@@ -217,10 +101,13 @@ spec:
             - configMapRef:
                 name: ceramic-one-env
           ports:
+            - containerPort: 5102
+              name: flight-sql
+              protocol: TCP
             - containerPort: 4101
               name: swarm-tcp
               protocol: TCP
-            - containerPort: 4101
+            - containerPort: 4102
               name: swarm-udp
               protocol: UDP
             - containerPort: 5101
@@ -231,39 +118,37 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 4
+              memory: 4Gi
             requests:
               cpu: 1
               memory: 1Gi
-          livenessProbe:
-            httpGet:
-              path: /ceramic/liveness
-              port: rpc
-              scheme: HTTP
-          readinessProbe:
-            httpGet:
-              path: /ceramic/liveness
-              port: rpc
-              scheme: HTTP
+          # livenessProbe:
+          #   httpGet:
+          #     path: /ceramic/liveness
+          #     port: rpc
+          #     scheme: HTTP
+          # readinessProbe:
+          #   httpGet:
+          #     path: /ceramic/liveness
+          #     port: rpc
+          #     scheme: HTTP
           volumeMounts:
             - name: ceramic-one-data
               mountPath: /data/ceramic-one
             - name: config-volume
               mountPath: /config
-
       initContainers:
         - name: init-ceramic-config
-          command: [ "bash", "-c" ]
-          args: [ "/ceramic-init/js-ceramic-init.sh && /ceramic-init/get-external-multiaddr.sh" ]
+          image: alpine:3
+          imagePullPolicy: Always
+          command: [ "sh", "-c" ]
+          args:
+            - apk add --no-cache bash curl &&
+              bash /ceramic-init/get-external-multiaddr.sh
           env:
             - name: BASH_ENV
               value: /vault/secrets/config
-          envFrom:
-            - configMapRef:
-                name: js-ceramic-env
-          image: ceramicnetwork/composedb-cli
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /config
               name: config-volume
@@ -282,23 +167,8 @@ spec:
         - configMap:
             name: ceramic-one-env
           name: ceramic-one-env
-        - name: js-ceramic-data
-          persistentVolumeClaim:
-            claimName: js-ceramic-data
 
   volumeClaimTemplates:
-    - metadata:
-        name: js-ceramic-data
-        labels:
-          App: CeramicReconDev
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: retained-standard
-        resources:
-          requests:
-            storage: 100Gi
-
     - metadata:
         name: ceramic-one-data
         labels:
@@ -324,18 +194,16 @@ spec:
   selector:
     App: CeramicReconDev
   ports:
-    - port: 7007
-      name: http-api
+    - port: 5102
+      name: flight-sql
     - port: 4101
       name: swarm-tcp
       protocol: TCP
-    - port: 4101
+    - port: 4102
       name: swarm-udp
       protocol: UDP
     - port: 5101
       name: rpc
-    - port: 9464
-      name: js-metrics
     - port: 9465
       name: one-metrics
 ---
@@ -354,45 +222,75 @@ spec:
     App: CeramicReconDev
     statefulset.kubernetes.io/pod-name: ceramic-recon-dev-0
   ports:
-    - port: 80
-      name: http-api
-      targetPort: http-api
-    - port: 4101
-      name: swarm-tcp
-      protocol: TCP
-      targetPort: swarm-tcp
-    - port: 4101
-      name: swarm-udp
-      protocol: UDP
-      targetPort: swarm-udp
+    # - port: 4101
+    #   name: swarm-tcp
+    #   protocol: TCP
+    #   targetPort: swarm-tcp
+    # - port: 4102
+    #   name: swarm-udp
+    #   protocol: UDP
+    #   targetPort: swarm-udp
+    - port: 5102
+      name: flight-sql
+      targetPort: flight-sql
     - port: 5101
       name: rpc
       targetPort: rpc
-    - port: 9464
-      name: js-metrics
-      targetPort: js-metrics
     - port: 9465
       name: one-metrics
       targetPort: one-metrics
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: ceramic-recon-dev-0-public
+# spec:
+#   type: LoadBalancer
+#   selector:
+#     App: CeramicReconDev
+#     statefulset.kubernetes.io/pod-name: ceramic-recon-dev-0
+#   ports:
+#     - port: 4101
+#       name: swarm-tcp
+#       protocol: TCP
+#       targetPort: swarm-tcp
+#     - port: 4102
+#       name: swarm-udp
+#       protocol: UDP
+#       targetPort: swarm-udp
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ceramic-recon-dev-0-public
+  name: ceramic-recon-dev-0-swarm
+  labels:
+    App: CeramicReconDev
+  annotations:
+    # NLB is preferred for libp2p/Kubo due to connection handling and UDP use
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    # Required for mixed protocol support
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    # AWS targetgroups doesn't support UDP checks, but defaults to creating one on the UDP port
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "4101"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: TCP
+    # Enable cross-AZ load balancing for better availability
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    # External access required for IPFS network participation
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    # Long timeout for libp2p connections
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   selector:
     App: CeramicReconDev
-    statefulset.kubernetes.io/pod-name: ceramic-recon-dev-0
   ports:
-    - port: 80
-      name: http-api
-      targetPort: http-api
-    - port: 4101
-      name: swarm-tcp
+    - name: swarm-tcp
       protocol: TCP
-      targetPort: swarm-tcp
-    - port: 4101
-      name: swarm-udp
+      port: 4101
+      targetPort: 4101
+    - name: swarm-udp
       protocol: UDP
-      targetPort: swarm-udp
+      port: 4102
+      targetPort: 4102

--- a/ceramic-k8s/dev/recon_dev.yaml
+++ b/ceramic-k8s/dev/recon_dev.yaml
@@ -88,7 +88,7 @@ spec:
       serviceAccountName: "vault-auth"
       containers:
         - name: ceramic-one
-          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:0.54.1
+          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:0.54.2
           command: [ "bash", "-c" ]
           args:
             # - echo "Container idling..."; tail --follow /dev/null

--- a/ceramic-k8s/dev/recon_dev.yaml
+++ b/ceramic-k8s/dev/recon_dev.yaml
@@ -17,6 +17,7 @@ data:
   CERAMIC_ONE_P2P_KEY_DIR: "/data/ceramic-one"
   CERAMIC_ONE_BIND_ADDRESS: "0.0.0.0:5101"
   CERAMIC_ONE_SWARM_ADDRESSES: "/ip4/0.0.0.0/tcp/4101,/ip4/0.0.0.0/udp/4102/quic-v1"
+  CERAMIC_ONE_FLIGHT_SQL_BIND_ADDRESS: "0.0.0.0:5102"
   CERAMIC_ONE_METRICS_BIND_ADDRESS: "0.0.0.0:9465"
   CERAMIC_ONE_LOCAL_NETWORK_ID: "0"
   CERAMIC_ONE_NETWORK: "testnet-clay"
@@ -88,7 +89,7 @@ spec:
       serviceAccountName: "vault-auth"
       containers:
         - name: ceramic-one
-          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:0.54.2
+          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:0.55.0
           command: [ "bash", "-c" ]
           args:
             # - echo "Container idling..."; tail --follow /dev/null
@@ -294,3 +295,7 @@ spec:
       protocol: UDP
       port: 4102
       targetPort: 4102
+    - name: flight-sql
+      protocol: TCP
+      port: 5102
+      targetPort: 5102

--- a/ceramic-k8s/migration.md
+++ b/ceramic-k8s/migration.md
@@ -1,0 +1,114 @@
+# Kubo -> Ceramic One migration
+
+## If running in `ceramic-recon` pod:
+```bash
+apt-get update
+apt-get install curl unzip groff less jq
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip awscliv2.zip
+./aws/install
+```
+
+Authenticate:
+```bash
+aws configure
+```
+
+Note: remove `/root/.aws/credentials` when done!
+
+## Bump `aws s3` concurrency
+```bash
+aws configure set default.s3.max_concurrent_requests 128
+```
+
+## Sync the blockstore data
+Sync the blockstore (not much data, but 600k+ files):
+```bash
+# This is the mounted PV in the ceramic-recon-dev container
+cd $CERAMIC_ONE_STORE_DIR
+mkdir kubo-blockstore
+
+# If initial copy (faster but dumb)
+aws s3 cp --recursive s3://public-ceramic-ipfs-dev/public-ceramic-ipfs-dev-1 kubo-blockstore
+
+# If topping up (slower but only transfers the delta)
+aws s3 sync s3://public-ceramic-ipfs-dev/public-ceramic-ipfs-dev-1 kubo-blockstore
+```
+
+This is OK to cancel and resume, and follow-up runs will only transfer the delta.
+
+
+## If syncing locally: send to pod as tarball
+There are so many files that it's a bit tricky to make a flat bundle efficiently, but we use `find` to get plain filenames without path, and feed `tar` filenames to include via `stdin`:
+```bash
+cd clay-blockstore
+find . -name "CIQ*" -printf '%f\n' | tar czf clay-blockstore.tar.gz --files-from -
+```
+
+Copy the tarball to the pod with `kubectl cp` and extract to `$CERAMIC_ONE_STORE_DIR/kubo-blockstore`
+
+## Run the block import
+
+```bash
+# Snapshot which blocks are are importing, so we can import deltas later
+find $CERAMIC_ONE_STORE_DIR/kubo-blockstore -type f \
+  | sort \
+  > $CERAMIC_ONE_STORE_DIR/migration-info/blocks_run_1.txt
+
+ceramic-one migrations from-ipfs \
+  --input-ipfs-path $CERAMIC_ONE_STORE_DIR/kubo-blockstore \
+  --input-file-list-path $CERAMIC_ONE_STORE_DIR/migration-info/blocks_run_1.txt \
+  --non-sharded-paths \
+  --output-store-path $CERAMIC_ONE_STORE_DIR \
+  --network testnet-clay \
+  --log-tile-docs \
+  --log-format json \
+  > "$CERAMIC_ONE_STORE_DIR/migration-info/log_$(date --iso-8601=minutes | sed 's|+00:00||').json" 2>&1
+
+
+  # With filtering / validation
+  ceramic-one migrations from-ipfs \
+    --input-ipfs-path $CERAMIC_ONE_STORE_DIR/kubo-blockstore \
+    --input-file-list-path $CERAMIC_ONE_STORE_DIR/migration-info/blocks_run_1.txt \
+    --non-sharded-paths \
+    --output-store-path $CERAMIC_ONE_STORE_DIR \
+    --network testnet-clay \
+    --validate-signatures \
+    --validate-chain \
+    --model-filter='kjzl6hvfrbw6cbe01it6hlcwopsv4cqrqysho4f1xd7rtqxew9yag3x2wxczhz0,kh4q0ozorrgaq2mezktnrmdwleo1d' \
+    --log-tile-docs \
+    --log-format json \
+    > "$CERAMIC_ONE_STORE_DIR/migration-info/log_$(date --iso-8601=minutes | sed 's|+00:00||').json" \
+    2>&1
+```
+
+After this, you will have a fat `log_[date].json` with all the output from the import, and a `model_error_counts.csv` which aggregates errors per model. We ran the nodes with the "historical sync" mode for a while, and all of those blocks likely lead to errors.
+
+At this point, what's important is that no errors happen for our `ResearchObject` model (`kjzl6hvfrbw6cbe01it6hlcwopsv4cqrqysho4f1xd7rtqxew9yag3x2wxczhz0`):
+
+```bash
+# Should print "No match!"
+grep kjzl6hvfrbw6cbe01it6hlcwopsv4cqrqysho4f1xd7rtqxew9yag3x2wxczhz0 model_error_counts.csv || echo "No match!"
+```
+
+### For subsequent refreshes:
+```bash
+# Sync block from kubo bucket
+aws s3 sync ...
+
+# Create an updated list of absolute paths to all synced blocks
+find $CERAMIC_ONE_STORE_DIR/kubo-blockstore -type f \
+  | sort \
+  > $CERAMIC_ONE_STORE_DIR/migration-info/all_blocks.txt
+
+# Find the blocks not included in the last (TODO: or other previous?) run
+# NOTE: replace X and X+1 with the next numbers to keep the old lists
+comm -13 \
+  $CERAMIC_ONE_STORE_DIR/migration-info/blocks_run_X.txt \
+  $CERAMIC_ONE_STORE_DIR/migration-info/all_blocks.txt \
+  > blocks_run_X+1.txt
+
+# Run migration command again, but with the latest block delta
+# NOTE: replace X+1 with the latest file
+ceramic-one migrations from-ipfs ... --input-file-list-path $CERAMIC_ONE_STORE_DIR/migration-info/blocks_run_X+1.txt
+```

--- a/ceramic-k8s/migration.md
+++ b/ceramic-k8s/migration.md
@@ -74,7 +74,6 @@ ceramic-one migrations from-ipfs \
     --output-store-path $CERAMIC_ONE_STORE_DIR \
     --network testnet-clay \
     --validate-signatures \
-    --validate-chain \
     --model-filter='kjzl6hvfrbw6cbe01it6hlcwopsv4cqrqysho4f1xd7rtqxew9yag3x2wxczhz0,kh4q0ozorrgaq2mezktnrmdwleo1d' \
     --log-tile-docs \
     --log-format json \
@@ -89,6 +88,29 @@ At this point, what's important is that no errors happen for our `ResearchObject
 ```bash
 # Should print "No match!"
 grep kjzl6hvfrbw6cbe01it6hlcwopsv4cqrqysho4f1xd7rtqxew9yag3x2wxczhz0 model_error_counts.csv || echo "No match!"
+```
+
+Note: on dev, there should/might be 18 errors. Grep on the same model ID in the log file, and all related errors should be mismatched chainID's in the controller (`11155420` vs `11155111`):
+```json
+{
+  "timestamp": "2025-06-03T09:05:26.289302Z",
+  "level": "ERROR",
+  "fields": {
+    "message": "error processing block",
+    "cid": "bagcqceravakeblrrcm7sh6owcau5nzrkwpvaowg2u6ytrzoxk6joym3amota",
+    "err": "fatal error: invalid_jws: 'did:pkh:eip155:11155420:0xdaf8752ddcce8a6b709aa271e7efc60f75cddf64' not in controllers list for issuer: 'did:pkh:eip155:11155111:0xdaf8752ddcce8a6b709aa271e7efc60f75cddf64'",
+    "model": "kjzl6hvfrbw6cbe01it6hlcwopsv4cqrqysho4f1xd7rtqxew9yag3x2wxczhz0"
+  },
+  "target": "ceramic_event_svc::event::migration",
+  "span": {
+    "name": "migrate"
+  },
+  "spans": [
+    {
+      "name": "migrate"
+    }
+  ]
+}
 ```
 
 ### For subsequent refreshes:


### PR DESCRIPTION
- Separate UDP swarm port as IF NLB doesn't support load balancing TPC & UDP concurrently on the same port
- Remove js-ceramic container from STS (C1 only)
- Bump version to 0.55.0 (includes anchor timestamps in the event aggregation pipeline)
- Docs for js-ceramic kubo blockstore migration/sync into C1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Flight SQL on port 5102.
	- Upgraded Ceramic One to a newer version with increased resource limits.
- **Bug Fixes**
	- Updated network ports and service configurations for improved compatibility and performance.
- **Chores**
	- Removed the js-ceramic component and related configurations.
	- Enhanced LoadBalancer service configuration for better AWS NLB support.
- **Documentation**
	- Introduced a comprehensive migration guide for moving data from Kubo to Ceramic One.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->