### PR TITLE
Update K8S config for missing env

### DIFF
--- a/desci-server/kubernetes/deployment_dev.yaml
+++ b/desci-server/kubernetes/deployment_dev.yaml
@@ -58,6 +58,7 @@ spec:
           export SERVER_URL={{ .Data.SERVER_URL }}
           export DAPP_URL={{ .Data.DAPP_URL }}
           export SENDGRID_API_KEY={{ .Data.SENDGRID_API_KEY }}
+          export SENDGRID_TEMPLATE_ID_MAP={{ .Data.SENDGRID_TEMPLATE_ID_MAP }}
           export SHOULD_SEND_EMAIL=true
           export AWS_ACCESS_KEY_ID={{ .Data.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY={{ .Data.AWS_SECRET_ACCESS_KEY }}

--- a/desci-server/kubernetes/deployment_prod.yaml
+++ b/desci-server/kubernetes/deployment_prod.yaml
@@ -57,6 +57,7 @@ spec:
           export SERVER_URL={{ .Data.SERVER_URL }}
           export DAPP_URL={{ .Data.DAPP_URL }}
           export SENDGRID_API_KEY={{ .Data.SENDGRID_API_KEY }}
+          export SENDGRID_TEMPLATE_ID_MAP={{ .Data.SENDGRID_TEMPLATE_ID_MAP }}
           export SHOULD_SEND_EMAIL=true
           export AWS_ACCESS_KEY_ID={{ .Data.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY={{ .Data.AWS_SECRET_ACCESS_KEY }}

--- a/desci-server/kubernetes/deployment_staging.yaml
+++ b/desci-server/kubernetes/deployment_staging.yaml
@@ -69,6 +69,7 @@ spec:
           export SERVER_URL={{ .Data.SERVER_URL }}
           export DAPP_URL={{ .Data.DAPP_URL }}
           export SENDGRID_API_KEY={{ .Data.SENDGRID_API_KEY }}
+          export SENDGRID_TEMPLATE_ID_MAP={{ .Data.SENDGRID_TEMPLATE_ID_MAP }}
           export SHOULD_SEND_EMAIL=true
           export AWS_ACCESS_KEY_ID={{ .Data.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY={{ .Data.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
- Add the sendgrid template ID map env to k8s config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new environment variable for managing SendGrid template IDs across development, staging, and production environments. This improves configuration consistency for email templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->