### PR TITLE
server: remove subgraph queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,6 @@ ESTUARY_API_URL=https://api.estuary.tech
 
 SERVER_URL=http://localhost:5420
 DAPP_URL=http://localhost:3000
-THEGRAPH_API_URL=http://host.docker.internal:8000/subgraphs/name/nodes
 
 # set to true if need to send email
 SHOULD_SEND_EMAIL=

--- a/desci-server/src/config/index.ts
+++ b/desci-server/src/config/index.ts
@@ -11,7 +11,6 @@ export const PUBLIC_IPFS_PATH =
 export const MEDIA_SERVER_API_URL = process.env.NODES_MEDIA_SERVER_URL;
 export const MEDIA_SERVER_API_KEY = process.env.MEDIA_SECRET_KEY;
 export const SERVER_URL = process.env.SERVER_URL ?? 'localhost';
-export const THEGRAPH_API_URL = process.env.THEGRAPH_API_URL;
 
 const OPTIMISM_RPC_URLS = {
   local: 'http://host.docker.internal:8545',

--- a/desci-server/src/routes/v1/admin/index.ts
+++ b/desci-server/src/routes/v1/admin/index.ts
@@ -2,11 +2,9 @@ import { Router } from 'express';
 
 import {
   createCsv,
-  getActiveOrcidUserAnalytics,
   getActiveUserAnalytics,
   getAnalytics,
   getAggregatedAnalytics,
-  getNewOrcidUserAnalytics,
   getNewUserAnalytics,
   userAnalyticsSchema,
   getAggregatedAnalyticsCsv,
@@ -17,11 +15,9 @@ import { debugAllNodesHandler, debugNodeHandler } from '../../../controllers/adm
 import { listDoiRecords, mintDoi } from '../../../controllers/admin/doi/index.js';
 import { resumePublish } from '../../../controllers/admin/publish/resumePublish.js';
 import { analyticsChartSchema } from '../../../controllers/admin/schema.js';
-import { getMarketingConsentUsersCsv, searchUserProfiles } from '../../../controllers/admin/users.js';
 import { ensureAdmin, ensureUserIsAdmin } from '../../../middleware/ensureAdmin.js';
 import { ensureUser } from '../../../middleware/permissions.js';
-import { validate, validateInputs } from '../../../middleware/validator.js';
-import { exportMarketingConsentSchema } from '../../../schemas/users.schema.js';
+import { validate } from '../../../middleware/validator.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 
 import communities from './communities/index.js';

--- a/desci-server/src/services/chain.ts
+++ b/desci-server/src/services/chain.ts
@@ -1,12 +1,8 @@
-import { providers, Wallet } from "ethers";
-import {
-  ALIAS_REGISTRY_ADDRESS,
-  GANACHE_PKEY,
-  OPTIMISM_RPC_URL,
-  serverIsLocal
-} from "../config/index.js";
-import { logger as parentLogger } from "../logger.js";
-import { DpidAliasRegistry__factory } from "@desci-labs/desci-contracts/dist/typechain-types/index.js";
+import { providers, Wallet } from 'ethers';
+import { ALIAS_REGISTRY_ADDRESS, GANACHE_PKEY, OPTIMISM_RPC_URL, serverIsLocal } from '../config/index.js';
+import { logger as parentLogger } from '../logger.js';
+import { DpidAliasRegistry__factory } from '@desci-labs/desci-contracts/dist/typechain-types/index.js';
+import { getOrCache } from '../redisClient.js';
 
 const logger = parentLogger.child({
   module: 'Services::Chain',
@@ -21,12 +17,12 @@ export const getOptimismProvider = async () => {
 export const getHotWalletKey = () => {
   if (serverIsLocal) {
     return GANACHE_PKEY;
-  } else if (process.env.HOT_WALLET_KEY){
+  } else if (process.env.HOT_WALLET_KEY) {
     return process.env.HOT_WALLET_KEY;
   } else {
-    logger.error({ fn: 'getHotWalletKey' }, "HOT_WALLET_KEY not set");
-    throw new Error("HOT_WALLET_KEY missing");
-  };
+    logger.error({ fn: 'getHotWalletKey' }, 'HOT_WALLET_KEY not set');
+    throw new Error('HOT_WALLET_KEY missing');
+  }
 };
 
 export const getOwnerWalletKey = () => {
@@ -35,9 +31,9 @@ export const getOwnerWalletKey = () => {
   } else if (process.env.REGISTRY_OWNER_PKEY) {
     return process.env.REGISTRY_OWNER_PKEY;
   } else {
-    logger.error({ fn: 'getOwnerWalletKey' }, "REGISTRY_OWNER_PKEY not set");
-    throw new Error("REGISTRY_OWNER_PKEY missing")
-  };
+    logger.error({ fn: 'getOwnerWalletKey' }, 'REGISTRY_OWNER_PKEY not set');
+    throw new Error('REGISTRY_OWNER_PKEY missing');
+  }
 };
 
 export const getHotWallet = async () => {
@@ -50,7 +46,56 @@ export const getRegistryOwnerWallet = async () => {
   const key = getOwnerWalletKey();
   const provider = await getOptimismProvider();
   return new Wallet(key, provider);
-}
+};
 
-export const getAliasRegistry = (wallet: Wallet) =>
-  DpidAliasRegistry__factory.connect(ALIAS_REGISTRY_ADDRESS, wallet);
+export const getAliasRegistry = (walletOrProvider: Wallet | providers.JsonRpcProvider) =>
+  DpidAliasRegistry__factory.connect(ALIAS_REGISTRY_ADDRESS, walletOrProvider);
+
+const getLegacyRpcProvider = async () => {
+  const provider = new providers.JsonRpcProvider('https://reverse-proxy-prod.desci.com/rpc_sepolia');
+  await provider.ready;
+  return provider;
+};
+
+export const getTransactionTimestamps = async (txHashes: string[]): Promise<Record<string, string>> => {
+  try {
+    const provider = await getLegacyRpcProvider();
+
+    // Get all transactions in parallel, caching results
+    const txPromises = txHashes.map((hash) =>
+      getOrCache(`tx-receipt-${hash}`, () => provider.getTransactionReceipt(hash)),
+    );
+    const txs = await Promise.all(txPromises);
+
+    // Get unique block numbers, caching results
+    const blockNumbers = [...new Set(txs.filter((tx) => tx !== null).map((tx) => tx.blockNumber))];
+
+    // Fetch blocks in parallel, caching results
+    const blockPromises = blockNumbers.map((num) =>
+      getOrCache(`block-timestamp-${num}`, async () => await provider.getBlock(num)),
+    );
+    const blocks = await Promise.all(blockPromises);
+
+    // Create a map of blockNumber -> timestamp
+    const blockTimestamps = new Map<number, number>();
+    blocks.forEach((block) => {
+      blockTimestamps.set(block.number, block.timestamp);
+    });
+
+    // Map back to transaction hashes
+    const result: Record<string, string> = {};
+    txHashes.forEach((hash, index) => {
+      const tx = txs[index];
+      if (tx) {
+        result[hash] = blockTimestamps.get(tx.blockNumber).toString();
+      } else {
+        result[hash] = undefined;
+      }
+    });
+
+    return result;
+  } catch (error) {
+    logger.warn(error, 'Error fetching transaction timestamps');
+    return {};
+  }
+};


### PR DESCRIPTION
The dev subgraph has been broken and semi-recently removed, which breaks fileTree timestamp retrieval for legacy nodes and the /admin/debug routes.
 
- Removes subgraph integration entirely
- Implements transaction timestamp fetching with the Alchemy RPC (responses cached in redis)
- Fixes /admin/debug route by relying on legacy history from the alias registry contracts instead of subgraph


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Switched timestamp retrieval to on-chain sources and updated legacy migration flow to use alias-based lookups, improving reliability of history and timestamp handling.
  - Trimmed unused admin analytics and validator imports.

- Chores
  - Removed obsolete THEGRAPH_API_URL from environment example and cleaned up related configuration exports.

No user-facing behavior changes; backend reliability and maintainability improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->