### PR TITLE
feat(openalex-importer): add /pipelines command for downstream health

### DIFF
--- a/openalex-importer/src/notifier.test.ts
+++ b/openalex-importer/src/notifier.test.ts
@@ -18,6 +18,7 @@ let notifyCaughtUp: typeof import('./notifier.js')['notifyCaughtUp'];
 let markImporting: typeof import('./notifier.js')['markImporting'];
 let sendDailyDigest: typeof import('./notifier.js')['sendDailyDigest'];
 let buildDigestMessage: typeof import('./notifier.js')['buildDigestMessage'];
+let buildPipelineStatus: typeof import('./notifier.js')['buildPipelineStatus'];
 let startCommandListener: typeof import('./notifier.js')['startCommandListener'];
 let stopCommandListener: typeof import('./notifier.js')['stopCommandListener'];
 
@@ -25,7 +26,7 @@ beforeEach(async () => {
   vi.resetModules();
   vi.stubEnv('TELEGRAM_BOT_TOKEN', 'test-token');
   vi.stubEnv('TELEGRAM_CHAT_ID', '-100123456');
-  fetchSpy.mockClear();
+  fetchSpy.mockReset();
   fetchSpy.mockResolvedValue({ ok: true, text: async () => '{}' });
 
   const mod = await import('./notifier.js');
@@ -35,6 +36,7 @@ beforeEach(async () => {
   markImporting = mod.markImporting;
   sendDailyDigest = mod.sendDailyDigest;
   buildDigestMessage = mod.buildDigestMessage;
+  buildPipelineStatus = mod.buildPipelineStatus;
   startCommandListener = mod.startCommandListener;
   stopCommandListener = mod.stopCommandListener;
 });
@@ -289,6 +291,137 @@ describe('buildDigestMessage', () => {
 
     const message = await buildDigestMessage(mockDb);
     expect(message).toContain('never');
+  });
+});
+
+describe('buildPipelineStatus', () => {
+  it('shows overall health and per-pipeline details', async () => {
+    const mockDb = {
+      oneOrNone: vi.fn().mockResolvedValueOnce({ max_batch: '14611' }),
+      manyOrNone: vi.fn().mockResolvedValueOnce([
+        { service: 'pg-to-es-batch-openalex', value: '14527', updated_at: new Date(Date.now() - 3600_000) },
+        { service: 'ml-novelty-batch-openalex', value: '14527', updated_at: new Date(Date.now() - 3600_000) },
+        { service: 'pg-to-vector-db-batch-openalex', value: '6451', updated_at: new Date('2026-02-27') },
+      ]),
+    } as any;
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 'deploy-es', name: 'pg_to_es_batch_import_deployment' },
+          { id: 'deploy-nov', name: 'batch_novelty_openalex_deployment' },
+          { id: 'deploy-qdr', name: 'pg_to_vector_db_batch_import_deployment' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 'run1', deployment_id: 'deploy-es', state: { type: 'COMPLETED', name: 'Completed' }, start_time: new Date(Date.now() - 7200_000).toISOString(), total_run_time: 221 },
+          { id: 'run2', deployment_id: 'deploy-nov', state: { type: 'COMPLETED', name: 'Completed' }, start_time: new Date(Date.now() - 7200_000).toISOString(), total_run_time: 1540 },
+          { id: 'run3', deployment_id: 'deploy-qdr', state: { type: 'COMPLETED', name: 'Completed' }, start_time: new Date(Date.now() - 86400_000).toISOString(), total_run_time: 3.8 },
+        ],
+      });
+
+    const message = await buildPipelineStatus(mockDb);
+    expect(message).toContain('Pipeline Health');
+    expect(message).toContain('action needed');
+    expect(message).toContain('PG → Elasticsearch');
+    expect(message).toContain('Lagging');
+    expect(message).toContain('99.4%');
+    expect(message).toContain('84 batches behind');
+    expect(message).toContain('PG → Qdrant');
+    expect(message).toContain('Stalled');
+    expect(message).toContain('6,451');
+    expect(message).toContain('no data processed');
+    expect(message).toContain('No progress since');
+    expect(message).toContain('Importer at batch');
+  });
+
+  it('shows all healthy when pipelines are caught up', async () => {
+    const mockDb = {
+      oneOrNone: vi.fn().mockResolvedValueOnce({ max_batch: '14611' }),
+      manyOrNone: vi.fn().mockResolvedValueOnce([
+        { service: 'pg-to-es-batch-openalex', value: '14611', updated_at: new Date() },
+        { service: 'ml-novelty-batch-openalex', value: '14611', updated_at: new Date() },
+        { service: 'pg-to-vector-db-batch-openalex', value: '14611', updated_at: new Date() },
+      ]),
+    } as any;
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 'd1', name: 'pg_to_es_batch_import_deployment' },
+          { id: 'd2', name: 'batch_novelty_openalex_deployment' },
+          { id: 'd3', name: 'pg_to_vector_db_batch_import_deployment' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 'r1', deployment_id: 'd1', state: { type: 'COMPLETED', name: 'Completed' }, start_time: new Date().toISOString(), total_run_time: 300 },
+          { id: 'r2', deployment_id: 'd2', state: { type: 'COMPLETED', name: 'Completed' }, start_time: new Date().toISOString(), total_run_time: 1200 },
+          { id: 'r3', deployment_id: 'd3', state: { type: 'COMPLETED', name: 'Completed' }, start_time: new Date().toISOString(), total_run_time: 600 },
+        ],
+      });
+
+    const message = await buildPipelineStatus(mockDb);
+    expect(message).toContain('All pipelines healthy');
+    expect(message).toContain('caught up');
+  });
+
+  it('handles Prefect API failure gracefully', async () => {
+    const mockDb = {
+      oneOrNone: vi.fn().mockResolvedValueOnce({ max_batch: '14611' }),
+      manyOrNone: vi.fn().mockResolvedValueOnce([
+        { service: 'pg-to-es-batch-openalex', value: '14527', updated_at: new Date() },
+      ]),
+    } as any;
+
+    fetchSpy.mockRejectedValueOnce(new Error('connection refused'));
+
+    const message = await buildPipelineStatus(mockDb);
+    expect(message).toContain('Pipeline Health');
+    expect(message).toContain('No recent runs found');
+    expect(message).toContain('14,527');
+  });
+
+  it('handles empty export_metadata gracefully', async () => {
+    const mockDb = {
+      oneOrNone: vi.fn().mockResolvedValueOnce({ max_batch: '100' }),
+      manyOrNone: vi.fn().mockResolvedValueOnce([]),
+    } as any;
+
+    fetchSpy.mockRejectedValueOnce(new Error('connection refused'));
+
+    const message = await buildPipelineStatus(mockDb);
+    expect(message).toContain('no tracking data');
+  });
+
+  it('shows failing status for crashed runs', async () => {
+    const mockDb = {
+      oneOrNone: vi.fn().mockResolvedValueOnce({ max_batch: '100' }),
+      manyOrNone: vi.fn().mockResolvedValueOnce([
+        { service: 'pg-to-es-batch-openalex', value: '90', updated_at: new Date() },
+      ]),
+    } as any;
+
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: 'd1', name: 'pg_to_es_batch_import_deployment' }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 'r1', deployment_id: 'd1', state: { type: 'CRASHED', name: 'Crashed' }, start_time: new Date().toISOString(), total_run_time: 2 },
+        ],
+      });
+
+    const message = await buildPipelineStatus(mockDb);
+    expect(message).toContain('Last run failed');
+    expect(message).toContain('action needed');
   });
 });
 

