### PR TITLE
GetIndexedRo graphless fix

### DIFF
--- a/desci-server/src/theGraph.ts
+++ b/desci-server/src/theGraph.ts
@@ -131,7 +131,7 @@ const getHistoryFromDpids = async (dpidsToUuidsMap: Record<number, string>): Pro
   try {
     // Convert resolver format to server format
     indexedHistory = historyRes.data.map((ro, index) => ({
-      id: uuids[index],
+      id: '0x' + decodeBase64UrlSafeToHex(uuids[index]),
       id10: BigInt('0x' + decodeBase64UrlSafeToHex(uuids[index])).toString(),
       streamId: ro.id,
       owner: ro.owner,


### PR DESCRIPTION
## Description of the Problem / Feature
In the previous changes there was a slight error in the graph resp emulation, we forgot to hex the id value, converted it to hex for consistency with the result from the graph node.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the format of displayed IDs to use a hex string prefixed with "0x" for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->