### PR TITLE
perf: cache /v1/data/pubTree and manifest resolve in Redis

### DIFF
--- a/desci-server/src/controllers/data/retrieve.ts
+++ b/desci-server/src/controllers/data/retrieve.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 
 import { prisma } from '../../client.js';
 import { logger as parentLogger } from '../../logger.js';
+import { getFromCache, ONE_DAY_TTL, setToCache } from '../../redisClient.js';
 import { getLatestDriveTime } from '../../services/draftTrees.js';
 import { FileTreeService } from '../../services/FileTreeService.js';
 import { NodeUuid } from '../../services/manifestRepo.js';
@@ -133,6 +134,18 @@ export const pubTree = async (req: Request, res: Response<PubTreeResponse | Erro
   if (!manifestCid) return res.status(400).json({ error: 'no manifest CID provided' });
   if (!uuid) return res.status(400).json({ error: 'no UUID provided' });
 
+  // Cache the success payload only (FileTreeService returns a Result type
+  // whose methods don't survive a Redis JSON round-trip). The manifestCid is
+  // content-addressed, so (uuid, manifestCid, rootCid, dataPath, depth) is
+  // fully immutable — no invalidation needed. New publishes mint a new
+  // manifestCid and write a new cache entry.
+  const cacheKey = `pub-tree:${ensureUuidEndsWithDot(uuid)}:${manifestCid}:${rootCid || ''}:${dataPath}:${depth ?? 'auto'}`;
+  const cached = await getFromCache<PubTreeResponse>(cacheKey, ONE_DAY_TTL);
+  if (cached) {
+    logger.info({ cacheKey }, '[pubTree] cache hit');
+    return res.status(200).json(cached);
+  }
+
   const result = await FileTreeService.getPublishedTree({
     manifestCid,
     rootCid,
@@ -163,5 +176,7 @@ export const pubTree = async (req: Request, res: Response<PubTreeResponse | Erro
   }
 
   const { tree, date } = result.value;
-  return res.status(200).json({ tree, date });
+  const payload: PubTreeResponse = { tree, date };
+  await setToCache(cacheKey, payload, ONE_DAY_TTL);
+  return res.status(200).json(payload);
 };

--- a/desci-server/src/controllers/nodes/publish.ts
+++ b/desci-server/src/controllers/nodes/publish.ts
@@ -139,6 +139,9 @@ export const publish = async (req: PublishRequest, res: Response<PublishResBody>
     delFromCache(`node-draft-${ensureUuidEndsWithDot(node.uuid)}`);
     // Invalidate versions cache so new version shows up immediately
     delFromCache(`indexed-versions-${ensureUuidEndsWithDot(node.uuid)}`);
+    // Invalidate "latest" manifest resolution. Per-index and per-CID keys are
+    // immutable (each version is content-addressed) so they don't need it.
+    delFromCache(`resolve-manifest:${ensureUuidEndsWithDot(node.uuid)}:latest`);
 
     // Invalidate dpid metadata cache so link previews reflect the new version
     if (dpidAlias) {

--- a/desci-server/src/controllers/raw/resolve.ts
+++ b/desci-server/src/controllers/raw/resolve.ts
@@ -8,10 +8,27 @@ import axios from 'axios';
 import { NextFunction, Request, Response } from 'express';
 import { pipeline } from 'node:stream/promises';
 import { logger as parentLogger } from '../../logger.js';
+import { getFromCache, ONE_DAY_TTL, setToCache } from '../../redisClient.js';
 import { getIndexedResearchObjects } from '../../theGraph.js';
-import { decodeBase64UrlSafeToHex, hexToCid } from '../../utils.js';
+import { decodeBase64UrlSafeToHex, ensureUuidEndsWithDot, hexToCid } from '../../utils.js';
 
 const IPFS_RESOLVER_OVERRIDE = process.env.IPFS_RESOLVER_OVERRIDE || '';
+
+/**
+ * Cache key for manifest resolution. Used by both the read (cache lookup at
+ * controller entry) and write (after successful IPFS fetch) paths, plus
+ * invalidation in publish.ts on `latest`.
+ *
+ *   firstParam=""       → resolve-manifest:<uuid>.:latest      (invalidate on publish)
+ *   firstParam="0".."N" → resolve-manifest:<uuid>.:<index>     (immutable per index)
+ *   firstParam=<cid>    → resolve-manifest:<uuid>.:<cid>       (immutable per CID)
+ *
+ * The uuid is normalized via ensureUuidEndsWithDot so the key shape matches
+ * regardless of whether the URL included a trailing dot. publish.ts uses the
+ * same normalization for invalidation.
+ */
+const buildResolveManifestCacheKey = (uuid: string, firstParam: string | undefined) =>
+  `resolve-manifest:${ensureUuidEndsWithDot(uuid)}:${firstParam && firstParam.trim().length ? firstParam : 'latest'}`;
 
 export const resolve = async (req: Request, res: Response, next: NextFunction) => {
   /**
@@ -45,6 +62,22 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
   });
   logger.debug(`[resolve::resolve] firstParam=${firstParam} secondParam=${secondParam}`);
 
+  // Cache the manifest-by-uuid+version path. Heavy work below:
+  // getIndexedResearchObjects (theGraph, 5-8s) + IPFS gateway fetch (1-2s).
+  // Only cache when no secondParam — i.e. the response is the bare manifest,
+  // fully deterministic by uuid+firstParam. Component/code/PDF responses
+  // and 4xx/5xx outcomes are not cached.
+  const isCacheableManifestRequest = !secondParam;
+  const manifestCacheKey = isCacheableManifestRequest ? buildResolveManifestCacheKey(uuid, firstParam) : null;
+
+  if (manifestCacheKey) {
+    const cached = await getFromCache<unknown>(manifestCacheKey);
+    if (cached) {
+      logger.info({ manifestCacheKey }, '[resolve] cache hit');
+      return res.send(cached);
+    }
+  }
+
   let result;
   try {
     const res = await getIndexedResearchObjects([uuid]);
@@ -74,6 +107,7 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
     try {
       logger.info(`Calling IPFS Resolver ${ipfsResolver} for CID ${cidString}`);
       const { data } = await axios.get(`${ipfsResolver}/${cidString}`);
+      if (manifestCacheKey) await setToCache(manifestCacheKey, data, ONE_DAY_TTL);
       return res.send(data);
     } catch (err) {
       return res.status(500).send({ ok: false, msg: 'ipfs uplink failed, try setting ?g= querystring to resolver' });
@@ -134,6 +168,7 @@ export const resolve = async (req: Request, res: Response, next: NextFunction) =
 
   if (!secondParam) {
     logger.info("Returning manifest as there is no additional path");
+    if (manifestCacheKey) await setToCache(manifestCacheKey, data, ONE_DAY_TTL);
     return res.send(data);
   };
 


### PR DESCRIPTION
## Summary

Same pattern as #1281 (which cached `/v1/pub/versions`). The dpid SSR path in `nodes-web-v2` hits two more endpoints on every cold render:

| nodes-web-v2 caller | desci-server controller | Cost |
|---|---|---|
| `resolvePublishedManifest` → `GET ${API}/<uuid>/<version>` | `controllers/raw/resolve.ts` | ~5-8s (theGraph + IPFS) |
| `loadDriveTree` → `GET /v1/data/pubTree/...` | `controllers/data/retrieve.ts:107` | ~1-3s |

Together they dominate the dpid SSR cold-load TTFB.

## Why these are safe to cache

Both responses are content-addressed:

- **`pubTree`** by `(uuid, manifestCid, rootCid, dataPath, depth)`. `manifestCid` is itself a content hash, so the tuple is fully immutable. No invalidation needed — new publishes mint a new `manifestCid` and write a fresh cache entry.
- **`resolve`** by `(uuid, firstParam)` where `firstParam` is `""` / index / CID. Index- and CID-keyed entries are immutable. The `latest` key is invalidated in `publish.ts` alongside the existing `indexed-versions` invalidation.

Only success paths cache. Component (PDF/code) responses in `resolve.ts` and 4xx/5xx responses are NOT cached.

`FileTreeService.getPublishedTree` returns a `Result` type whose `.isErr()`/`.value` methods don't survive a Redis JSON round-trip — `pubTree` caches the unwrapped success payload only, after the error check.

## Expected impact (combined with nodes-web-v2#1540)

| Stage | Today | With #1540 only | With #1540 + this PR |
|---|---|---|---|
| Cold first-hit per dpid (per Vercel region per 5min) | 12-16s | 12-16s | **~1.5s** |
| Warm hit | 12-16s | ~150ms | ~150ms |

## Test plan

- [ ] Deploy to dev, hit `nodes-api-dev.desci.com/<uuid>/0` twice. First hit logs `getIndexedResearchObjects` work; second hit logs `[resolve] cache hit` and is <100ms.
- [ ] Same for `/v1/data/pubTree/<uuid>/<manifestCid>` (`[pubTree] cache hit` on warm).
- [ ] Publish a new version. Confirm `/<uuid>/<latest>` reflects the new version on next request (latest key invalidated).
- [ ] Publish does NOT invalidate per-index keys (they remain immutable; verified by hitting `/<uuid>/0` after publish — same response, cached).
- [ ] Confirm component responses (`/<uuid>/<v>/<componentIdx>`) and 4xx are not cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented response caching for publication tree and manifest data retrieval, significantly improving response times for frequently accessed data
  * Enhanced manifest resolution with automatic cache invalidation to ensure updates are immediately reflected after publishing operations
  * Optimized data resolution endpoints with intelligent caching strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->