--- a/openalex-importer/src/notifier.ts
+++ b/openalex-importer/src/notifier.ts
@@ -6,6 +6,13 @@ import type { OaDb } from './db/index.js';
 const TELEGRAM_API = 'https://api.telegram.org';
 const ERROR_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour between error notifications
 const POLL_INTERVAL_MS = 5_000;
+const PREFECT_API = process.env.PREFECT_API_URL || 'http://alexandria.desci.com:4200';
+
+const DOWNSTREAM_PIPELINES = [
+  { deployment: 'pg_to_es_batch_import_deployment', service: 'pg-to-es-batch-openalex', label: 'PG → Elasticsearch' },
+  { deployment: 'batch_novelty_openalex_deployment', service: 'ml-novelty-batch-openalex', label: 'Batch Novelty' },
+  { deployment: 'pg_to_vector_db_batch_import_deployment', service: 'pg-to-vector-db-batch-openalex', label: 'PG → Qdrant' },
+] as const;
 
 let lastErrorNotifyMs = 0;
 let wasCaughtUp = true;
@@ -214,6 +221,175 @@ export const sendDailyDigest = async (db: OaDb): Promise<void> => {
   }
 };
 
+interface PrefectFlowRun {
+  id: string;
+  deployment_id: string;
+  state: { type: string; name: string };
+  start_time: string | null;
+  total_run_time: number;
+}
+
+interface PrefectDeployment {
+  id: string;
+  name: string;
+  schedules: Array<{ schedule: { cron: string; timezone?: string }; active: boolean }>;
+}
+
+/**
+ * Queries the Prefect API and export_metadata to build a status summary
+ * for all downstream pipelines (ES, novelty, Qdrant).
+ */
+export const buildPipelineStatus = async (db: OaDb): Promise<string> => {
+  const importerBatch = await db.oneOrNone<{ max_batch: string }>(
+    `SELECT MAX(id)::text AS max_batch FROM openalex.batch WHERE finished_at IS NOT NULL`,
+  );
+  const currentBatch = parseInt(importerBatch?.max_batch ?? '0');
+
+  const exportRows = await db.manyOrNone<{ service: string; value: string; updated_at: Date }>(
+    `SELECT service, value, updated_at FROM openalex.export_metadata
+     WHERE service IN ($1:csv)`,
+    [DOWNSTREAM_PIPELINES.map(p => p.service)],
+  );
+  const exportByService = new Map(exportRows.map(r => [r.service, r]));
+
+  let deploymentMap = new Map<string, string>();
+  let latestRuns = new Map<string, PrefectFlowRun>();
+
+  try {
+    const deployRes = await fetch(`${PREFECT_API}/api/deployments/filter`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        deployments: { name: { any_: DOWNSTREAM_PIPELINES.map(p => p.deployment) } },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (deployRes.ok) {
+      const deploys = await deployRes.json() as PrefectDeployment[];
+      deploymentMap = new Map(deploys.map(d => [d.name, d.id]));
+
+      if (deploymentMap.size > 0) {
+        const runsRes = await fetch(`${PREFECT_API}/api/flow_runs/filter`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sort: 'START_TIME_DESC',
+            limit: 30,
+            flow_runs: {
+              state: { type: { any_: ['COMPLETED', 'FAILED', 'CRASHED'] } },
+              deployment_id: { any_: [...deploymentMap.values()] },
+            },
+          }),
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (runsRes.ok) {
+          const runs = await runsRes.json() as PrefectFlowRun[];
+          for (const run of runs) {
+            if (!latestRuns.has(run.deployment_id)) {
+              latestRuns.set(run.deployment_id, run);
+            }
+          }
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to query Prefect API for pipeline status');
+  }
+
+  type PipelineHealth = 'healthy' | 'lagging' | 'stalled' | 'failing' | 'unknown';
+
+  const statuses: Array<{ label: string; health: PipelineHealth; lines: string[] }> = [];
+
+  for (const pipeline of DOWNSTREAM_PIPELINES) {
+    const deployId = deploymentMap.get(pipeline.deployment);
+    const run = deployId ? latestRuns.get(deployId) : undefined;
+    const exportRow = exportByService.get(pipeline.service);
+
+    const batch = exportRow ? parseInt(exportRow.value) : null;
+    const behind = batch !== null ? currentBatch - batch : null;
+    const pct = batch !== null && currentBatch > 0
+      ? ((batch / currentBatch) * 100).toFixed(1)
+      : null;
+
+    let health: PipelineHealth = 'unknown';
+    if (run?.state.type === 'FAILED' || run?.state.type === 'CRASHED') {
+      health = 'failing';
+    } else if (behind !== null && behind > 100) {
+      health = 'stalled';
+    } else if (behind !== null && behind > 10) {
+      health = 'lagging';
+    } else if (run?.state.type === 'COMPLETED' && (behind === null || behind <= 10)) {
+      health = 'healthy';
+    }
+
+    const icon = { healthy: '✅', lagging: '🟡', stalled: '🔴', failing: '❌', unknown: '❓' }[health];
+    const verdict = {
+      healthy: 'Healthy',
+      lagging: 'Lagging',
+      stalled: 'Stalled',
+      failing: 'Last run failed',
+      unknown: 'Unknown',
+    }[health];
+
+    const detail: string[] = [];
+
+    if (run) {
+      const ago = run.start_time
+        ? formatDistanceToNowStrict(new UTCDate(run.start_time), { addSuffix: true })
+        : 'unknown';
+      const duration = run.total_run_time < 60
+        ? `${run.total_run_time.toFixed(1)}s`
+        : `${Math.floor(run.total_run_time / 60)}m ${Math.round(run.total_run_time % 60)}s`;
+      const didWork = run.total_run_time > 30;
+      detail.push(`  Ran ${ago} · ${duration}${!didWork ? ' (no data processed)' : ''}`);
+    } else {
+      detail.push(`  No recent runs found`);
+    }
+
+    if (batch !== null) {
+      if (behind !== null && behind <= 0) {
+        detail.push(`  Progress: ${batch.toLocaleString()} / ${currentBatch.toLocaleString()} — caught up`);
+      } else if (behind !== null) {
+        detail.push(`  Progress: ${batch.toLocaleString()} / ${currentBatch.toLocaleString()} (${pct}%) — ${behind.toLocaleString()} batches behind`);
+      }
+      if (health === 'stalled' && exportRow) {
+        const stalledAgo = formatDistanceToNowStrict(new UTCDate(exportRow.updated_at), { addSuffix: true });
+        detail.push(`  ⚠️ No progress since ${stalledAgo}`);
+      }
+    } else {
+      detail.push(`  Progress: no tracking data`);
+    }
+
+    statuses.push({ label: pipeline.label, health, lines: [`${icon} <b>${pipeline.label}</b> — ${verdict}`, ...detail] });
+  }
+
+  const healthy = statuses.filter(s => s.health === 'healthy').length;
+  const total = statuses.length;
+  let overallIcon: string;
+  let overallVerdict: string;
+  if (healthy === total) {
+    overallIcon = '✅';
+    overallVerdict = 'All pipelines healthy';
+  } else if (statuses.some(s => s.health === 'stalled' || s.health === 'failing')) {
+    overallIcon = '🔴';
+    overallVerdict = `${healthy}/${total} healthy — action needed`;
+  } else {
+    overallIcon = '🟡';
+    overallVerdict = `${healthy}/${total} healthy`;
+  }
+
+  const lines = [
+    `🔗 <b>Pipeline Health — ${overallIcon} ${overallVerdict}</b>`,
+    ``,
+    ...statuses.flatMap(s => [...s.lines, ``]),
+    `<i>Importer at batch ${currentBatch.toLocaleString()}</i>`,
+  ];
+
+  return lines.join('\n');
+};
+
 interface TelegramUpdate {
   update_id: number;
   message?: {
@@ -315,6 +491,24 @@ export const startCommandListener = (db: OaDb): void => {
                 update.message.message_thread_id,
               );
             }
+          } else if (command === '/pipelines') {
+            try {
+              const message = await buildPipelineStatus(db);
+              await replyToMessage(
+                update.message.chat.id,
+                update.message.message_id,
+                message,
+                update.message.message_thread_id,
+              );
+            } catch (err) {
+              logger.warn({ err }, 'Failed to build pipeline status');
+              await replyToMessage(
+                update.message.chat.id,
+                update.message.message_id,
+                '⚠️ Failed to fetch pipeline status — check logs',
+                update.message.message_thread_id,
+              );
+            }
           } else if (command === '/help') {
             await replyToMessage(
               update.message.chat.id,
@@ -322,7 +516,8 @@ export const startCommandListener = (db: OaDb): void => {
               [
                 `<b>OpenAlex Importer Bot</b>`,
                 ``,
-                `/status — sync position, last 24h stats, pod uptime`,
+                `/status — importer sync position, records, uptime`,
+                `/pipelines — downstream pipeline health (ES, novelty, Qdrant)`,
                 `/help — show this message`,
               ].join('\n'),
               update.message.message_thread_id,

--- a/openalex-importer/src/notifier.ts
+++ b/openalex-importer/src/notifier.ts
@@ -243,7 +243,7 @@ export const buildPipelineStatus = async (db: OaDb): Promise<string> => {
   const importerBatch = await db.oneOrNone<{ max_batch: string }>(
     `SELECT MAX(id)::text AS max_batch FROM openalex.batch WHERE finished_at IS NOT NULL`,
   );
-  const currentBatch = parseInt(importerBatch?.max_batch ?? '0');
+  const currentBatch = parseInt(importerBatch?.max_batch ?? '0', 10) || 0;
 
   const exportRows = await db.manyOrNone<{ service: string; value: string; updated_at: Date }>(
     `SELECT service, value, updated_at FROM openalex.export_metadata
@@ -291,8 +291,12 @@ export const buildPipelineStatus = async (db: OaDb): Promise<string> => {
               latestRuns.set(run.deployment_id, run);
             }
           }
+        } else {
+          logger.warn({ status: runsRes.status }, 'Prefect flow_runs/filter returned non-OK');
         }
       }
+    } else {
+      logger.warn({ status: deployRes.status }, 'Prefect deployments/filter returned non-OK');
     }
   } catch (err) {
     logger.warn({ err }, 'Failed to query Prefect API for pipeline status');
@@ -307,7 +311,8 @@ export const buildPipelineStatus = async (db: OaDb): Promise<string> => {
     const run = deployId ? latestRuns.get(deployId) : undefined;
     const exportRow = exportByService.get(pipeline.service);
 
-    const batch = exportRow ? parseInt(exportRow.value) : null;
+    const parsedBatch = exportRow ? parseInt(exportRow.value, 10) : NaN;
+    const batch = Number.isFinite(parsedBatch) ? parsedBatch : null;
     const behind = batch !== null ? currentBatch - batch : null;
     const pct = batch !== null && currentBatch > 0
       ? ((batch / currentBatch) * 100).toFixed(1)


### PR DESCRIPTION
## Summary
- Adds /pipelines Telegram bot command showing real-time health of downstream pipelines (ES, novelty, Qdrant)
- Queries Prefect API + export_metadata for overall health verdict, per-pipeline status, batch progress %, stall warnings
- Gracefully degrades if Prefect API unreachable

## Test plan
- [x] 69 tests pass, tsc clean
- [ ] Verify /pipelines in Telegram after deploy

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /pipelines command to show downstream pipeline health, progress, and alerts.
  * Updated help text to document the new monitoring command.

* **Bug Fixes**
  * Improved reliability and error handling when external status APIs or tracking data are unavailable; clearer user-facing messages on failures or missing data.

* **Tests**
  * Expanded tests covering pipeline status generation, healthy/lagging/stalled/failing paths, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->