### PR TITLE
add support for anonymous referee invite using email only

### DIFF
--- a/desci-server/src/controllers/journals/referees/refereeInviteDecision.ts
+++ b/desci-server/src/controllers/journals/referees/refereeInviteDecision.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Response } from 'express';
 import _ from 'lodash';
+import { errWithCause } from 'pino-std-serializers';
 
 import { sendError, sendSuccess } from '../../../core/api.js';
 import { OptionalAuthenticatedRequest, ValidatedRequest } from '../../../core/types.js';
@@ -44,7 +45,10 @@ export const refereeInviteDecisionController = async (
 
     if (inviteResult.isErr()) {
       const error = inviteResult.error;
-      logger.error({ error, body: req.body, userId: req.user?.id }, 'Failed to process referee invite decision');
+      logger.error(
+        { error: errWithCause(error), body: req.body, userId: req.user?.id },
+        'Failed to process referee invite decision',
+      );
       if (error.message === 'Referee invite not found' || error.message === 'Referee invite not valid') {
         return sendError(res, error.message, 400);
       }

--- a/desci-server/src/schemas/journals.schema.ts
+++ b/desci-server/src/schemas/journals.schema.ts
@@ -261,7 +261,8 @@ export const inviteRefereeSchema = z.object({
     journalId: z.string(),
   }),
   body: z.object({
-    refereeUserId: z.number().int().positive(),
+    refereeEmail: z.string().email().optional(),
+    refereeUserId: z.number().int().positive().optional(),
     relativeDueDateHrs: z.number().int().positive().optional(), // lets restric tthis further.
     expectedFormTemplateIds: z.array(z.number().int().positive()).optional().default([]),
   }),

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -428,9 +428,15 @@ async function acceptRefereeInvite(data: AcceptRefereeInviteInput): Promise<Resu
       return err(new Error('Referee invite not valid'));
     }
 
-    const refereeUser = await prisma.user.findUnique({
-      where: { id: refereeInvite.userId },
-    });
+    const refereeUser = refereeInvite?.userId
+      ? await prisma.user.findUnique({
+          where: { id: refereeInvite.userId },
+        })
+      : refereeInvite.email
+        ? await prisma.user.findUnique({
+            where: { email: refereeInvite.email },
+          })
+        : null;
     if (!refereeUser) {
       return err(new Error('Referee not found'));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inviting referees by either user ID or email address.
  * Invitation responses now include additional details such as email, token, inviter, and timestamps.

* **Bug Fixes**
  * Improved error messages for failed referee invitations and retrievals.

* **Documentation**
  * Enhanced API documentation for referee invitation and decision endpoints, including clearer descriptions, updated response schemas, and detailed error responses.

* **Refactor**
  * Improved robustness in referee invite acceptance by supporting user lookup via email when user ID is not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->