### PR TITLE
auto match referee invite to existing users using email

### DIFF
--- a/desci-server/src/controllers/journals/referees/inviteReferee.ts
+++ b/desci-server/src/controllers/journals/referees/inviteReferee.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import _ from 'lodash';
 
+import { prisma } from '../../../client.js';
 import { sendError, sendSuccess } from '../../../core/api.js';
 import { AuthenticatedRequest, ValidatedRequest } from '../../../core/types.js';
 import { logger as parentLogger } from '../../../logger.js';
@@ -24,10 +25,23 @@ export const inviteRefereeController = async (req: InviteRefereeRequest, res: Re
       'Attempting to invite referee',
     );
 
+    let invitedUserId = refereeUserId;
+    if (!invitedUserId) {
+      const refereeEmailIsExists = await prisma.user.findFirst({
+        where: {
+          email: refereeEmail,
+        },
+      });
+
+      if (refereeEmailIsExists) {
+        invitedUserId = refereeEmailIsExists.id;
+      }
+    }
+
     const result = await JournalRefereeManagementService.inviteReferee({
       submissionId: parseInt(submissionId),
       refereeEmail,
-      refereeUserId,
+      refereeUserId: invitedUserId,
       managerUserId,
       relativeDueDateHrs,
       expectedFormTemplateIds,

--- a/desci-server/src/controllers/journals/referees/inviteReferee.ts
+++ b/desci-server/src/controllers/journals/referees/inviteReferee.ts
@@ -25,23 +25,10 @@ export const inviteRefereeController = async (req: InviteRefereeRequest, res: Re
       'Attempting to invite referee',
     );
 
-    let invitedUserId = refereeUserId;
-    if (!invitedUserId) {
-      const refereeEmailIsExists = await prisma.user.findFirst({
-        where: {
-          email: refereeEmail,
-        },
-      });
-
-      if (refereeEmailIsExists) {
-        invitedUserId = refereeEmailIsExists.id;
-      }
-    }
-
     const result = await JournalRefereeManagementService.inviteReferee({
       submissionId: parseInt(submissionId),
       refereeEmail,
-      refereeUserId: invitedUserId,
+      refereeUserId,
       managerUserId,
       relativeDueDateHrs,
       expectedFormTemplateIds,

--- a/desci-server/src/services/Notifications/NotificationService.ts
+++ b/desci-server/src/services/Notifications/NotificationService.ts
@@ -618,7 +618,7 @@ const emitOnRefereeInvitation = async ({
   editor: JournalEditor;
   submission: JournalSubmission;
   submissionTitle: string;
-  referee: User;
+  referee: Pick<User, 'id' | 'name' | 'email'>;
   inviteToken: string;
   dueDateHrs: number;
 }) => {

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -38,10 +38,20 @@ async function inviteReferee(data: InviteRefereeInput): Promise<Result<RefereeIn
     const existingReferee = data.refereeUserId
       ? await prisma.user.findUnique({
           where: { id: data.refereeUserId },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
         })
       : await prisma.user.findFirst({
           where: {
             email: data.refereeEmail,
+          },
+          select: {
+            id: true,
+            name: true,
+            email: true,
           },
         });
 

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -39,7 +39,11 @@ async function inviteReferee(data: InviteRefereeInput): Promise<Result<RefereeIn
       ? await prisma.user.findUnique({
           where: { id: data.refereeUserId },
         })
-      : null;
+      : await prisma.user.findFirst({
+          where: {
+            email: data.refereeEmail,
+          },
+        });
 
     const submission = await prisma.journalSubmission.findUnique({
       where: { id: data.submissionId },


### PR DESCRIPTION
Closes #<GH_issue_number>

## Description of the Problem / Feature

## Explanation of the solution

## Instructions on making this work

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved referee invitation process to automatically use an existing user account when inviting by email, ensuring more accurate and consistent invitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->