### PR TITLE
Missing req params in swagger docs

### DIFF
--- a/desci-server/src/docs/journals.ts
+++ b/desci-server/src/docs/journals.ts
@@ -224,6 +224,7 @@ export const editorInviteDecisionOperation: ZodOpenApiOperationObject = {
   operationId: 'editorInviteDecision',
   tags: ['Journals'],
   summary: 'Accept or decline an editor invitation',
+  requestParams: { path: editorInviteDecisionSchema.shape.params },
   requestBody: {
     content: {
       'application/json': {

--- a/desci-server/src/schemas/journals.schema.ts
+++ b/desci-server/src/schemas/journals.schema.ts
@@ -47,6 +47,9 @@ export const inviteEditorSchema = z.object({
 });
 
 export const editorInviteDecisionSchema = z.object({
+  params: z.object({
+    journalId: z.string().transform((val) => parseInt(val, 10)),
+  }),
   body: z.object({
     decision: z.enum(['accept', 'decline']),
     token: z.string(),


### PR DESCRIPTION
Added missing param in the journal editor invite decision endpoint schema for swagger docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of editor invitation decisions by now requiring a journal ID in the request path for relevant API operations. This enhances clarity and accuracy when responding to editor invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->