### PR TITLE
Fix flight URL protocol

### DIFF
--- a/nodes-lib/package.json
+++ b/nodes-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desci-labs/nodes-lib",
-  "version": "0.2.0-rc10",
+  "version": "0.2.0-rc11",
   "homepage": "https://github.com/desci-labs/nodes#readme",
   "description": "Stand-alone client library for interacting with desci-server",
   "repository": {

--- a/nodes-lib/src/shared/config/index.ts
+++ b/nodes-lib/src/shared/config/index.ts
@@ -37,7 +37,7 @@ export const NODESLIB_CONFIGS = {
     ceramicNodeUrl: "https://ceramic-dev.desci.com",
     legacyChainConfig: LEGACY_CHAIN_CONFIGS.dev,
     ceramicOneRpcUrl: "https://ceramic-one-dev-rpc.desci.com",
-    ceramicOneFlightUrl: "https://ceramic-one-dev.desci.com:5102",
+    ceramicOneFlightUrl: "http://ceramic-one-dev.desci.com:5102",
     chainConfig: CHAIN_CONFIGS.dev,
   },
   staging: {
@@ -46,7 +46,7 @@ export const NODESLIB_CONFIGS = {
     ceramicNodeUrl: "https://ceramic-prod.desci.com",
     legacyChainConfig: LEGACY_CHAIN_CONFIGS.prod, // also using the prod contracts
     ceramicOneRpcUrl: "https://ceramic-one-prod-rpc.desci.com",
-    ceramicOneFlightUrl: "https://ceramic-one-prod.desci.com:5102",
+    ceramicOneFlightUrl: "http://ceramic-one-prod.desci.com:5102",
     chainConfig: CHAIN_CONFIGS.prod, // also using prod contracts
   },
   prod: {
@@ -55,7 +55,7 @@ export const NODESLIB_CONFIGS = {
     ceramicNodeUrl: "https://ceramic-prod.desci.com",
     legacyChainConfig: LEGACY_CHAIN_CONFIGS.prod,
     ceramicOneRpcUrl: "https://ceramic-one-prod-rpc.desci.com",
-    ceramicOneFlightUrl: "https://ceramic-one-prod.desci.com:5102",
+    ceramicOneFlightUrl: "http://ceramic-one-prod.desci.com:5102",
     chainConfig: CHAIN_CONFIGS.prod,
   },
 } as const satisfies { [Env in NodesEnv]: NodesLibConfig };


### PR DESCRIPTION
We can't terminate SSL for unproxied records in Cloudflare, and the proxy doesn't support non-standard ports or protocols. Anyway these are queries of public data without any auth so should be np for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped package version to 0.2.0-rc11.
  - Updated backend service endpoints to use HTTP (dev, staging, prod) for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->