### PR TITLE
fix: cover version race condition on publish

### DIFF
--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -330,9 +330,15 @@ const syncPublish = async (
   void discordNotify({ message: `${targetDpidUrl}/${dpidAlias}` });
 
   /**
-   * Save the cover art for this Node for later sharing: PDF -> JPG for this version
+   * Save the cover art for this Node for later sharing: PDF -> JPG for this version.
+   * Pass the version explicitly because the subgraph may not have indexed the new
+   * version yet, causing cacheNodeMetadata to save the cover under the wrong version.
    */
-  void cacheNodeMetadata(node.uuid, cid).catch((err) => logger.warn(err, 'Error: Caching node metadata failed'));
+  const versionCount = await prisma.nodeVersion.count({ where: { nodeId: node.id } });
+  const newVersionIndex = versionCount - 1;
+  void cacheNodeMetadata(node.uuid, cid, newVersionIndex).catch((err) =>
+    logger.warn(err, 'Error: Caching node metadata failed'),
+  );
   return dpidAlias;
 };
 


### PR DESCRIPTION
## Summary
- `cacheNodeMetadata` derives the version number from the subgraph, but during publish the new version isn't indexed yet
- This caused covers to be saved under the **previous** version number (e.g., version 11 instead of 12)
- `getDpidMetadata` then queries by the correct version and finds nothing → OG image falls back to generic S3 placeholder
- Fix: pass the explicit version count from `NodeVersion` table, which is already updated at that point in the publish flow

## Root cause
Race condition between publish and subgraph indexing. `cacheNodeMetadata` was fire-and-forget with no explicit version, so it called `getIndexedResearchObjects` which returned stale version count.

## Test plan
- [ ] Publish a new version of a node with a starred PDF
- [ ] Check `nodeCover` table — version should match the new version index
- [ ] Verify `GET /v1/dpid/:dpid` returns `coverImageUrl` for the latest version
- [ ] Share `dpid.org/<dpid>` on iMessage/Slack — should show PDF cover, not generic image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyword extraction from research papers during metadata processing
  * Implemented AI-powered metadata extraction as a fallback when primary parsing service is unavailable

* **Improvements**
  * Enhanced manuscript metadata handling during publishing for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->