### PR TITLE
fix(desci-server): don't crash the pod on unhandled promise rejections

### DIFF
--- a/desci-server/src/controllers/raw/resolve.ts
+++ b/desci-server/src/controllers/raw/resolve.ts
@@ -116,10 +116,20 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
     cidString = hexToCid(version.cid);
   };
 
-  const { data } = await axios.get(
-    `${ipfsResolver}/${cidString}`,
-    { headers: { 'Bypass-Tunnel-Reminder': true } }
-  );
+  let data;
+  try {
+    const response = await axios.get(
+      `${ipfsResolver}/${cidString}`,
+      { headers: { 'Bypass-Tunnel-Reminder': true } }
+    );
+    data = response.data;
+  } catch (err) {
+    logger.warn({ err, ipfsResolver, cidString }, 'ipfs uplink failed');
+    return res.status(502).send({
+      ok: false,
+      msg: 'ipfs uplink failed, try setting ?g= querystring to resolver',
+    });
+  }
 
   if (!secondParam) {
     logger.info("Returning manifest as there is no additional path");
@@ -160,13 +170,18 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
         if (thirdParam == '!') {
           logger.debug('recognize zip');
           //send the zip
-          return axios.get(
-            `${ipfsResolver}/${codeComponent.payload.url}`,
-            { responseType: 'stream' }
-          ).then((response) => {
+          try {
+            const response = await axios.get(
+              `${ipfsResolver}/${codeComponent.payload.url}`,
+              { responseType: 'stream' }
+            );
             // The response will give you the zip file
             response.data.pipe(res);
-          });
+            return res;
+          } catch (err) {
+            logger.warn({ err, ipfsResolver, url: codeComponent.payload.url }, 'ipfs zip stream failed');
+            return res.status(502).send({ ok: false, msg: 'ipfs uplink failed' });
+          }
         };
 
         // send the individual file

--- a/desci-server/src/controllers/raw/resolve.ts
+++ b/desci-server/src/controllers/raw/resolve.ts
@@ -6,6 +6,7 @@ import {
 } from '@desci-labs/desci-models';
 import axios from 'axios';
 import { NextFunction, Request, Response } from 'express';
+import { pipeline } from 'node:stream/promises';
 import { logger as parentLogger } from '../../logger.js';
 import { getIndexedResearchObjects } from '../../theGraph.js';
 import { decodeBase64UrlSafeToHex, hexToCid } from '../../utils.js';
@@ -175,11 +176,20 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
               `${ipfsResolver}/${codeComponent.payload.url}`,
               { responseType: 'stream' }
             );
-            // The response will give you the zip file
-            response.data.pipe(res);
+            // Use stream.pipeline so errors from either side (source aborts,
+            // client disconnects mid-stream) are forwarded and both streams
+            // are torn down properly. A bare .pipe() leaks on error.
+            await pipeline(response.data, res);
             return res;
           } catch (err) {
             logger.warn({ err, ipfsResolver, url: codeComponent.payload.url }, 'ipfs zip stream failed');
+            // If headers are already sent (mid-stream failure) we can't send
+            // a JSON error — just destroy the response so the client sees an
+            // aborted connection instead of hanging.
+            if (res.headersSent) {
+              res.destroy(err instanceof Error ? err : new Error(String(err)));
+              return res;
+            }
             return res.status(502).send({ ok: false, msg: 'ipfs uplink failed' });
           }
         };

--- a/desci-server/src/index.ts
+++ b/desci-server/src/index.ts
@@ -84,8 +84,8 @@ process.on('SIGUSR2', () => gracefulShutdown('SIGUSR2'));
  */
 const FATAL_TIMEOUT_MS = 500;
 
-/** Handler to use for uncaught exceptions and promise rejections, from which we
- * want to extract as much log info as possible to the log aggregator.
+/** Handler for uncaughtException — process state is unknown after one of
+ * these, so we log and then exit. This is the standard Node.js recommendation.
  */
 const handleFatalError = async (error: unknown, type: string) => {
   // Mostly error should be an Error, but in theory anything can be thrown
@@ -108,8 +108,26 @@ const handleFatalError = async (error: unknown, type: string) => {
   }
 };
 
+/** Handler for unhandledRejection — log it, but DO NOT crash the process.
+ *
+ * Historically this called handleFatalError, which exited. That turned every
+ * un-try/catched upstream HTTP failure (e.g. a transient 503 from
+ * ipfs.desci.com) into a full pod crash, taking down the whole desci-server
+ * fleet in lockstep with any upstream hiccup. A long-running web server should
+ * survive a single bad request — the offending handler should be fixed to
+ * catch its own errors, but the process must keep serving traffic in the
+ * meantime. Sentry still picks these up via its global integration.
+ */
+const handleUnhandledRejection = (reason: unknown) => {
+  const normalizedError = reason instanceof Error ? reason : new Error(String(reason));
+  logger.error(
+    { err: errWithCause(normalizedError), type: 'unhandledRejection' },
+    'Unhandled promise rejection (process continuing)',
+  );
+};
+
 process.on('uncaughtException', (err) => handleFatalError(err, 'uncaughtException'));
