### PR TITLE
perf: cache /v1/pub/versions in Redis (7s → <100ms)

### DIFF
--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -137,6 +137,8 @@ export const publish = async (req: PublishRequest, res: Response<PublishResBody>
 
     // Make sure we don't serve stale manifest state when a publish is happening
     delFromCache(`node-draft-${ensureUuidEndsWithDot(node.uuid)}`);
+    // Invalidate versions cache so new version shows up immediately
+    delFromCache(`indexed-versions-${ensureUuidEndsWithDot(node.uuid)}`);
 
     // Invalidate dpid metadata cache so link previews reflect the new version
     if (dpidAlias) {

--- a/desci-server/src/controllers/raw/versions.ts
+++ b/desci-server/src/controllers/raw/versions.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 
 import { logger as parentLogger } from '../../logger.js';
-import { getIndexedResearchObjects, IndexedResearchObject } from '../../theGraph.js';
+import { getIndexedResearchObjects } from '../../theGraph.js';
+import { getOrCache, ONE_DAY_TTL } from '../../redisClient.js';
 import { ensureUuidEndsWithDot } from '../../utils.js';
 
 const logger = parentLogger.child({
@@ -9,23 +10,33 @@ const logger = parentLogger.child({
 });
 
 /**
- * Get all versions of research object from index (publicView)
+ * Get all versions of research object from index (publicView).
+ * Cached in Redis for 1 day — the dpid.org /api/v2/query/history
+ * endpoint takes 5-8 seconds uncached.
  */
 export const versions = async (req: Request, res: Response, next: NextFunction) => {
   const uuid = ensureUuidEndsWithDot(req.params.uuid);
-  let result: IndexedResearchObject;
+  const cacheKey = `indexed-versions-${uuid}`;
 
   try {
-    const { researchObjects } = await getIndexedResearchObjects([uuid]);
-    result = researchObjects[0];
-  } catch (err) {
-    logger.error({ result, err }, `[ERROR] graph lookup fail ${err.message}`);
-  }
-  if (!result) {
-    logger.warn({ uuid, result }, 'could not find indexed versions');
-    res.status(404).send({ ok: false, msg: `could not locate uuid ${uuid}` });
-    return;
-  }
+    const result = await getOrCache(
+      cacheKey,
+      async () => {
+        const { researchObjects } = await getIndexedResearchObjects([uuid]);
+        return researchObjects[0] ?? null;
+      },
+      ONE_DAY_TTL,
+    );
 
-  res.send(result);
+    if (!result) {
+      logger.warn({ uuid }, 'could not find indexed versions');
+      res.status(404).send({ ok: false, msg: `could not locate uuid ${uuid}` });
+      return;
+    }
+
+    res.send(result);
+  } catch (err) {
+    logger.error({ uuid, err }, `[ERROR] versions lookup fail ${err.message}`);
+    res.status(500).send({ ok: false, msg: 'Failed to fetch versions' });
+  }
 };

--- a/desci-server/src/scripts/warm-versions-cache.ts
+++ b/desci-server/src/scripts/warm-versions-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * Pre-warm the Redis cache for /v1/pub/versions responses.
+ *
+ * Queries all published nodes from the DB, then calls getIndexedResearchObjects
+ * for each one, which populates the `indexed-versions-{uuid}` cache key.
+ *
+ * Usage:
+ *   npx ts-node src/scripts/warm-versions-cache.ts
+ *   # or with concurrency limit:
+ *   CONCURRENCY=5 npx ts-node src/scripts/warm-versions-cache.ts
+ */
+import { prisma } from '../client.js';
+import { getIndexedResearchObjects } from '../theGraph.js';
+import { getOrCache, ONE_DAY_TTL } from '../redisClient.js';
+import { ensureUuidEndsWithDot } from '../utils.js';
+
+const CONCURRENCY = parseInt(process.env.CONCURRENCY || '3', 10);
+
+async function main() {
+  console.log('Fetching all published nodes with dpidAlias...');
+
+  const nodes = await prisma.node.findMany({
+    select: { uuid: true, dpidAlias: true },
+    where: {
+      dpidAlias: { not: null },
+      isDeleted: false,
+    },
+    orderBy: { dpidAlias: 'desc' },
+  });
+
+  console.log(`Found ${nodes.length} published nodes. Warming cache with concurrency=${CONCURRENCY}...`);
+
+  let warmed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < nodes.length; i += CONCURRENCY) {
+    const batch = nodes.slice(i, i + CONCURRENCY);
+
+    await Promise.allSettled(
+      batch.map(async (node) => {
+        const uuid = ensureUuidEndsWithDot(node.uuid);
+        const cacheKey = `indexed-versions-${uuid}`;
+
+        try {
+          await getOrCache(
+            cacheKey,
+            async () => {
+              const { researchObjects } = await getIndexedResearchObjects([uuid]);
+              return researchObjects[0] ?? null;
+            },
+            ONE_DAY_TTL,
+          );
+          warmed++;
+          if (warmed % 10 === 0) {
+            console.log(`  Progress: ${warmed}/${nodes.length} warmed, ${failed} failed`);
+          }
+        } catch (e) {
+          failed++;
+          console.error(`  Failed dpid=${node.dpidAlias} uuid=${uuid}: ${(e as Error).message}`);
+        }
+      }),
+    );
+  }
+
+  console.log(`\nDone. Warmed: ${warmed}, Failed: ${failed}, Total: ${nodes.length}`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error('Fatal error:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The `/v1/pub/versions/:uuid` endpoint calls `dpid.org/api/v2/query/history` which takes **5-8 seconds** per request. This blocks every dpid page SSR render on nodes-web-v2.

### Trace data
```
POST dpid.org/api/v2/query/history {ids:["1077"]}
  TTFB: 7.06s | Total: 7.26s | Size: 4.6KB (13 versions)

GET /v1/pub/versions/{uuid}  
  TTFB: 5.27s (99% is the dpid.org call above)

All other SSR steps combined: <500ms
```

### Fix
- Wrap `getIndexedResearchObjects` call in `getOrCache` with `ONE_DAY_TTL`
- First request: 5-8s (cold, fetches from dpid.org resolver)
- Subsequent requests: **<100ms** (Redis hit)
- Cache invalidated on publish via `delFromCache` in publish controller

Uses existing Redis infrastructure — no new dependencies.

## Test plan
- [ ] Load `/dpid/1077/v1` — first load ~5s (cold), refresh should be <500ms
- [ ] Publish a new version of a node — verify `/v1/pub/versions` returns the new version
- [ ] Redis unavailable — verify graceful fallback to uncached behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added caching for the versions endpoint (1-day TTL) to reduce latency.
  * Introduced a new cache-warming script to pre-populate versions cache on startup.

* **Bug Fixes**
  * Improved error handling and diagnostics for the versions endpoint.
  * Ensured additional cache invalidation during publish to keep data consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->