### PR TITLE
Referee Invitee details

### DIFF
--- a/desci-server/src/docs/journals.ts
+++ b/desci-server/src/docs/journals.ts
@@ -3081,6 +3081,12 @@ export const getRefereeInviteByTokenOperation: ZodOpenApiOperationObject = {
               relativeDueDateHrs: z.number().nullable(),
               expectedFormTemplateIds: z.array(z.number()),
               token: z.string(),
+              user: z
+                .object({
+                  id: z.number(),
+                  orcid: z.string().nullable(),
+                })
+                .optional(),
             }),
           }),
         },

--- a/desci-server/src/docs/journals.ts
+++ b/desci-server/src/docs/journals.ts
@@ -3086,7 +3086,11 @@ export const getRefereeInviteByTokenOperation: ZodOpenApiOperationObject = {
                   id: z.number(),
                   orcid: z.string().nullable(),
                 })
-                .optional(),
+                .nullable()
+                .optional()
+                .describe(
+                  'The user who was invited to review the submission. This is null if the referee is not a registered user.',
+                ),
             }),
           }),
         },

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -319,10 +319,10 @@ export interface IRefereeInvite {
   expiresAt: Date; // Refers to the invite expiration date.
   relativeDueDateHrs: number; // Refers to the review due date, from the time of acceptance.
   token: string;
-  user: {
+  user?: {
     id: number;
     orcid: string;
-  };
+  } | null;
 }
 
 async function getRefereeInvites(

--- a/desci-server/src/services/journals/JournalRefereeManagementService.ts
+++ b/desci-server/src/services/journals/JournalRefereeManagementService.ts
@@ -277,6 +277,12 @@ async function fetchRefereeInvites(where: Prisma.RefereeInviteWhereInput): Promi
             },
           },
         },
+        user: {
+          select: {
+            id: true,
+            orcid: true,
+          },
+        },
       },
       orderBy: {
         createdAt: 'desc',
@@ -313,6 +319,10 @@ export interface IRefereeInvite {
   expiresAt: Date; // Refers to the invite expiration date.
   relativeDueDateHrs: number; // Refers to the review due date, from the time of acceptance.
   token: string;
+  user: {
+    id: number;
+    orcid: string;
+  };
 }
 
 async function getRefereeInvites(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referee invites now include associated user details (ID and ORCID) when available, enabling richer context wherever invites are viewed.
* **Public API**
  * The response for fetching referee invites now optionally returns a nested user object (ID, ORCID) alongside existing fields. This is backward compatible and only present when data exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->