-process.on('unhandledRejection', (reason) => handleFatalError(reason, 'unhandledRejection'));
+process.on('unhandledRejection', handleUnhandledRejection);
 
 process.on('exit', () => {
   if (!isShuttingDown) {

--- a/desci-server/src/index.ts
+++ b/desci-server/src/index.ts
@@ -13,9 +13,16 @@ const logger = parentLogger.child({
 // Create the server instance for production
 const server = createServer();
 
-server.ready().then((_) => {
-  console.log('server is ready');
-});
+server.ready()
+  .then((_) => {
+    console.log('server is ready');
+  })
+  .catch((err) => {
+    // Now that unhandledRejection is non-fatal, a startup failure here would
+    // otherwise be silently logged and the process would limp along
+    // half-initialized. Treat startup failure as fatal explicitly.
+    void handleFatalError(err, 'server.ready');
+  });
 export const app = server.app;
 
 /**


### PR DESCRIPTION
## Summary

Today's `ipfs.desci.com` outage caused a **second-order outage** in `desci-server`: every replica crashed in lockstep on each request that hit the IPFS gateway during the ~3 minute window it was down. Restart counts on `prod-desci-server` pods hit 3 in 18 minutes.

The IPFS gateway downtime is being addressed separately in [desci-labs/infra#52](https://github.com/desci-labs/infra/pull/52) — but even after that, **any** transient upstream failure (Stripe, ORCID, dpid resolver, etc.) could trigger the same cascade. This PR fixes the underlying class of bug.

## Root cause

1. `controllers/raw/resolve.ts` had **two unprotected `axios.get` calls** to `${ipfsResolver}/${cidString}` (the version-by-cid/index branch around line 119 and the zip-streaming branch around line 163). When `ipfs.desci.com` returned 503, axios threw, and the rejection was unhandled in the request handler.

2. `index.ts` wired **both** `uncaughtException` **and** `unhandledRejection` into the same `handleFatalError` path, which calls `cleanup()` and `process.exit(1)`. So a single failing upstream HTTP call took down the entire pod.

This was a design bug masquerading as a probe failure. A long-running web server must survive a bad request.

## Evidence from the incident

From the previous container logs of `desci-server-b7699858b-prpzj`:

```
AxiosError: Request failed with status code 503
    at async resolve (file:///app/dist/controllers/raw/resolve.js:94:22)
  url: "https://ipfs.desci.com/ipfs/bafkreiho2ipglkfppftalyrhyfj63a65sw262n3ewsao7lpo26mz6mthzq"

{"level":60, "module":"index.ts", "type":"unhandledRejection",
 "msg":"Process got fatal error"}
"Starting cleanup"
"FREE ALL LOCKS"
[exit code 1]
```

## Changes

- **`src/index.ts`**: Split `unhandledRejection` off from `handleFatalError` into a log-only handler. `uncaughtException` still exits — that's the correct Node.js behavior, since process state is unknown after an uncaught sync exception. Sentry still picks up unhandled rejections via its global integration, so we don't lose visibility.
- **`src/controllers/raw/resolve.ts`**: Wrap the two unprotected `axios.get` calls in `try/catch` and return a 502 to the client when the IPFS uplink fails, matching the existing pattern in the latest-version branch at line 75.

## Test plan

- [ ] `npx tsc --noEmit` is clean for the changed files (verified locally)
- [ ] Manual: hit `/v1/pub/versions/<CID>` while pointing `IPFS_RESOLVER_OVERRIDE` at an unreachable host — should return 502, not crash the pod
- [ ] Manual: trigger an unhandled rejection from another code path (e.g. via a temporary `Promise.reject()` in a controller) — should log at `error` level and continue serving requests
- [ ] Verify Sentry still receives unhandled rejection events

## Out of scope

There are other unprotected `axios.get` calls elsewhere in the codebase that could exhibit the same crash pattern. With the `unhandledRejection` handler now non-fatal, those become latent bugs (500/502 to the client) instead of full pod crashes — they should still be hardened individually, but it's no longer an incident-level issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for IPFS manifest resolution, returning clearer 502 responses and warning logs when uplink failures occur.
  * Switched ZIP payload streaming to a more robust stream-handling flow with better failure detection and response cleanup.
  * Enhanced startup and runtime stability by logging unhandled promise rejections without forcing immediate process termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->