### PR TITLE
fix(openalex-importer): break single-day tx into per-chunk commits

### DIFF
--- a/openalex-importer/drizzle/batches-schema.ts
+++ b/openalex-importer/drizzle/batches-schema.ts
@@ -10,7 +10,9 @@ export const batchesInOpenAlex = openAlexSchema.table("batch", {
   query_type: text().notNull(),
   query_from: timestamp({ mode: "date" }).notNull(),
   query_to: timestamp({ mode: "date" }).notNull(),
-});
+}, (table) => [
+  index("batch_cleanup_idx").on(table.query_type, table.query_from, table.query_to, table.finished_at),
+]);
 
 export const workBatchesInOpenAlex = openAlexSchema.table("works_batch", {
   work_id: text().references(() => worksInOpenalex.id, {

--- a/openalex-importer/drizzle/migrations/0011_batch_cleanup_idx.sql
+++ b/openalex-importer/drizzle/migrations/0011_batch_cleanup_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "batch_cleanup_idx" ON "openalex"."batch" USING btree ("query_type","query_from","query_to","finished_at");

--- a/openalex-importer/drizzle/migrations/meta/0011_snapshot.json
+++ b/openalex-importer/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2042 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "93eb937d-cf30-42ec-b4eb-70a198ca9681",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "openalex.authors": {
+      "name": "authors",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "orcid": {
+          "name": "orcid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_alternatives": {
+          "name": "display_name_alternatives",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_institution": {
+          "name": "last_known_institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.authors_counts_by_year": {
+      "name": "authors_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authors_counts_by_year_author_id_year_pk": {
+          "name": "authors_counts_by_year_author_id_year_pk",
+          "columns": [
+            "author_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.authors_ids": {
+      "name": "authors_ids",
+      "schema": "openalex",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orcid": {
+          "name": "orcid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopus": {
+          "name": "scopus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts": {
+      "name": "concepts",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_thumbnail_url": {
+          "name": "image_thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descriptions_embeddings": {
+          "name": "descriptions_embeddings",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_embeddings": {
+          "name": "name_embeddings",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_ancestors": {
+      "name": "concepts_ancestors",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ancestor_id": {
+          "name": "ancestor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_counts_by_year": {
+      "name": "concepts_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "concepts_counts_by_year_concept_id_year_pk": {
+          "name": "concepts_counts_by_year_concept_id_year_pk",
+          "columns": [
+            "concept_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_ids": {
+      "name": "concepts_ids",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "umls_aui": {
+          "name": "umls_aui",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "umls_cui": {
+          "name": "umls_cui",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.concepts_related_concepts": {
+      "name": "concepts_related_concepts",
+      "schema": "openalex",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_concept_id": {
+          "name": "related_concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "concepts_related_concepts_concept_id_related_concept_id_pk": {
+          "name": "concepts_related_concepts_concept_id_related_concept_id_pk",
+          "columns": [
+            "concept_id",
+            "related_concept_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions": {
+      "name": "institutions",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ror": {
+          "name": "ror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_thumbnail_url": {
+          "name": "image_thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_acronyms": {
+          "name": "display_name_acronyms",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_alternatives": {
+          "name": "display_name_alternatives",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_associated_institutions": {
+      "name": "institutions_associated_institutions",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "associated_institution_id": {
+          "name": "associated_institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "institutions_associated_institutions_institution_id_associated_institution_id_pk": {
+          "name": "institutions_associated_institutions_institution_id_associated_institution_id_pk",
+          "columns": [
+            "institution_id",
+            "associated_institution_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_counts_by_year": {
+      "name": "institutions_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "institutions_counts_by_year_institution_id_year_pk": {
+          "name": "institutions_counts_by_year_institution_id_year_pk",
+          "columns": [
+            "institution_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_geo": {
+      "name": "institutions_geo",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geonames_city_id": {
+          "name": "geonames_city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.institutions_ids": {
+      "name": "institutions_ids",
+      "schema": "openalex",
+      "columns": {
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ror": {
+          "name": "ror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grid": {
+          "name": "grid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.publishers": {
+      "name": "publishers",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternate_titles": {
+          "name": "alternate_titles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_codes": {
+          "name": "country_codes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_level": {
+          "name": "hierarchy_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_publisher": {
+          "name": "parent_publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources_api_url": {
+          "name": "sources_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.publishers_counts_by_year": {
+      "name": "publishers_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "publishers_counts_by_year_publisher_id_year_pk": {
+          "name": "publishers_counts_by_year_publisher_id_year_pk",
+          "columns": [
+            "publisher_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.publishers_ids": {
+      "name": "publishers_ids",
+      "schema": "openalex",
+      "columns": {
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ror": {
+          "name": "ror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.sources": {
+      "name": "sources",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issn_l": {
+          "name": "issn_l",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_in_doaj": {
+          "name": "is_in_doaj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.sources_counts_by_year": {
+      "name": "sources_counts_by_year",
+      "schema": "openalex",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_works_count": {
+          "name": "oa_works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sources_counts_by_year_source_id_year_pk": {
+          "name": "sources_counts_by_year_source_id_year_pk",
+          "columns": [
+            "source_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.sources_ids": {
+      "name": "sources_ids",
+      "schema": "openalex",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn_l": {
+          "name": "issn_l",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issn": {
+          "name": "issn",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fatcat": {
+          "name": "fatcat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.topics": {
+      "name": "topics",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subfield_id": {
+          "name": "subfield_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subfield_display_name": {
+          "name": "subfield_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_display_name": {
+          "name": "field_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_display_name": {
+          "name": "domain_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_api_url": {
+          "name": "works_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia_id": {
+          "name": "wikipedia_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "works_count": {
+          "name": "works_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_date": {
+          "name": "updated_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siblings": {
+          "name": "siblings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works": {
+      "name": "works",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_year": {
+          "name": "publication_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_count": {
+          "name": "cited_by_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_retracted": {
+          "name": "is_retracted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_paratext": {
+          "name": "is_paratext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cited_by_api_url": {
+          "name": "cited_by_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abstract_inverted_index": {
+          "name": "abstract_inverted_index",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_authorships": {
+      "name": "works_authorships",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_position": {
+          "name": "author_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_ids": {
+          "name": "institution_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "raw_affiliation_string": {
+          "name": "raw_affiliation_string",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_authorships_work_id_author_id_pk": {
+          "name": "works_authorships_work_id_author_id_pk",
+          "columns": [
+            "work_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_best_oa_locations": {
+      "name": "works_best_oa_locations",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landing_page_url": {
+          "name": "landing_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_biblio": {
+      "name": "works_biblio",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue": {
+          "name": "issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_page": {
+          "name": "first_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_page": {
+          "name": "last_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_concepts": {
+      "name": "works_concepts",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_concepts_work_id_concept_id_pk": {
+          "name": "works_concepts_work_id_concept_id_pk",
+          "columns": [
+            "work_id",
+            "concept_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_ids": {
+      "name": "works_ids",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openalex": {
+          "name": "openalex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi": {
+          "name": "doi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mag": {
+          "name": "mag",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pmcid": {
+          "name": "pmcid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_locations": {
+      "name": "works_locations",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landing_page_url": {
+          "name": "landing_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "locations_work_id_idx": {
+          "name": "locations_work_id_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_mesh": {
+      "name": "works_mesh",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descriptor_ui": {
+          "name": "descriptor_ui",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descriptor_name": {
+          "name": "descriptor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifier_ui": {
+          "name": "qualifier_ui",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifier_name": {
+          "name": "qualifier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_major_topic": {
+          "name": "is_major_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_mesh_work_id_descriptor_ui_qualifier_ui_pk": {
+          "name": "works_mesh_work_id_descriptor_ui_qualifier_ui_pk",
+          "columns": [
+            "work_id",
+            "descriptor_ui",
+            "qualifier_ui"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_open_access": {
+      "name": "works_open_access",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_status": {
+          "name": "oa_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oa_url": {
+          "name": "oa_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "any_repository_has_fulltext": {
+          "name": "any_repository_has_fulltext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "works_open_access_is_oa_idx": {
+          "name": "works_open_access_is_oa_idx",
+          "columns": [
+            {
+              "expression": "is_oa",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_primary_locations": {
+      "name": "works_primary_locations",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landing_page_url": {
+          "name": "landing_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_oa": {
+          "name": "is_oa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_referenced_works": {
+      "name": "works_referenced_works",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenced_work_id": {
+          "name": "referenced_work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_referenced_works_work_id_referenced_work_id_pk": {
+          "name": "works_referenced_works_work_id_referenced_work_id_pk",
+          "columns": [
+            "work_id",
+            "referenced_work_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_related_works": {
+      "name": "works_related_works",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_work_id": {
+          "name": "related_work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_related_works_work_id_related_work_id_pk": {
+          "name": "works_related_works_work_id_related_work_id_pk",
+          "columns": [
+            "work_id",
+            "related_work_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_topics": {
+      "name": "works_topics",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "works_topics_work_id_topic_id_pk": {
+          "name": "works_topics_work_id_topic_id_pk",
+          "columns": [
+            "work_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.batch": {
+      "name": "batch",
+      "schema": "openalex",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_from": {
+          "name": "query_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_to": {
+          "name": "query_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "batch_cleanup_idx": {
+          "name": "batch_cleanup_idx",
+          "columns": [
+            {
+              "expression": "query_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "query_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "query_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "openalex.works_batch": {
+      "name": "works_batch",
+      "schema": "openalex",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "works_batch_work_id_works_id_fk": {
+          "name": "works_batch_work_id_works_id_fk",
+          "tableFrom": "works_batch",
+          "tableTo": "works",
+          "schemaTo": "openalex",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "works_batch_batch_id_batch_id_fk": {
+          "name": "works_batch_batch_id_batch_id_fk",
+          "tableFrom": "works_batch",
+          "tableTo": "batch",
+          "schemaTo": "openalex",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "works_batch_work_id_batch_id_pk": {
+          "name": "works_batch_work_id_batch_id_pk",
+          "columns": [
+            "work_id",
+            "batch_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "openalex": "openalex"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/openalex-importer/drizzle/migrations/meta/_journal.json
+++ b/openalex-importer/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1747667888986,
       "tag": "0010_nappy_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1749177600000,
+      "tag": "0011_batch_cleanup_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/openalex-importer/src/db/index.ts
+++ b/openalex-importer/src/db/index.ts
@@ -116,9 +116,13 @@ export const hasUnfinishedBatches = async (db: OaDb): Promise<boolean> => {
   return result !== null;
 };
 
+/**
+ * Clean up unfinished batches for a specific day only.
+ * Intentionally scoped to queryInfo's day — other days may be in-progress
+ * via time-travel mode or a parallel process.
+ */
 export const cleanupUnfinishedBatches = async (db: OaDb, queryInfo: QueryInfo) => {
   await db.tx(async (tx) => {
-    // Find unfinished batch IDs for this day
     const unfinished = await tx.manyOrNone(
       'SELECT id FROM openalex.batch WHERE query_type = $1 AND query_from = $2 AND query_to = $3 AND finished_at IS NULL',
       [queryInfo.query_type, queryInfo.query_from, queryInfo.query_to]

--- a/openalex-importer/src/db/index.ts
+++ b/openalex-importer/src/db/index.ts
@@ -95,16 +95,49 @@ export const db = pgp(dbInfo);
 
 export type OaDb = typeof db;
 
-export const createBatch = async (tx: pgPromise.ITask<any>, queryInfo: QueryInfo) => {
-  const savedBatch = await tx.one(
+export const createBatch = async (db: OaDb, queryInfo: QueryInfo) => {
+  const savedBatch = await db.one(
     'INSERT INTO openalex.batch (query_type, query_from, query_to) VALUES ($1, $2, $3) RETURNING id',
     [queryInfo.query_type, queryInfo.query_from, queryInfo.query_to]
   );
   return savedBatch.id;
 };
 
-export const finalizeBatch = async (tx: pgPromise.ITask<any>, batchId: number) =>
-  await tx.none('UPDATE openalex.batch SET finished_at = $1 WHERE id = $2', [new UTCDate(), batchId]);
+export const finalizeBatch = async (db: OaDb, batchId: number) =>
+  await db.none('UPDATE openalex.batch SET finished_at = $1 WHERE id = $2', [new UTCDate(), batchId]);
+
+/**
+ * Check if there are unfinished batches from a previous crash (without cleaning them up).
+ */
+export const hasUnfinishedBatches = async (db: OaDb): Promise<boolean> => {
+  const result = await db.oneOrNone(
+    'SELECT 1 FROM openalex.batch WHERE finished_at IS NULL LIMIT 1',
+  );
+  return result !== null;
+};
+
+export const cleanupUnfinishedBatches = async (db: OaDb, queryInfo: QueryInfo) => {
+  await db.tx(async (tx) => {
+    // Find unfinished batch IDs for this day
+    const unfinished = await tx.manyOrNone(
+      'SELECT id FROM openalex.batch WHERE query_type = $1 AND query_from = $2 AND query_to = $3 AND finished_at IS NULL',
+      [queryInfo.query_type, queryInfo.query_from, queryInfo.query_to]
+    );
+
+    if (unfinished.length === 0) return;
+
+    const batchIds = unfinished.map(r => r.id);
+    logger.info({ batchIds, queryInfo }, 'Cleaning up unfinished batches from previous crash');
+
+    // Delete works_batch rows for these batches first (avoid orphaned NULL rows)
+    await tx.none('DELETE FROM openalex.works_batch WHERE batch_id IN ($1:list)', [batchIds]);
+
+    // Then delete the batch records themselves
+    await tx.none('DELETE FROM openalex.batch WHERE id IN ($1:list)', [batchIds]);
+
+    logger.info({ batchIds }, 'Cleanup complete');
+  });
+};
 
 export const saveData = async (tx: pgPromise.ITask<any>, batchId: number, models: DataModels) => {
   const counts = Object.entries(models).reduce((acc, [k, a]) => ({ ...acc, [k]: a.length}), {});
@@ -463,7 +496,7 @@ const updateWorksTopics = async (tx: pgPromise.ITask<any>, data: DataModels['wor
  */
 export const getNextDayToImport = async (queryType: QueryInfo['query_type']): Promise<UTCDate> => {
   const lastBatchEnd = await db.oneOrNone(
-    'SELECT query_to FROM openalex.batch WHERE query_type = $1 ORDER BY query_to DESC LIMIT 1',
+    'SELECT query_to FROM openalex.batch WHERE query_type = $1 AND finished_at IS NOT NULL ORDER BY query_to DESC LIMIT 1',
     [queryType]
   );
 

--- a/openalex-importer/src/db/index.ts
+++ b/openalex-importer/src/db/index.ts
@@ -120,11 +120,20 @@ export const hasUnfinishedBatches = async (db: OaDb): Promise<boolean> => {
  * Clean up unfinished batches for a specific day only.
  * Intentionally scoped to queryInfo's day — other days may be in-progress
  * via time-travel mode or a parallel process.
+ *
+ * Uses FOR UPDATE SKIP LOCKED to avoid deleting batches that are actively
+ * being written to by a concurrent process (e.g. during rolling restarts).
+ * Only targets batches older than 5 minutes to avoid racing with freshly
+ * created batches.
  */
 export const cleanupUnfinishedBatches = async (db: OaDb, queryInfo: QueryInfo) => {
   await db.tx(async (tx) => {
     const unfinished = await tx.manyOrNone(
-      'SELECT id FROM openalex.batch WHERE query_type = $1 AND query_from = $2 AND query_to = $3 AND finished_at IS NULL',
+      `SELECT id FROM openalex.batch
+       WHERE query_type = $1 AND query_from = $2 AND query_to = $3
+         AND finished_at IS NULL
+         AND started_at < NOW() - INTERVAL '5 minutes'
+       FOR UPDATE SKIP LOCKED`,
       [queryInfo.query_type, queryInfo.query_from, queryInfo.query_to]
     );
 

--- a/openalex-importer/src/db/index.ts
+++ b/openalex-importer/src/db/index.ts
@@ -108,6 +108,8 @@ export const finalizeBatch = async (db: OaDb, batchId: number) =>
 
 /**
  * Check if there are unfinished batches from a previous crash (without cleaning them up).
+ * Intentionally global (not scoped to a specific day) — used only at startup to detect
+ * any crash evidence and send the "recovering" notification. Cleanup is day-scoped separately.
  */
 export const hasUnfinishedBatches = async (db: OaDb): Promise<boolean> => {
   const result = await db.oneOrNone(

--- a/openalex-importer/src/notifier.ts
+++ b/openalex-importer/src/notifier.ts
@@ -19,6 +19,11 @@ let wasCaughtUp = true;
 let pollAbort: AbortController | null = null;
 let digestPaused = false;
 
+const getAdminUserIds = (): Set<number> => {
+  const raw = process.env.TELEGRAM_ADMIN_IDS ?? '';
+  return new Set(raw.split(',').map(s => Number(s.trim())).filter(n => !Number.isNaN(n) && n > 0));
+};
+
 export const isDigestPaused = (): boolean => digestPaused;
 
 const getConfig = () => {
@@ -408,6 +413,7 @@ interface TelegramUpdate {
   update_id: number;
   message?: {
     message_id: number;
+    from?: { id: number };
     chat: { id: number };
     message_thread_id?: number;
     text?: string;
@@ -528,24 +534,29 @@ export const startCommandListener = (db: OaDb): void => {
                 update.message.message_thread_id,
               );
             }
-          } else if (command === '/stopupdate') {
-            digestPaused = true;
-            logger.info('Daily digest paused via /stopupdate');
-            await replyToMessage(
-              update.message.chat.id,
-              update.message.message_id,
-              '⏸️ Daily updates paused. Use /startupdate to resume.',
-              update.message.message_thread_id,
-            );
-          } else if (command === '/startupdate') {
-            digestPaused = false;
-            logger.info('Daily digest resumed via /startupdate');
-            await replyToMessage(
-              update.message.chat.id,
-              update.message.message_id,
-              '▶️ Daily updates resumed.',
-              update.message.message_thread_id,
-            );
+          } else if (command === '/stopupdate' || command === '/startupdate') {
+            const adminIds = getAdminUserIds();
+            const senderId = update.message.from?.id;
+            if (adminIds.size > 0 && (!senderId || !adminIds.has(senderId))) {
+              logger.warn({ senderId, command }, 'Unauthorized command attempt');
+              await replyToMessage(
+                update.message.chat.id,
+                update.message.message_id,
+                '🚫 You are not authorized to use this command.',
+                update.message.message_thread_id,
+              );
+            } else {
+              digestPaused = command === '/stopupdate';
+              logger.info({ command, senderId }, `Daily digest ${digestPaused ? 'paused' : 'resumed'} via ${command}`);
+              await replyToMessage(
+                update.message.chat.id,
+                update.message.message_id,
+                digestPaused
+                  ? '⏸️ Daily updates paused. Use /startupdate to resume.'
+                  : '▶️ Daily updates resumed.',
+                update.message.message_thread_id,
+              );
+            }
           } else if (command === '/help') {
             await replyToMessage(
               update.message.chat.id,

--- a/openalex-importer/src/notifier.ts
+++ b/openalex-importer/src/notifier.ts
@@ -1,7 +1,7 @@
 import { logger } from './logger.js';
 import { differenceInCalendarDays, formatDistanceToNowStrict } from 'date-fns';
 import { UTCDate } from '@date-fns/utc';
-import type { OaDb } from './db/index.js';
+import { hasUnfinishedBatches, type OaDb } from './db/index.js';
 
 const TELEGRAM_API = 'https://api.telegram.org';
 const ERROR_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour between error notifications
@@ -17,6 +17,9 @@ const DOWNSTREAM_PIPELINES = [
 let lastErrorNotifyMs = 0;
 let wasCaughtUp = true;
 let pollAbort: AbortController | null = null;
+let digestPaused = false;
+
+export const isDigestPaused = (): boolean => digestPaused;
 
 const getConfig = () => {
   const token = process.env.TELEGRAM_BOT_TOKEN;
@@ -212,9 +215,13 @@ export const buildDigestMessage = async (db: OaDb): Promise<string> => {
 };
 
 export const sendDailyDigest = async (db: OaDb): Promise<void> => {
+  if (digestPaused) {
+    logger.info('Daily digest skipped (paused)');
+    return;
+  }
   try {
     const message = await buildDigestMessage(db);
-    await sendTelegram(message);
+    await sendTelegram(`📅 <b>Daily Update</b>\n\n${message}`);
   } catch (err) {
     logger.warn({ err }, 'Failed to build daily digest');
     await sendTelegram('⚠️ <b>OpenAlex Importer</b>\nFailed to generate daily digest — check logs');
@@ -449,8 +456,13 @@ export const startCommandListener = (db: OaDb): void => {
 
   void (async () => {
     try {
-      const message = await buildDigestMessage(db);
-      await sendTelegram(`🟢 <b>OpenAlex Importer online</b>\n\n${message}\n\nType /help for commands.`);
+      const crashRecovery = await hasUnfinishedBatches(db);
+      if (crashRecovery) {
+        const message = await buildDigestMessage(db);
+        await sendTelegram(`🔄 <b>OpenAlex Importer back online</b> (recovering from crash)\n\n${message}`);
+      } else {
+        await sendTelegram(`🟢 <b>OpenAlex Importer online</b>\nType /help for commands.`);
+      }
     } catch {
       await sendTelegram('🟢 <b>OpenAlex Importer online</b>\nFailed to fetch initial status — type /status to retry.');
     }
@@ -516,6 +528,24 @@ export const startCommandListener = (db: OaDb): void => {
                 update.message.message_thread_id,
               );
             }
+          } else if (command === '/stopupdate') {
+            digestPaused = true;
+            logger.info('Daily digest paused via /stopupdate');
+            await replyToMessage(
+              update.message.chat.id,
+              update.message.message_id,
+              '⏸️ Daily updates paused. Use /startupdate to resume.',
+              update.message.message_thread_id,
+            );
+          } else if (command === '/startupdate') {
+            digestPaused = false;
+            logger.info('Daily digest resumed via /startupdate');
+            await replyToMessage(
+              update.message.chat.id,
+              update.message.message_id,
+              '▶️ Daily updates resumed.',
+              update.message.message_thread_id,
+            );
           } else if (command === '/help') {
             await replyToMessage(
               update.message.chat.id,
@@ -525,6 +555,8 @@ export const startCommandListener = (db: OaDb): void => {
                 ``,
                 `/status — importer sync position, records, uptime`,
                 `/pipelines — downstream pipeline health (ES, novelty, Qdrant)`,
+                `/stopupdate — pause daily digest`,
+                `/startupdate — resume daily digest`,
                 `/help — show this message`,
               ].join('\n'),
               update.message.message_thread_id,

--- a/openalex-importer/src/notifier.ts
+++ b/openalex-importer/src/notifier.ts
@@ -221,7 +221,7 @@ export const buildDigestMessage = async (db: OaDb): Promise<string> => {
 
 export const sendDailyDigest = async (db: OaDb): Promise<void> => {
   if (digestPaused) {
-    logger.info('Daily digest skipped (paused)');
+    logger.info({ paused: true }, 'Daily digest skipped (paused)');
     return;
   }
   try {
@@ -537,6 +537,7 @@ export const startCommandListener = (db: OaDb): void => {
           } else if (command === '/stopupdate' || command === '/startupdate') {
             const adminIds = getAdminUserIds();
             const senderId = update.message.from?.id;
+            // When TELEGRAM_ADMIN_IDS is unset, allow all users (backwards-compatible dev default)
             if (adminIds.size > 0 && (!senderId || !adminIds.has(senderId))) {
               logger.warn({ senderId, command }, 'Unauthorized command attempt');
               await replyToMessage(

--- a/openalex-importer/src/pipeline.ts
+++ b/openalex-importer/src/pipeline.ts
@@ -212,13 +212,18 @@ export const runImportPipeline = async (db: OaDb, queryInfo: QueryInfo): Promise
   logger.info({ batchId, queryInfo }, 'Created batch record');
 
   // Each chunk saves in its own transaction — progress survives crashes
-  await pipeline(
-    createWorksAPIStream(filter),
-    createBufferStream(),
-    createTransformStream(),
-    createLogStream(),
-    createSaveStream(db, batchId),
-  );
+  try {
+    await pipeline(
+      createWorksAPIStream(filter),
+      createBufferStream(),
+      createTransformStream(),
+      createLogStream(),
+      createSaveStream(db, batchId),
+    );
+  } catch (err) {
+    logger.error({ batchId, queryInfo, err: errWithCause(err as Error) }, 'Import pipeline failed — batch left unfinished for recovery');
+    throw err;
+  }
 
   // Mark the batch as complete
   await finalizeBatch(db, batchId);

--- a/openalex-importer/src/pipeline.ts
+++ b/openalex-importer/src/pipeline.ts
@@ -1,6 +1,7 @@
 import { Readable, Transform } from 'stream';
 import { pipeline } from 'stream/promises';
 import {
+  cleanupUnfinishedBatches,
   createBatch,
   finalizeBatch,
   type OaDb,
@@ -16,7 +17,6 @@ import { getDuration, sleep } from './util.js';
 import { Writable } from 'node:stream';
 import { IS_DEV, MAX_PAGES_TO_FETCH, SKIP_LOG_WRITE } from '../index.js';
 import { RateLimiter } from './rateLimiter.js';
-import * as pgPromise from 'pg-promise';
 
 const MAX_RETRIES = 10;
 const BASE_DELAY = 1_000;
@@ -178,14 +178,16 @@ const createLogStream = (): Transform => {
   });
 };
 
-const createSaveStream = (tx: pgPromise.ITask<object>, batchId: number): Writable => {
+const createSaveStream = (db: OaDb, batchId: number): Writable => {
   return new Writable({
     highWaterMark: 1,
     objectMode: true,
     async write(chunk: DataModels, _encoding, callback) {
       try {
         const start = Date.now();
-        await saveData(tx, batchId, chunk);
+        await db.tx(async (tx) => {
+          await saveData(tx, batchId, chunk);
+        });
         logger.info({ duration: Date.now() - start }, 'Saved chunk to database');
         callback();
       } catch (error) {
@@ -202,18 +204,24 @@ export const runImportPipeline = async (db: OaDb, queryInfo: QueryInfo): Promise
   await nukeOldLogs();
   const filter = filterFromQueryInfo(queryInfo);
 
-  await db.tx(async (tx) => {
-    const batchId = await createBatch(tx, queryInfo);
-    await pipeline(
-      createWorksAPIStream(filter),
-      createBufferStream(),
-      createTransformStream(),
-      createLogStream(),
-      createSaveStream(tx, batchId),
-    );
+  // Clean up any unfinished batch from a previous crash for this day
+  await cleanupUnfinishedBatches(db, queryInfo);
 
-    await finalizeBatch(tx, batchId);
-  });
+  // Create batch record in its own transaction
+  const batchId = await createBatch(db, queryInfo);
+  logger.info({ batchId, queryInfo }, 'Created batch record');
+
+  // Each chunk saves in its own transaction — progress survives crashes
+  await pipeline(
+    createWorksAPIStream(filter),
+    createBufferStream(),
+    createTransformStream(),
+    createLogStream(),
+    createSaveStream(db, batchId),
+  );
+
+  // Mark the batch as complete
+  await finalizeBatch(db, batchId);
 
   const duration = getDuration(startTime, Date.now());
   logger.info({ duration: `${duration} s`, queryInfo }, 'Import pipeline finished!');


### PR DESCRIPTION
## Summary
- **Core fix**: The entire day's import was wrapped in one PG transaction. For days with millions of updated works, the tx runs 10+ hours and any crash rolls back all progress. Now each 1000-work chunk saves in its own transaction — committed data survives crashes.
- **Crash detection**: `getNextDayToImport` now filters by `finished_at IS NOT NULL`, and unfinished batch records from crashed runs are cleaned up on restart.
- **TG bot improvements**: Startup message distinguishes crash recovery (🔄) from clean start (🟢), daily digest prefixed with "📅 Daily Update", and `/stopupdate` / `/startupdate` commands to pause/resume the digest.

## Note
This fixes the immediate reliability issue but does NOT fix the root cause of monster days taking too long. The OpenAlex cursor resets on restart, so a crash still means re-fetching from page 1. A follow-up to split large days into hourly batches is recommended.

## Test plan
- [ ] Deploy to dev and verify chunked saves appear in logs (`Saved chunk to database` outside of a wrapping tx)
- [ ] Kill the pod mid-import, verify it restarts with `🔄 back online` message and re-processes the same day
- [ ] Verify `/status`, `/stopupdate`, `/startupdate`, `/help` commands work
- [ ] Verify daily digest at 9 UTC shows `📅 Daily Update` prefix
- [ ] Confirm `getNextDayToImport` doesn't skip past unfinished days

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/stopupdate` and `/startupdate` Telegram commands to pause/resume daily digests.
  * Daily digest now includes a "📅 Daily Update" header and reports paused/resumed state; bot announces when recovering from an interrupted import.

* **Improvements**
  * Better crash recovery: detects and cleans up unfinished imports and excludes them when choosing next import day.
  * Import pipeline made more resilient with per-chunk transactions and clearer logging.
  * Added a database index to speed batch cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->