### PR TITLE
fix: edit comment api should not require node access

### DIFF
--- a/desci-server/src/routes/v1/nodes.ts
+++ b/desci-server/src/routes/v1/nodes.ts
@@ -214,11 +214,7 @@ router.post(
   [ensureUser, validate(postCommentVoteSchema)],
   asyncHandler(upvoteComment),
 );
-router.put(
-  '/:uuid/comments/:id',
-  [ensureUser, ensureNodeAccess, validate(editCommentsSchema)],
-  asyncHandler(editComment),
-);
+router.put('/:uuid/comments/:id', [ensureUser, validate(editCommentsSchema)], asyncHandler(editComment));
 router.post(
   '/:uuid/comments/:commentId/downvote',
   [ensureUser, validate(postCommentVoteSchema)],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated comment editing permissions to no longer require node access checks. Now, only user authentication and request validation are required to edit comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->