### PR TITLE
fix(openalex-importer): simplify pipeline health — healthy if ran + d…

### DIFF
--- a/openalex-importer/src/notifier.test.ts
+++ b/openalex-importer/src/notifier.test.ts
@@ -326,15 +326,13 @@ describe('buildPipelineStatus', () => {
     const message = await buildPipelineStatus(mockDb);
     expect(message).toContain('Pipeline Health');
     expect(message).toContain('action needed');
+    expect(message).toContain('✅');
     expect(message).toContain('PG → Elasticsearch');
-    expect(message).toContain('Lagging');
-    expect(message).toContain('99.4%');
-    expect(message).toContain('84 batches behind');
+    expect(message).toContain('Healthy');
     expect(message).toContain('PG → Qdrant');
     expect(message).toContain('Stalled');
     expect(message).toContain('6,451');
     expect(message).toContain('no data processed');
-    expect(message).toContain('No progress since');
     expect(message).toContain('Importer at batch');
   });
 

--- a/openalex-importer/src/notifier.ts
+++ b/openalex-importer/src/notifier.ts
@@ -302,7 +302,7 @@ export const buildPipelineStatus = async (db: OaDb): Promise<string> => {
     logger.warn({ err }, 'Failed to query Prefect API for pipeline status');
   }
 
-  type PipelineHealth = 'healthy' | 'lagging' | 'stalled' | 'failing' | 'unknown';
+  type PipelineHealth = 'healthy' | 'stalled' | 'failing' | 'unknown';
 
   const statuses: Array<{ label: string; health: PipelineHealth; lines: string[] }> = [];
 
@@ -318,21 +318,23 @@ export const buildPipelineStatus = async (db: OaDb): Promise<string> => {
       ? ((batch / currentBatch) * 100).toFixed(1)
       : null;
 
+    const ranRecently = run?.start_time
+      ? (Date.now() - new UTCDate(run.start_time).getTime()) < 24 * 60 * 60 * 1000
+      : false;
+    const didWork = run ? run.total_run_time > 30 : false;
+
     let health: PipelineHealth = 'unknown';
     if (run?.state.type === 'FAILED' || run?.state.type === 'CRASHED') {
       health = 'failing';
-    } else if (behind !== null && behind > 100) {
-      health = 'stalled';
-    } else if (behind !== null && behind > 10) {
-      health = 'lagging';
-    } else if (run?.state.type === 'COMPLETED' && (behind === null || behind <= 10)) {
+    } else if (ranRecently && didWork) {
       health = 'healthy';
+    } else if (run) {
+      health = 'stalled';
     }
 
-    const icon = { healthy: '✅', lagging: '🟡', stalled: '🔴', failing: '❌', unknown: '❓' }[health];
+    const icon = { healthy: '✅', stalled: '🔴', failing: '❌', unknown: '❓' }[health];
     const verdict = {
       healthy: 'Healthy',
-      lagging: 'Lagging',
       stalled: 'Stalled',
       failing: 'Last run failed',
       unknown: 'Unknown',


### PR DESCRIPTION
…id work within 24h

Made-with: Cursor

Closes #<GH_issue_number>

## Description of the Problem / Feature

## Explanation of the solution

## Instructions on making this work

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pipeline health classification now based on run recency (within 24 hours) and run duration metrics instead of batch lag
  * Removed lagging status indicator for simplified health categorization
  * Updated pipeline status display to show refined health states: healthy, stalled, failing, and unknown
  * Enhanced overall health computation for improved operational status visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->