### PR TITLE
fix: cover image fade to white

### DIFF
--- a/desci-server/Dockerfile.ci
+++ b/desci-server/Dockerfile.ci
@@ -43,6 +43,7 @@ COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 COPY --from=builder --chown=node:node /app/prisma ./prisma
 COPY --from=builder --chown=node:node /app/package.json ./package.json
 COPY --from=builder --chown=node:node /app/scripts ./scripts
+COPY --from=builder --chown=node:node /app/src/ssl ./src/ssl
 
 USER node
 

--- a/nodes-media/src/controllers/nodes/cover.ts
+++ b/nodes-media/src/controllers/nodes/cover.ts
@@ -57,20 +57,18 @@ const cover = async function (req: Request, res: Response) {
       CROPPED_IMG,
     ]);
 
-    // Step 2: Generate a gradient mask (white→black over bottom 120px)
+    // Step 2: Generate a white gradient overlay (transparent→white over bottom 120px)
     await convertAsync([
-      '-size', '1200x630', 'xc:white',
-      '-size', '1200x120', 'gradient:white-black',
-      '-gravity', 'South',
-      '-composite',
+      '-size', '1200x510', 'xc:none',
+      '-size', '1200x120', 'gradient:none-white',
+      '-append',
       GRADIENT_IMG,
     ]);
 
-    // Step 3: Composite — fade bottom to black
+    // Step 3: Composite — fade bottom to white
     await convertAsync([
       CROPPED_IMG,
       GRADIENT_IMG,
-      '-compose', 'Multiply',
       '-composite',
       '-quality', '90',
       TARGET_IMG,


### PR DESCRIPTION
## Summary
- Switch cover gradient from fade-to-black to fade-to-white
- Looks better on iMessage/social card light backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)