### PR TITLE
implement api to retrieve invites referees for a journal submission

### DIFF
--- a/desci-server/src/controllers/journals/submissions/index.ts
+++ b/desci-server/src/controllers/journals/submissions/index.ts
@@ -462,7 +462,7 @@ export const getRefereeInvitationsBySubmissionController = async (
   const result = await getRefereeInvitationsBySubmission({ submissionId });
 
   if (result.isErr()) {
-    return sendError(res, result.error, 403);
+    return sendError(res, result.error.message, 403);
   }
 
   return sendSuccess(res, result.value);

--- a/desci-server/src/controllers/journals/submissions/index.ts
+++ b/desci-server/src/controllers/journals/submissions/index.ts
@@ -455,7 +455,7 @@ export const getRefereeInvitationsBySubmissionController = async (
   if (
     isEditor.isOk() &&
     isEditor.value === EditorRole.ASSOCIATE_EDITOR &&
-    submission.value.assignedEditor.id !== req.user.id
+    submission.value.assignedEditorId !== req.user.id
   ) {
     return sendError(res, 'User is not the assigned editor for this submission', 403);
   }

--- a/desci-server/src/controllers/journals/submissions/index.ts
+++ b/desci-server/src/controllers/journals/submissions/index.ts
@@ -435,7 +435,6 @@ export const getRefereeInvitationsBySubmissionController = async (
   res: Response,
 ) => {
   const { journalId, submissionId } = req.validatedData.params;
-  const { limit, offset } = req.validatedData.query;
 
   const journal = await JournalManagementService.getJournalById(journalId);
   if (journal.isErr()) {
@@ -460,7 +459,7 @@ export const getRefereeInvitationsBySubmissionController = async (
     return sendError(res, 'User is not the assigned editor for this submission', 403);
   }
 
-  const result = await getRefereeInvitationsBySubmission({ submissionId, limit, offset });
+  const result = await getRefereeInvitationsBySubmission({ submissionId });
 
   if (result.isErr()) {
     return sendError(res, result.error, 403);

--- a/desci-server/src/docs/journals.ts
+++ b/desci-server/src/docs/journals.ts
@@ -3026,6 +3026,7 @@ export const getRefereeInvitationsBySubmissionOperation: ZodOpenApiOperationObje
       description: 'Not found - Journal or submission not found',
     },
   },
+  security: [{ BearerAuth: [] }],
 };
 
 export const journalPaths: ZodOpenApiPathsObject = {

--- a/desci-server/src/docs/journals.ts
+++ b/desci-server/src/docs/journals.ts
@@ -2973,6 +2973,61 @@ export const listJournalEditorialBoardOperation: ZodOpenApiOperationObject = {
   security: [{ BearerAuth: [] }],
 };
 
+// Get Referee Invitations by Submission
+export const getRefereeInvitationsBySubmissionOperation: ZodOpenApiOperationObject = {
+  operationId: 'getRefereeInvitationsBySubmission',
+  tags: ['Journals'],
+  summary: 'Get referee invitations for a specific submission',
+  description:
+    'Retrieve all referee invitations for a specific journal submission. This endpoint is restricted to editors (Chief Editor or Associate Editor) of the journal. Associate Editors can only view invitations for submissions they are assigned to.',
+  requestParams: {
+    path: reviewsApiSchema.shape.params,
+    query: reviewsApiSchema.shape.query,
+  },
+  responses: {
+    '200': {
+      description: 'Referee invitations retrieved successfully',
+      content: {
+        'application/json': {
+          schema: z.object({
+            ok: z.boolean(),
+            data: z.array(
+              z.object({
+                id: z.number(),
+                email: z.string().nullable(),
+                name: z.string().nullable(),
+                accepted: z.boolean(),
+                acceptedAt: z.string().nullable(),
+                declined: z.boolean(),
+                declinedAt: z.string().nullable(),
+                createdAt: z.string(),
+                expiresAt: z.string().nullable(),
+                invitedById: z.number(),
+                relativeDueDateHrs: z.number().nullable(),
+                expectedFormTemplateIds: z.array(z.number()),
+                invitedBy: z.object({
+                  id: z.number(),
+                  name: z.string().nullable(),
+                  email: z.string().nullable(),
+                }),
+              }),
+            ),
+          }),
+        },
+      },
+    },
+    '400': {
+      description: 'Bad request - Invalid submission ID or parameters',
+    },
+    '403': {
+      description: 'Forbidden - User is not authorized to view referee invitations for this submission',
+    },
+    '404': {
+      description: 'Not found - Journal or submission not found',
+    },
+  },
+};
+
 export const journalPaths: ZodOpenApiPathsObject = {
   '/v1/journals': {
     get: listJournalsOperation,
@@ -3032,6 +3087,9 @@ export const journalPaths: ZodOpenApiPathsObject = {
   },
   '/v1/journals/{journalId}/submissions/{submissionId}/assignments': {
     get: getAssignmentsBySubmissionOperation,
+  },
+  '/v1/journals/{journalId}/submissions/{submissionId}/referee-invitations': {
+    get: getRefereeInvitationsBySubmissionOperation,
   },
   '/v1/journals/{journalId}/submissions/{submissionId}/request-revision': {
     post: requestRevisionOperation,

--- a/desci-server/src/routes/v1/journals/submissions.ts
+++ b/desci-server/src/routes/v1/journals/submissions.ts
@@ -94,8 +94,8 @@ export default function submissionRoutes(router: Router) {
     '/:journalId/submissions/:submissionId/referee-invitations',
     [
       ensureUser,
-      validateInputs(reviewsApiSchema),
       ensureJournalRole([EditorRole.ASSOCIATE_EDITOR, EditorRole.CHIEF_EDITOR]),
+      validateInputs(reviewsApiSchema),
     ],
     asyncHandler(getRefereeInvitationsBySubmissionController),
   );

--- a/desci-server/src/routes/v1/journals/submissions.ts
+++ b/desci-server/src/routes/v1/journals/submissions.ts
@@ -10,6 +10,7 @@ import {
   acceptSubmissionController,
   requestRevisionController,
   getJournalSubmissionController,
+  getRefereeInvitationsBySubmissionController,
 } from '../../../controllers/journals/submissions/index.js';
 import { ensureJournalRole } from '../../../middleware/journalPermissions.js';
 import { ensureUser } from '../../../middleware/permissions.js';
@@ -21,6 +22,7 @@ import {
   listJournalSubmissionsSchema,
   rejectSubmissionSchema,
   requestRevisionSchema,
+  reviewsApiSchema,
   submissionApiSchema,
 } from '../../../schemas/journals.schema.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
@@ -86,5 +88,15 @@ export default function submissionRoutes(router: Router) {
       validateInputs(rejectSubmissionSchema),
     ],
     asyncHandler(rejectSubmissionController),
+  );
+
+  router.get(
+    '/:journalId/submissions/:submissionId/referee-invitations',
+    [
+      ensureUser,
+      validateInputs(reviewsApiSchema),
+      ensureJournalRole([EditorRole.ASSOCIATE_EDITOR, EditorRole.CHIEF_EDITOR]),
+    ],
+    asyncHandler(getRefereeInvitationsBySubmissionController),
   );
 }

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -234,7 +234,8 @@ export interface IRefereeInvite {
   id: number;
   submissionId: number;
   accepted: boolean;
-  acceptedAt: Date;
+  acceptedAt: Date | null;
+  declinedAt: Date | null;
   declined: boolean;
   expiresAt: Date; // Refers to the invite expiration date.
   relativeDueDateHrs: number; // Refers to the review due date, from the time of acceptance.
@@ -256,6 +257,7 @@ async function getRefereeInvites(
         accepted: true,
         acceptedAt: true,
         declined: true,
+        declinedAt: true,
         expiresAt: true,
         relativeDueDateHrs: true,
         token: true,

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -234,6 +234,7 @@ export interface IRefereeInvite {
   id: number;
   submissionId: number;
   accepted: boolean;
+  acceptedAt: Date;
   declined: boolean;
   expiresAt: Date; // Refers to the invite expiration date.
   relativeDueDateHrs: number; // Refers to the review due date, from the time of acceptance.
@@ -253,6 +254,7 @@ async function getRefereeInvites(
         id: true,
         submissionId: true,
         accepted: true,
+        acceptedAt: true,
         declined: true,
         expiresAt: true,
         relativeDueDateHrs: true,

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -1,4 +1,11 @@
-import { EditorRole, JournalEventLogAction, RefereeAssignment, RefereeInvite, SubmissionStatus } from '@prisma/client';
+import {
+  EditorRole,
+  JournalEventLogAction,
+  Prisma,
+  RefereeAssignment,
+  RefereeInvite,
+  SubmissionStatus,
+} from '@prisma/client';
 import { ok, err, Result } from 'neverthrow';
 
 import { prisma } from '../../client.js';
@@ -220,6 +227,72 @@ async function inviteReferee(data: InviteRefereeInput): Promise<Result<RefereeIn
 }
 
 /**
+ * Shared helper function to fetch referee invites with consistent select fields and ordering.
+ * This function centralizes the common query logic used across different services.
+ */
+async function fetchRefereeInvites(where: Prisma.RefereeInviteWhereInput): Promise<Result<any[], Error>> {
+  try {
+    const refereeInvites = await prisma.refereeInvite.findMany({
+      where,
+      select: {
+        id: true,
+        submissionId: true,
+        userId: true,
+        email: true,
+        name: true,
+        accepted: true,
+        acceptedAt: true,
+        declined: true,
+        declinedAt: true,
+        createdAt: true,
+        expiresAt: true,
+        invitedById: true,
+        relativeDueDateHrs: true,
+        expectedFormTemplateIds: true,
+        token: true,
+        invitedBy: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        submission: {
+          select: {
+            id: true,
+            journalId: true,
+            node: {
+              select: {
+                title: true,
+              },
+            },
+            author: {
+              select: {
+                name: true,
+              },
+            },
+            journal: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    return ok(refereeInvites);
+  } catch (error) {
+    logger.error({ error, where }, 'Failed to fetch referee invites');
+    return err(
+      error instanceof Error ? error : new Error('An unexpected error occurred during referee invite retrieval'),
+    );
+  }
+}
+
+/**
  * Get all referee invites for a referee.
  */
 export interface IRefereeInvite {
@@ -247,57 +320,37 @@ async function getRefereeInvites(
   refereeEmail?: string,
 ): Promise<Result<IRefereeInvite[], Error>> {
   try {
-    const refereeInvites = await prisma.refereeInvite.findMany({
-      where: {
-        OR: [{ userId: refereeUserId }, { email: refereeEmail }],
-      },
-      select: {
-        id: true,
-        submissionId: true,
-        accepted: true,
-        acceptedAt: true,
-        declined: true,
-        declinedAt: true,
-        expiresAt: true,
-        relativeDueDateHrs: true,
-        token: true,
-        submission: {
-          select: {
-            id: true,
-            dpid: true,
-            node: {
-              select: {
-                title: true,
-              },
-            },
-            author: {
-              select: {
-                name: true,
-              },
-            },
-            journalId: true,
-            journal: {
-              select: {
-                name: true,
-              },
-            },
-          },
-        },
-      },
+    const refereeInvitesResult = await fetchRefereeInvites({
+      OR: [{ userId: refereeUserId }, { email: refereeEmail }],
     });
 
-    const invites = refereeInvites.map((invite) => ({
-      ...invite,
-      submission: {
-        author: invite.submission.author.name,
-        id: invite.submissionId,
-        journalId: invite.submission.journalId,
-        journal: invite.submission.journal.name,
-        title: invite.submission.node.title,
-        dpid: invite.submission.dpid,
-      },
-    }));
-    return ok(invites);
+    if (refereeInvitesResult.isErr()) {
+      return refereeInvitesResult;
+    }
+
+    const refereeInvites = refereeInvitesResult.value;
+
+    // Get additional submission data for each invite
+    const invitesWithSubmissionData = refereeInvites.map((invite) => {
+      if (!invite.submission) {
+        throw new Error(`Submission not found for invite ${invite.id}`);
+      }
+
+      return {
+        ...invite,
+        invitedBy: invite.invitedBy?.name,
+        submission: {
+          author: invite.submission.author.name,
+          id: invite.submissionId,
+          journalId: invite.submission.journalId,
+          journal: invite.submission.journal.name,
+          title: invite.submission.node.title,
+          dpid: invite.submission.dpid,
+        },
+      };
+    });
+
+    return ok(invitesWithSubmissionData);
   } catch (error) {
     logger.error({ error, refereeUserId }, 'Failed to get referee invites');
     return err(
@@ -1045,4 +1098,5 @@ export const JournalRefereeManagementService = {
   invalidateRefereeAssignment,
   getRefereeInviteByToken,
   sendRefereeReviewReminder,
+  fetchRefereeInvites,
 };

--- a/desci-server/src/services/journals/JournalReviewService.ts
+++ b/desci-server/src/services/journals/JournalReviewService.ts
@@ -584,15 +584,7 @@ async function getAssignmentsBySubmission({
   return ok(assignments);
 }
 
-async function getRefereeInvitationsBySubmission({
-  submissionId,
-  limit = 20,
-  offset = 0,
-}: {
-  submissionId: number;
-  limit?: number;
-  offset?: number;
-}) {
+async function getRefereeInvitationsBySubmission({ submissionId }: { submissionId: number }) {
   // Get all assignments for this submission
   const assignments = await prisma.refereeInvite.findMany({
     where: {
@@ -619,8 +611,6 @@ async function getRefereeInvitationsBySubmission({
         },
       },
     },
-    skip: offset,
-    take: limit,
     orderBy: {
       createdAt: 'desc',
     },

--- a/desci-server/src/services/journals/JournalReviewService.ts
+++ b/desci-server/src/services/journals/JournalReviewService.ts
@@ -584,6 +584,51 @@ async function getAssignmentsBySubmission({
   return ok(assignments);
 }
 
+async function getRefereeInvitationsBySubmission({
+  submissionId,
+  limit = 20,
+  offset = 0,
+}: {
+  submissionId: number;
+  limit?: number;
+  offset?: number;
+}) {
+  // Get all assignments for this submission
+  const assignments = await prisma.refereeInvite.findMany({
+    where: {
+      submissionId,
+    },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      accepted: true,
+      acceptedAt: true,
+      declined: true,
+      declinedAt: true,
+      createdAt: true,
+      expiresAt: true,
+      invitedById: true,
+      relativeDueDateHrs: true,
+      expectedFormTemplateIds: true,
+      invitedBy: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+    },
+    skip: offset,
+    take: limit,
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+
+  return ok(assignments);
+}
+
 export {
   getSubmissionReviews,
   isSubmissionReviewed,
@@ -597,4 +642,5 @@ export {
   getJournalReviewById,
   getReviewsByAssignment,
   getAssignmentsBySubmission,
+  getRefereeInvitationsBySubmission,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET /v1/journals/{journalId}/submissions/{submissionId}/referee-invitations (no pagination). Added GET /v1/journals/referee/invitations/{token} to fetch an invite by token.

* **API Changes**
  * Responses now use an envelope { ok, data } instead of a bare array. Invitation items include expanded submission details and new timestamps acceptedAt/declinedAt.

* **Documentation**
  * API docs updated with new endpoints, parameters, response shapes, and error responses (400, 403, 404).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->