### PR TITLE
perf: cache /v1/pub/versions in Redis (cherry-pick #1281 to prod)

### DIFF
--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -137,6 +137,8 @@ export const publish = async (req: PublishRequest, res: Response<PublishResBody>
 
     // Make sure we don't serve stale manifest state when a publish is happening
     delFromCache(`node-draft-${ensureUuidEndsWithDot(node.uuid)}`);
+    // Invalidate versions cache so new version shows up immediately
+    delFromCache(`indexed-versions-${ensureUuidEndsWithDot(node.uuid)}`);
 
     // Invalidate dpid metadata cache so link previews reflect the new version
     if (dpidAlias) {

--- a/desci-server/src/controllers/raw/versions.ts
+++ b/desci-server/src/controllers/raw/versions.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 
 import { logger as parentLogger } from '../../logger.js';
-import { getIndexedResearchObjects, IndexedResearchObject } from '../../theGraph.js';
+import { getIndexedResearchObjects } from '../../theGraph.js';
+import { getOrCache, ONE_DAY_TTL } from '../../redisClient.js';
 import { ensureUuidEndsWithDot } from '../../utils.js';
 
 const logger = parentLogger.child({
@@ -9,23 +10,33 @@ const logger = parentLogger.child({
 });
 
 /**
- * Get all versions of research object from index (publicView)
+ * Get all versions of research object from index (publicView).
+ * Cached in Redis for 1 day — the dpid.org /api/v2/query/history
+ * endpoint takes 5-8 seconds uncached.
  */
 export const versions = async (req: Request, res: Response, next: NextFunction) => {
   const uuid = ensureUuidEndsWithDot(req.params.uuid);
-  let result: IndexedResearchObject;
+  const cacheKey = `indexed-versions-${uuid}`;
 
   try {
-    const { researchObjects } = await getIndexedResearchObjects([uuid]);
-    result = researchObjects[0];
-  } catch (err) {
-    logger.error({ result, err }, `[ERROR] graph lookup fail ${err.message}`);
-  }
-  if (!result) {
-    logger.warn({ uuid, result }, 'could not find indexed versions');
-    res.status(404).send({ ok: false, msg: `could not locate uuid ${uuid}` });
-    return;
-  }
+    const result = await getOrCache(
+      cacheKey,
+      async () => {
+        const { researchObjects } = await getIndexedResearchObjects([uuid]);
+        return researchObjects[0] ?? null;
+      },
+      ONE_DAY_TTL,
+    );
 
-  res.send(result);
+    if (!result) {
+      logger.warn({ uuid }, 'could not find indexed versions');
+      res.status(404).send({ ok: false, msg: `could not locate uuid ${uuid}` });
+      return;
+    }
+
+    res.send(result);
+  } catch (err) {
+    logger.error({ uuid, err }, `[ERROR] versions lookup fail ${err.message}`);
+    res.status(500).send({ ok: false, msg: 'Failed to fetch versions' });
+  }
 };

--- a/desci-server/src/scripts/warm-versions-cache.ts
+++ b/desci-server/src/scripts/warm-versions-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * Pre-warm the Redis cache for /v1/pub/versions responses.
+ *
+ * Queries all published nodes from the DB, then calls getIndexedResearchObjects
+ * for each one, which populates the `indexed-versions-{uuid}` cache key.
+ *
+ * Usage:
+ *   npx ts-node src/scripts/warm-versions-cache.ts
+ *   # or with concurrency limit:
+ *   CONCURRENCY=5 npx ts-node src/scripts/warm-versions-cache.ts
+ */
+import { prisma } from '../client.js';
+import { getIndexedResearchObjects } from '../theGraph.js';
+import { getOrCache, ONE_DAY_TTL } from '../redisClient.js';
+import { ensureUuidEndsWithDot } from '../utils.js';
+
+const CONCURRENCY = parseInt(process.env.CONCURRENCY || '3', 10);
+
+async function main() {
+  console.log('Fetching all published nodes with dpidAlias...');
+
+  const nodes = await prisma.node.findMany({
+    select: { uuid: true, dpidAlias: true },
+    where: {
+      dpidAlias: { not: null },
+      isDeleted: false,
+    },
+    orderBy: { dpidAlias: 'desc' },
+  });
+
+  console.log(`Found ${nodes.length} published nodes. Warming cache with concurrency=${CONCURRENCY}...`);
+
+  let warmed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < nodes.length; i += CONCURRENCY) {
+    const batch = nodes.slice(i, i + CONCURRENCY);
+
+    await Promise.allSettled(
+      batch.map(async (node) => {
+        const uuid = ensureUuidEndsWithDot(node.uuid);
+        const cacheKey = `indexed-versions-${uuid}`;
+
+        try {
+          await getOrCache(
+            cacheKey,
+            async () => {
+              const { researchObjects } = await getIndexedResearchObjects([uuid]);
+              return researchObjects[0] ?? null;
+            },
+            ONE_DAY_TTL,
+          );
+          warmed++;
+          if (warmed % 10 === 0) {
+            console.log(`  Progress: ${warmed}/${nodes.length} warmed, ${failed} failed`);
+          }
+        } catch (e) {
+          failed++;
+          console.error(`  Failed dpid=${node.dpidAlias} uuid=${uuid}: ${(e as Error).message}`);
+        }
+      }),
+    );
+  }
+
+  console.log(`\nDone. Warmed: ${warmed}, Failed: ${failed}, Total: ${nodes.length}`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error('Fatal error:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
Cherry-pick of #1281 (already merged to develop, verified working on dev) to fix dpid.org/<dpid> page load times in production.

## Why cherry-pick instead of develop→main

The pending develop→main promotion (#1284) bundles 41 commits including a Prisma 4.10.1 → 6.15.0 major-version upgrade with no documented rationale and only CodeRabbit review. Shipping that needs careful babysitting; this surgical cherry-pick fixes the user-reported slowness today without taking on that risk.

## Verified on dev (post-#1281 deploy)

```
URL: nodes-api-dev.desci.com/v1/pub/versions/<uuid> (dpid=3, 1 version, 453B payload)
call 1 (cold):  646ms
call 2 (warm):  114ms
call 3 (warm):  114ms
call 4 (warm):  107ms
```

6x speedup on a small payload. PR description's 7s→<100ms claim should hold for the larger 13-version dpid 1077 (4.6KB) which is the original symptom.

## Scope

Two commits, 3 files:
- `desci-server/src/controllers/raw/versions.ts` — wraps `getIndexedResearchObjects` in `getOrCache` with 1-day TTL
- `desci-server/src/controllers/nodes/publish.ts` — invalidates `indexed-versions-{uuid}` cache on publish
- `desci-server/src/scripts/warm-versions-cache.ts` — optional pre-warm script (run post-deploy to eliminate cold first-hit per dpid)

Uses existing Redis infrastructure (already configured in prod via vault). Graceful no-op fallback if Redis is unavailable.

## Test plan

- [ ] Wait for prod deploy after merge
- [ ] `time curl https://nodes-api.desci.com/v1/pub/versions/ZoHA0q5s5hLtzBI1gU8xSUhPSGSDX-aI6pm-dPOrARE.` — first call ~5s (cold), subsequent <500ms
- [ ] Verify dpid.org/1077 → nodes.desci.com/dpid/1077 loads in browser <2s
- [ ] (Optional) Run `npx ts-node desci-server/src/scripts/warm-versions-cache.ts` in a prod pod to pre-warm all dpids

🤖 Generated with [Claude Code](https://claude.com/claude-code)