### PR TITLE
chore: merge develop to main (dpid metadata fix)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,7 +3,7 @@ NODE_ENV=test
 PORT=5421
 
 IPFS_NODE_URL=http://host.docker.internal:5003
-PUBLIC_IPFS_RESOLVER=https://babel.desci.com
+PUBLIC_IPFS_RESOLVER=https://pub.desci.com
 GUEST_IPFS_NODE_URL=http://host.docker.internal:5003 # Share the same kubo node
 
 ### Database - Postgres

--- a/desci-server/src/controllers/data/delete.ts
+++ b/desci-server/src/controllers/data/delete.ts
@@ -41,11 +41,15 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
   });
   if (!node) {
     logger.warn(`DATA::Delete: auth failed, user id: ${owner.id} does not own node: ${uuid}`);
-    return res.status(400).json({ error: 'failed' });
+    return res.status(403).json({ error: 'node not found or not owned by user' });
   }
 
   const latestManifest = await getLatestManifestFromNode(node);
   console.log('latestManifest', latestManifest);
+  if (!latestManifest) {
+    logger.error({ uuid }, 'DATA::Delete: failed to retrieve manifest from node');
+    return res.status(400).json({ error: 'manifest not found' });
+  }
   try {
     /**
      * Remove draft node tree entries, add them to the cid prune list
@@ -96,7 +100,7 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
           },
         });
 
-    const dataRefsToDelete = existingDataRefs.filter((e) => e.path.startsWith(path + '/') || e.path === path);
+    const dataRefsToDelete = existingDataRefs.filter((e) => e.path?.startsWith(path + '/') || e.path === path);
 
     const dataRefDeletionIds = dataRefsToDelete.map((e) => e.id);
 
@@ -131,8 +135,10 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
     }
 
     const { persistedManifestCid } = await persistManifest({ manifest: updatedManifest, node, userId: owner.id });
-    if (!persistedManifestCid)
-      throw Error(`[DATA::DELETE]Failed to persist manifest: ${updatedManifest}, node: ${node}, userId: ${owner.id}`);
+    if (!persistedManifestCid) {
+      logger.error({ uuid, path }, 'DATA::Delete: failed to persist manifest to IPFS');
+      return res.status(500).json({ error: 'failed to persist manifest' });
+    }
 
     logger.info(`DATA::Delete Success, path: `, path, ' deleted');
 
@@ -160,10 +166,9 @@ export const deleteData = async (req: Request, res: Response<DeleteResponse | Er
       manifestCid: persistedManifestCid,
     });
   } catch (e: any) {
-    console.log('[ERROR]::[DeleteComponentsFromManifest]::', e);
-    logger.error(e, `DATA::Delete error: ${e}`);
+    logger.error({ err: e, uuid, path }, `DATA::Delete unhandled error: ${e.message}`);
+    return res.status(500).json({ error: `delete failed: ${e.message}` });
   }
-  return res.status(400).json({ error: 'failed' });
 };
 
 interface UpdatingManifestParams {

--- a/desci-server/src/controllers/dpid/index.ts
+++ b/desci-server/src/controllers/dpid/index.ts
@@ -19,17 +19,42 @@ export async function retrieveDpidMetadata(req: RetrieveDpidMetadataRequest, res
   const { dpid } = req.validatedData.params;
   const { version } = req.validatedData.query;
 
-  const versionSuffix = version ? `-v${version}` : '';
+  // When a specific version is requested, cache it for a long time (immutable).
+  // When "latest" is requested (no version), use a short TTL so new publishes
+  // are reflected quickly instead of being stale for up to a week.
+  const LATEST_TTL = 60 * 10; // 10 minutes
+  const isLatest = !version;
+  const versionSuffix = version ? `-v${version}` : '-latest';
   const cacheKey = `${DPID_METADATA_CACHE_PREFIX}-${dpid}${versionSuffix}`;
+
+  logger.info({ dpid, version, isLatest, cacheKey }, 'Retrieving dpid metadata');
 
   const cachedMetadata = (await getFromCache(cacheKey)) as DpidMetadata | null;
   if (cachedMetadata) {
+    logger.info(
+      { dpid, version: (cachedMetadata as any).version, cacheKey, hasCover: !!cachedMetadata.coverImageUrl },
+      'Cache HIT',
+    );
     new SuccessResponse(cachedMetadata).send(res);
     return;
   }
 
+  logger.info({ dpid, cacheKey }, 'Cache MISS, fetching from DB');
+  const start = Date.now();
   const dpidMetadata = await getDpidMetadata(Number(dpid), version);
-  await setToCache(cacheKey, dpidMetadata, DEFAULT_TTL);
+  const elapsed = Date.now() - start;
+  logger.info(
+    {
+      dpid,
+      resolvedVersion: (dpidMetadata as any).version,
+      title: (dpidMetadata as any).title,
+      hasCover: !!(dpidMetadata as any).coverImageUrl,
+      elapsed,
+      ttl: isLatest ? LATEST_TTL : DEFAULT_TTL,
+    },
+    'Fetched dpid metadata, caching',
+  );
+  await setToCache(cacheKey, dpidMetadata, isLatest ? LATEST_TTL : DEFAULT_TTL);
 
   new SuccessResponse(dpidMetadata).send(res);
 

--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -138,6 +138,12 @@ export const publish = async (req: PublishRequest, res: Response<PublishResBody>
     // Make sure we don't serve stale manifest state when a publish is happening
     delFromCache(`node-draft-${ensureUuidEndsWithDot(node.uuid)}`);
 
+    // Invalidate dpid metadata cache so link previews reflect the new version
+    if (dpidAlias) {
+      logger.info({ dpidAlias, cacheKey: `dpid-metadata-${dpidAlias}-latest` }, 'Invalidating dpid metadata cache');
+      delFromCache(`dpid-metadata-${dpidAlias}-latest`);
+    }
+
     saveInteraction({
       req,
       action: ActionType.PUBLISH_NODE,

--- a/desci-server/src/services/dpid.ts
+++ b/desci-server/src/services/dpid.ts
@@ -17,6 +17,7 @@ export interface DpidMetadata {
   publicationYear: number;
   publicationDate: string;
   pdfUrl: string;
+  coverImageUrl: string;
 }
 
 export async function getDpidMetadata(dpid: number, version?: number): Promise<DpidMetadata> {
@@ -64,6 +65,12 @@ export async function getDpidMetadata(dpid: number, version?: number): Promise<D
         component.payload?.path?.endsWith('.pdf')),
   );
 
+  // Look up the cached cover image for this version
+  const coverEntry = await prisma.nodeCover.findFirst({
+    where: { nodeUuid: node.uuid, version: targetVersionIndex },
+    select: { url: true },
+  });
+
   const date = targetVersion.time ? new Date(parseInt(targetVersion.time) * 1000) : undefined;
   const pubDate = date ? date.toLocaleDateString().split('/') : undefined;
   const metadata = {
@@ -74,6 +81,7 @@ export async function getDpidMetadata(dpid: number, version?: number): Promise<D
     publicationYear: targetVersion.time ? new Date(parseInt(targetVersion.time) * 1000).getFullYear() : undefined,
     publicationDate: pubDate ? `${pubDate[2]}/${pubDate[0]}/${pubDate[1]}` : undefined, // YYYY/MM/DD
     pdfUrl: pdfComponent ? `${IPFS_RESOLVER}/${pdfComponent.payload.cid}` : undefined,
+    coverImageUrl: coverEntry?.url || undefined,
     dpid: node.dpidAlias || node.legacyDpid,
     version: targetVersionIndex + 1,
   };


### PR DESCRIPTION
## Summary
- Merges develop → main to deploy dpid metadata fixes to production
- Includes: cache key fix, 10min TTL for latest, cache invalidation on publish, coverImageUrl

## Test plan
- [ ] Verify prod desci-server deployment succeeds
- [ ] `curl https://nodes-api.desci.com/v1/dpid/1077` returns coverImageUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)