### PR TITLE
fix: api response object formatter breaks Date

### DIFF
--- a/desci-server/src/core/utils.ts
+++ b/desci-server/src/core/utils.ts
@@ -1,11 +1,11 @@
 export function sanitizeBigInts(obj: any): any {
   if (Array.isArray(obj)) {
     return obj.map(sanitizeBigInts);
+  } else if (typeof obj === 'bigint') {
+    return obj.toString();
   } else if (obj && typeof obj === 'object') {
     const keys = Object.keys(obj);
     return keys.length > 0 ? Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, sanitizeBigInts(v)])) : obj;
-  } else if (typeof obj === 'bigint') {
-    return obj.toString();
   } else {
     return obj;
   }

--- a/desci-server/src/core/utils.ts
+++ b/desci-server/src/core/utils.ts
@@ -2,7 +2,8 @@ export function sanitizeBigInts(obj: any): any {
   if (Array.isArray(obj)) {
     return obj.map(sanitizeBigInts);
   } else if (obj && typeof obj === 'object') {
-    return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, sanitizeBigInts(v)]));
+    const keys = Object.keys(obj);
+    return keys.length > 0 ? Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, sanitizeBigInts(v)])) : obj;
   } else if (typeof obj === 'bigint') {
     return obj.toString();
   } else {


### PR DESCRIPTION
## Description of the Problem / Feature
- Fix `sanitizeBigInts` bug when formatting date fields