### PR TITLE
Add revenuecat bundle support

### DIFF
--- a/desci-server/prisma/migrations/20260505113000_add_revenuecat_purchase_fulfillment/migration.sql
+++ b/desci-server/prisma/migrations/20260505113000_add_revenuecat_purchase_fulfillment/migration.sql
@@ -1,0 +1,42 @@
+CREATE TYPE "RevenueCatPurchaseFulfillmentType" AS ENUM ('BUNDLE_CHATS', 'LIFETIME_UNLOCK');
+
+CREATE TABLE "RevenueCatPurchaseFulfillment" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "revenueCatEventId" TEXT,
+    "revenueCatTransactionId" TEXT NOT NULL,
+    "revenueCatOriginalTransactionId" TEXT,
+    "revenueCatProductId" TEXT NOT NULL,
+    "revenueCatStore" TEXT,
+    "amountPaid" DOUBLE PRECISION,
+    "currency" TEXT,
+    "fulfillmentType" "RevenueCatPurchaseFulfillmentType" NOT NULL,
+    "purchasedUnits" INTEGER NOT NULL,
+    "grantedUnits" INTEGER NOT NULL,
+    "skipReason" TEXT,
+    "details" JSONB,
+    "reversedAt" TIMESTAMP(3),
+    "reversalReason" TEXT,
+    "reversalDetails" JSONB,
+    "fulfilledAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RevenueCatPurchaseFulfillment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "RevenueCatPurchaseFulfillment_revenueCatTransactionId_key"
+ON "RevenueCatPurchaseFulfillment"("revenueCatTransactionId");
+
+CREATE INDEX "RevenueCatPurchaseFulfillment_userId_idx"
+ON "RevenueCatPurchaseFulfillment"("userId");
+
+CREATE INDEX "RevenueCatPurchaseFulfillment_revenueCatProductId_idx"
+ON "RevenueCatPurchaseFulfillment"("revenueCatProductId");
+
+CREATE INDEX "RevenueCatPurchaseFulfillment_fulfilledAt_idx"
+ON "RevenueCatPurchaseFulfillment"("fulfilledAt");
+
+ALTER TABLE "RevenueCatPurchaseFulfillment"
+ADD CONSTRAINT "RevenueCatPurchaseFulfillment_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/desci-server/prisma/schema.prisma
+++ b/desci-server/prisma/schema.prisma
@@ -285,6 +285,7 @@ model User {
   AbandonedCheckout         AbandonedCheckout[]
   accountDeletionRequest    AccountDeletionRequest?
   StripeCheckoutFulfillment StripeCheckoutFulfillment[]
+  RevenueCatPurchaseFulfillment RevenueCatPurchaseFulfillment[]
 
   @@index([orcid])
   @@index([walletAddress])
@@ -1634,6 +1635,35 @@ model StripeCheckoutFulfillment {
   @@index([fulfilledAt])
 }
 
+model RevenueCatPurchaseFulfillment {
+  id                               Int                                @id @default(autoincrement())
+  userId                           Int
+  revenueCatEventId                String?
+  revenueCatTransactionId          String                             @unique
+  revenueCatOriginalTransactionId  String?
+  revenueCatProductId              String
+  revenueCatStore                  String?
+  amountPaid                       Float?
+  currency                         String?
+  fulfillmentType                  RevenueCatPurchaseFulfillmentType
+  purchasedUnits                   Int
+  grantedUnits                     Int
+  skipReason                       String?
+  details                          Json?
+  reversedAt                       DateTime?
+  reversalReason                   String?
+  reversalDetails                  Json?
+  fulfilledAt                      DateTime                           @default(now())
+  createdAt                        DateTime                           @default(now())
+  updatedAt                        DateTime                           @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId])
+  @@index([revenueCatProductId])
+  @@index([fulfilledAt])
+}
+
 enum ImportTaskQueueStatus {
   PENDING
   IN_PROGRESS
@@ -1643,6 +1673,11 @@ enum ImportTaskQueueStatus {
 
 enum StripeCheckoutFulfillmentType {
   BUNDLE_CHATS
+}
+
+enum RevenueCatPurchaseFulfillmentType {
+  BUNDLE_CHATS
+  LIFETIME_UNLOCK
 }
 
 enum Feature {

--- a/desci-server/src/config/mobileBundles.ts
+++ b/desci-server/src/config/mobileBundles.ts
@@ -1,0 +1,24 @@
+export const MOBILE_CHAT_BUNDLE_PRODUCT_IDS = {
+  CHAT_BUNDLE_10: 'com.desci.research.chatbundle10',
+  CHAT_BUNDLE_30: 'com.desci.research.chatbundle30',
+  CHAT_BUNDLE_200: 'com.desci.research.chatbundle200',
+  LIFETIME: 'com.desci.research.lifetime',
+} as const;
+
+const CHAT_BUNDLE_GRANTS: Record<string, number> = {
+  [MOBILE_CHAT_BUNDLE_PRODUCT_IDS.CHAT_BUNDLE_10]: 10,
+  [MOBILE_CHAT_BUNDLE_PRODUCT_IDS.CHAT_BUNDLE_30]: 30,
+  [MOBILE_CHAT_BUNDLE_PRODUCT_IDS.CHAT_BUNDLE_200]: 200,
+};
+
+export function getChatBundleUnitsForProduct(productId: string): number | null {
+  return CHAT_BUNDLE_GRANTS[productId] ?? null;
+}
+
+export function isLifetimeMobileProduct(productId: string): boolean {
+  return productId === MOBILE_CHAT_BUNDLE_PRODUCT_IDS.LIFETIME;
+}
+
+export function isRevenueCatBundleOrLifetimeProduct(productId: string): boolean {
+  return getChatBundleUnitsForProduct(productId) !== null || isLifetimeMobileProduct(productId);
+}

--- a/desci-server/src/services/RevenueCatService.ts
+++ b/desci-server/src/services/RevenueCatService.ts
@@ -3,6 +3,7 @@
  */
 import crypto from 'node:crypto';
 
+import { getChatBundleUnitsForProduct, isLifetimeMobileProduct } from '../config/mobileBundles.js';
 import { REVENUECAT_API_KEY, REVENUECAT_ENTITLEMENT_ID, REVENUECAT_WEBHOOK_SECRET } from '../config.js';
 import { logger as parentLogger } from '../logger.js';
 import { delFromCache, getFromCache, setToCache } from '../redisClient.js';
@@ -74,8 +75,14 @@ export interface RevenueCatWebhookPayload {
   api_version: string;
   event: {
     app_user_id: string;
+    cancel_reason?: string | null;
+    currency?: string | null;
     event_timestamp_ms: number;
     expiration_at_ms: number;
+    id?: string;
+    original_transaction_id?: string | null;
+    presented_offering_id?: string | null;
+    price?: number | null;
     product_id: string;
     store: string;
     subscriber_attributes: {
@@ -84,6 +91,19 @@ export interface RevenueCatWebhookPayload {
     transaction_id: string | null;
     type: string;
   };
+}
+
+function getWebhookUserId(payload: RevenueCatWebhookPayload): number | null {
+  const attributeUserId = payload.event.subscriber_attributes['userId']?.value;
+  if (attributeUserId) {
+    const parsed = Number(attributeUserId);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  const appUserId = Number(payload.event.app_user_id);
+  return Number.isNaN(appUserId) ? null : appUserId;
 }
 
 function getAuthHeaders(): Record<string, string> {
@@ -264,14 +284,156 @@ async function cacheMobileSubscriptionFromCustomerInfo(
 export async function handleWebhookEvent(
   payload: RevenueCatWebhookPayload,
 ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-  const userIdValue = payload.event.subscriber_attributes['userId']?.value;
-  const userId = userIdValue ? Number(userIdValue) : null;
-  const user = userId != null && !Number.isNaN(userId) ? await getUserById(userId) : null;
+  const userId = getWebhookUserId(payload);
+  const user = userId != null ? await getUserById(userId) : null;
   if (!user) {
-    logger.warn({ userId: userIdValue }, 'RevenueCat webhook: user not found');
+    logger.warn({ appUserId: payload.event.app_user_id }, 'RevenueCat webhook: user not found');
     return { ok: false, status: 404, error: 'User not found' };
   }
   const appUserId = payload.event.app_user_id;
+  const productId = payload.event.product_id;
+  const bundleUnits = getChatBundleUnitsForProduct(productId);
+  const isLifetimeProduct = isLifetimeMobileProduct(productId);
+
+  if (bundleUnits !== null || isLifetimeProduct) {
+    switch (payload.event.type) {
+      case 'NON_RENEWING_PURCHASE':
+      case 'INITIAL_PURCHASE':
+        if (!payload.event.transaction_id) {
+          logger.warn(
+            { userId, productId, eventType: payload.event.type },
+            'RevenueCat purchase missing transaction id',
+          );
+          break;
+        }
+
+        if (bundleUnits !== null) {
+          const fulfillment = await SubscriptionService.handleRevenueCatBundlePurchase({
+            userId,
+            productId,
+            transactionId: payload.event.transaction_id,
+            originalTransactionId: payload.event.original_transaction_id,
+            eventId: payload.event.id,
+            store: payload.event.store,
+            amountPaid: payload.event.price,
+            currency: payload.event.currency,
+            presentedOfferingId: payload.event.presented_offering_id,
+          });
+
+          logger.info(
+            {
+              userId,
+              productId,
+              transactionId: payload.event.transaction_id,
+              grantedChats: fulfillment.grantedChats,
+              totalChats: fulfillment.totalChats,
+              skipReason: fulfillment.skipReason,
+              alreadyFulfilled: fulfillment.alreadyFulfilled,
+            },
+            'RevenueCat bundle purchase fulfilled',
+          );
+        } else {
+          const fulfillment = await SubscriptionService.handleRevenueCatLifetimePurchase({
+            userId,
+            productId,
+            transactionId: payload.event.transaction_id,
+            originalTransactionId: payload.event.original_transaction_id,
+            eventId: payload.event.id,
+            store: payload.event.store,
+            amountPaid: payload.event.price,
+            currency: payload.event.currency,
+            presentedOfferingId: payload.event.presented_offering_id,
+          });
+
+          logger.info(
+            {
+              userId,
+              productId,
+              transactionId: payload.event.transaction_id,
+              createdNewLifetime: fulfillment.createdNewLifetime,
+              alreadyFulfilled: fulfillment.alreadyFulfilled,
+            },
+            'RevenueCat lifetime purchase fulfilled',
+          );
+        }
+        break;
+      case 'CANCELLATION':
+        if (!payload.event.transaction_id) {
+          logger.warn(
+            { userId, productId, eventType: payload.event.type },
+            'RevenueCat cancellation missing transaction id',
+          );
+          break;
+        }
+
+        if (bundleUnits !== null) {
+          const reversal = await SubscriptionService.reverseRevenueCatBundlePurchase({
+            userId,
+            productId,
+            transactionId: payload.event.transaction_id,
+            eventId: payload.event.id,
+            reason: payload.event.cancel_reason,
+          });
+
+          logger.info(
+            {
+              userId,
+              productId,
+              transactionId: payload.event.transaction_id,
+              reversed: reversal.reversed,
+              alreadyReversed: reversal.alreadyReversed,
+              reversedChats: reversal.reversedChats,
+            },
+            'RevenueCat bundle cancellation handled',
+          );
+        } else {
+          const cancellation = await SubscriptionService.handleRevenueCatLifetimeCancellation({
+            userId,
+            transactionId: payload.event.transaction_id,
+            eventId: payload.event.id,
+            reason: payload.event.cancel_reason,
+          });
+
+          logger.info(
+            {
+              userId,
+              productId,
+              transactionId: payload.event.transaction_id,
+              canceled: cancellation.canceled,
+              alreadyReversed: cancellation.alreadyReversed,
+            },
+            'RevenueCat lifetime cancellation handled',
+          );
+        }
+        break;
+      case 'EXPIRATION':
+        if (isLifetimeProduct && payload.event.transaction_id) {
+          const cancellation = await SubscriptionService.handleRevenueCatLifetimeCancellation({
+            userId,
+            transactionId: payload.event.transaction_id,
+            eventId: payload.event.id,
+            reason: 'expiration',
+          });
+
+          logger.info(
+            {
+              userId,
+              productId,
+              transactionId: payload.event.transaction_id,
+              canceled: cancellation.canceled,
+              alreadyReversed: cancellation.alreadyReversed,
+            },
+            'RevenueCat lifetime expiration handled',
+          );
+        }
+        break;
+      default:
+        logger.info({ eventType: payload.event.type, userId, productId }, 'RevenueCat bundle/lifetime webhook ignored');
+        break;
+    }
+
+    return { ok: true };
+  }
 
   const customerInfo = await getCustomerInfo(appUserId);
   if (customerInfo) {

--- a/desci-server/src/services/SubscriptionService.ts
+++ b/desci-server/src/services/SubscriptionService.ts
@@ -714,7 +714,7 @@ export class SubscriptionService {
       });
 
       let reversedChats = 0;
-      if (activeLimit?.useLimit !== null && fulfillment.grantedUnits > 0) {
+      if (activeLimit && activeLimit.useLimit !== null && fulfillment.grantedUnits > 0) {
         const nextUseLimit = Math.max(0, activeLimit.useLimit - fulfillment.grantedUnits);
         await tx.userFeatureLimit.update({
           where: { id: activeLimit.id },

--- a/desci-server/src/services/SubscriptionService.ts
+++ b/desci-server/src/services/SubscriptionService.ts
@@ -8,10 +8,12 @@ import {
   Feature,
   PlanCodename,
   Period,
+  RevenueCatPurchaseFulfillmentType,
   SentEmailType,
 } from '@prisma/client';
 import Stripe from 'stripe';
 
+import { getChatBundleUnitsForProduct } from '../config/mobileBundles.js';
 import { getPlanTypeFromPriceId, getBillingIntervalFromPriceId } from '../config/stripe.js';
 import { capturePostHogEvent } from '../lib/PostHog.js';
 import { logger as parentLogger } from '../logger.js';
@@ -556,6 +558,378 @@ export class SubscriptionService {
   static async handleMobileSubscriptionCancelled(userId: number) {
     logger.info({ userId }, 'Handling mobile subscription cancelled');
     return await this.updateFeatureLimitsAfterCancellation(userId);
+  }
+
+  static async handleRevenueCatBundlePurchase({
+    userId,
+    productId,
+    transactionId,
+    originalTransactionId,
+    eventId,
+    store,
+    amountPaid,
+    currency,
+    presentedOfferingId,
+  }: {
+    userId: number;
+    productId: string;
+    transactionId: string;
+    originalTransactionId?: string | null;
+    eventId?: string | null;
+    store?: string | null;
+    amountPaid?: number | null;
+    currency?: string | null;
+    presentedOfferingId?: string | null;
+  }): Promise<{
+    alreadyFulfilled: boolean;
+    grantedChats: number;
+    totalChats: number;
+    skipReason: string | null;
+  }> {
+    const bundleChatsPerUnit = getChatBundleUnitsForProduct(productId);
+
+    if (!bundleChatsPerUnit) {
+      throw new Error(`Unsupported RevenueCat chat bundle product: ${productId}`);
+    }
+
+    const { FeatureLimitsService } = await import('./FeatureLimits/FeatureLimitsService.js');
+    const limitResult = await FeatureLimitsService.getOrCreateUserFeatureLimit(userId, Feature.RESEARCH_ASSISTANT);
+    if (limitResult.isErr()) {
+      throw limitResult.error;
+    }
+
+    return await prisma.$transaction(async (tx) => {
+      const existingFulfillment = await tx.revenueCatPurchaseFulfillment.findUnique({
+        where: { revenueCatTransactionId: transactionId },
+      });
+
+      if (existingFulfillment) {
+        return {
+          alreadyFulfilled: true,
+          grantedChats: existingFulfillment.grantedUnits,
+          totalChats: existingFulfillment.purchasedUnits,
+          skipReason: existingFulfillment.skipReason,
+        };
+      }
+
+      const activeLimit = await tx.userFeatureLimit.findFirst({
+        where: {
+          userId,
+          feature: Feature.RESEARCH_ASSISTANT,
+          isActive: true,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      if (!activeLimit) {
+        throw new Error(`Active RESEARCH_ASSISTANT feature limit not found for user ${userId}`);
+      }
+
+      const totalChats = bundleChatsPerUnit;
+      let grantedChats = 0;
+      let skipReason: string | null = null;
+
+      if (activeLimit.useLimit === null) {
+        skipReason = 'user_has_unlimited_chat_access';
+      } else {
+        grantedChats = totalChats;
+        await tx.userFeatureLimit.update({
+          where: { id: activeLimit.id },
+          data: { useLimit: activeLimit.useLimit + totalChats },
+        });
+      }
+
+      await tx.revenueCatPurchaseFulfillment.create({
+        data: {
+          userId,
+          revenueCatEventId: eventId ?? null,
+          revenueCatTransactionId: transactionId,
+          revenueCatOriginalTransactionId: originalTransactionId ?? null,
+          revenueCatProductId: productId,
+          revenueCatStore: store ?? null,
+          amountPaid: amountPaid ?? null,
+          currency: currency ?? null,
+          fulfillmentType: RevenueCatPurchaseFulfillmentType.BUNDLE_CHATS,
+          purchasedUnits: totalChats,
+          grantedUnits: grantedChats,
+          skipReason,
+          details: {
+            presentedOfferingId: presentedOfferingId ?? null,
+            bundleChatsPerUnit,
+          },
+        },
+      });
+
+      return {
+        alreadyFulfilled: false,
+        grantedChats,
+        totalChats,
+        skipReason,
+      };
+    });
+  }
+
+  static async reverseRevenueCatBundlePurchase({
+    userId,
+    productId,
+    transactionId,
+    eventId,
+    reason,
+  }: {
+    userId: number;
+    productId: string;
+    transactionId: string;
+    eventId?: string | null;
+    reason?: string | null;
+  }): Promise<{
+    reversed: boolean;
+    alreadyReversed: boolean;
+    reversedChats: number;
+  }> {
+    const bundleChatsPerUnit = getChatBundleUnitsForProduct(productId);
+    if (!bundleChatsPerUnit) {
+      throw new Error(`Unsupported RevenueCat chat bundle product: ${productId}`);
+    }
+
+    return await prisma.$transaction(async (tx) => {
+      const fulfillment = await tx.revenueCatPurchaseFulfillment.findUnique({
+        where: { revenueCatTransactionId: transactionId },
+      });
+
+      if (!fulfillment || fulfillment.fulfillmentType !== RevenueCatPurchaseFulfillmentType.BUNDLE_CHATS) {
+        return { reversed: false, alreadyReversed: false, reversedChats: 0 };
+      }
+
+      if (fulfillment.reversedAt) {
+        return { reversed: false, alreadyReversed: true, reversedChats: 0 };
+      }
+
+      const activeLimit = await tx.userFeatureLimit.findFirst({
+        where: {
+          userId,
+          feature: Feature.RESEARCH_ASSISTANT,
+          isActive: true,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      let reversedChats = 0;
+      if (activeLimit?.useLimit !== null && fulfillment.grantedUnits > 0) {
+        const nextUseLimit = Math.max(0, activeLimit.useLimit - fulfillment.grantedUnits);
+        await tx.userFeatureLimit.update({
+          where: { id: activeLimit.id },
+          data: { useLimit: nextUseLimit },
+        });
+        reversedChats = fulfillment.grantedUnits;
+      }
+
+      await tx.revenueCatPurchaseFulfillment.update({
+        where: { id: fulfillment.id },
+        data: {
+          reversedAt: new Date(),
+          reversalReason: reason ?? 'revenuecat_cancellation',
+          reversalDetails: {
+            eventId: eventId ?? null,
+          },
+        },
+      });
+
+      return { reversed: true, alreadyReversed: false, reversedChats };
+    });
+  }
+
+  static async handleRevenueCatLifetimePurchase({
+    userId,
+    productId,
+    transactionId,
+    originalTransactionId,
+    eventId,
+    store,
+    amountPaid,
+    currency,
+    presentedOfferingId,
+  }: {
+    userId: number;
+    productId: string;
+    transactionId: string;
+    originalTransactionId?: string | null;
+    eventId?: string | null;
+    store?: string | null;
+    amountPaid?: number | null;
+    currency?: string | null;
+    presentedOfferingId?: string | null;
+  }): Promise<{
+    alreadyFulfilled: boolean;
+    createdNewLifetime: boolean;
+  }> {
+    const now = new Date();
+    const syntheticSubscriptionId = `revenuecat_lifetime_${transactionId}`;
+
+    const result = await prisma.$transaction(async (tx) => {
+      const existingFulfillment = await tx.revenueCatPurchaseFulfillment.findUnique({
+        where: { revenueCatTransactionId: transactionId },
+      });
+
+      if (existingFulfillment) {
+        return {
+          alreadyFulfilled: true,
+          createdNewLifetime: false,
+        };
+      }
+
+      const existingSubscription = await tx.subscription.findFirst({
+        where: {
+          stripeSubscriptionId: syntheticSubscriptionId,
+        },
+      });
+
+      await tx.subscription.upsert({
+        where: { stripeSubscriptionId: syntheticSubscriptionId },
+        create: {
+          userId,
+          stripeCustomerId: null,
+          stripeSubscriptionId: syntheticSubscriptionId,
+          stripePriceId: productId,
+          status: SubscriptionStatus.ACTIVE,
+          planType: PlanType.SCIWEAVE_LIFETIME,
+          billingInterval: BillingInterval.LIFETIME,
+          currentPeriodStart: now,
+          currentPeriodEnd: null,
+          cancelAtPeriodEnd: false,
+          canceledAt: null,
+          trialStart: null,
+          trialEnd: null,
+        },
+        update: {
+          userId,
+          stripePriceId: productId,
+          status: SubscriptionStatus.ACTIVE,
+          planType: PlanType.SCIWEAVE_LIFETIME,
+          billingInterval: BillingInterval.LIFETIME,
+          currentPeriodStart: existingSubscription?.currentPeriodStart ?? now,
+          currentPeriodEnd: null,
+          cancelAtPeriodEnd: false,
+          canceledAt: null,
+          trialStart: null,
+          trialEnd: null,
+        },
+      });
+
+      await tx.revenueCatPurchaseFulfillment.create({
+        data: {
+          userId,
+          revenueCatEventId: eventId ?? null,
+          revenueCatTransactionId: transactionId,
+          revenueCatOriginalTransactionId: originalTransactionId ?? null,
+          revenueCatProductId: productId,
+          revenueCatStore: store ?? null,
+          amountPaid: amountPaid ?? null,
+          currency: currency ?? null,
+          fulfillmentType: RevenueCatPurchaseFulfillmentType.LIFETIME_UNLOCK,
+          purchasedUnits: 1,
+          grantedUnits: 1,
+          details: {
+            presentedOfferingId: presentedOfferingId ?? null,
+            syntheticSubscriptionId,
+          },
+        },
+      });
+
+      return {
+        alreadyFulfilled: false,
+        createdNewLifetime: !existingSubscription,
+      };
+    });
+
+    await this.updateUserFeatureLimits(userId, PlanType.SCIWEAVE_LIFETIME);
+
+    if (result.createdNewLifetime) {
+      try {
+        const user = await this.getUserForEmail(userId);
+        if (user) {
+          await sendEmail({
+            type: SciweaveEmailTypes.SCIWEAVE_UPGRADE_EMAIL,
+            payload: {
+              email: user.email,
+              firstName: user.firstName,
+              lastName: user.lastName,
+            },
+          });
+          logger.info({ userId, transactionId, productId }, 'Upgrade email sent for RevenueCat lifetime purchase');
+        }
+      } catch (emailError) {
+        logger.error(
+          { error: emailError, userId, transactionId, productId },
+          'Failed to send upgrade email for RevenueCat lifetime purchase',
+        );
+      }
+    }
+
+    return result;
+  }
+
+  static async handleRevenueCatLifetimeCancellation({
+    userId,
+    transactionId,
+    eventId,
+    reason,
+  }: {
+    userId: number;
+    transactionId: string;
+    eventId?: string | null;
+    reason?: string | null;
+  }): Promise<{
+    canceled: boolean;
+    alreadyReversed: boolean;
+  }> {
+    const syntheticSubscriptionId = `revenuecat_lifetime_${transactionId}`;
+
+    const result = await prisma.$transaction(async (tx) => {
+      const fulfillment = await tx.revenueCatPurchaseFulfillment.findUnique({
+        where: { revenueCatTransactionId: transactionId },
+      });
+
+      if (!fulfillment || fulfillment.fulfillmentType !== RevenueCatPurchaseFulfillmentType.LIFETIME_UNLOCK) {
+        return { canceled: false, alreadyReversed: false };
+      }
+
+      if (fulfillment.reversedAt) {
+        return { canceled: false, alreadyReversed: true };
+      }
+
+      await tx.revenueCatPurchaseFulfillment.update({
+        where: { id: fulfillment.id },
+        data: {
+          reversedAt: new Date(),
+          reversalReason: reason ?? 'revenuecat_cancellation',
+          reversalDetails: {
+            eventId: eventId ?? null,
+          },
+        },
+      });
+
+      await tx.subscription.updateMany({
+        where: {
+          userId,
+          stripeSubscriptionId: syntheticSubscriptionId,
+          status: SubscriptionStatus.ACTIVE,
+        },
+        data: {
+          status: SubscriptionStatus.CANCELED,
+          cancelAtPeriodEnd: false,
+          canceledAt: new Date(),
+          currentPeriodEnd: new Date(),
+        },
+      });
+
+      return { canceled: true, alreadyReversed: false };
+    });
+
+    if (result.canceled) {
+      await this.updateFeatureLimitsAfterCancellation(userId);
+    }
+
+    return result;
   }
 
   /**

--- a/desci-server/test/integration/revenuecatBundles.test.ts
+++ b/desci-server/test/integration/revenuecatBundles.test.ts
@@ -1,0 +1,192 @@
+import { Feature, PlanType, RevenueCatPurchaseFulfillmentType, SubscriptionStatus, User } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/services/email/email.js', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { prisma } from '../../src/client.js';
+import { MOBILE_CHAT_BUNDLE_PRODUCT_IDS } from '../../src/config/mobileBundles.js';
+import { SCIWEAVE_FREE_LIMIT } from '../../src/config.js';
+import { handleWebhookEvent, type RevenueCatWebhookPayload } from '../../src/services/RevenueCatService.js';
+
+describe('RevenueCat bundle fulfillment', () => {
+  let user: User;
+
+  beforeEach(async () => {
+    await prisma.$queryRaw`TRUNCATE TABLE "RevenueCatPurchaseFulfillment" CASCADE;`;
+    await prisma.$queryRaw`TRUNCATE TABLE "Subscription" CASCADE;`;
+    await prisma.$queryRaw`TRUNCATE TABLE "UserFeatureLimit" CASCADE;`;
+    await prisma.$queryRaw`TRUNCATE TABLE "User" CASCADE;`;
+
+    user = await prisma.user.create({
+      data: {
+        email: 'revenuecat-bundles-test@desci.com',
+        name: 'RevenueCat Bundles Test User',
+      },
+    });
+  });
+
+  it('grants chats for a bundle purchase webhook', async () => {
+    const result = await handleWebhookEvent(
+      makePayload({
+        userId: user.id,
+        type: 'NON_RENEWING_PURCHASE',
+        productId: MOBILE_CHAT_BUNDLE_PRODUCT_IDS.CHAT_BUNDLE_10,
+        transactionId: 'bundle_txn_10',
+        price: 4.99,
+      }),
+    );
+
+    expect(result).toEqual({ ok: true });
+
+    const activeLimit = await prisma.userFeatureLimit.findFirst({
+      where: { userId: user.id, feature: Feature.RESEARCH_ASSISTANT, isActive: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(activeLimit?.useLimit).toBe(SCIWEAVE_FREE_LIMIT + 10);
+
+    const fulfillment = await prisma.revenueCatPurchaseFulfillment.findUnique({
+      where: { revenueCatTransactionId: 'bundle_txn_10' },
+    });
+    expect(fulfillment?.fulfillmentType).toBe(RevenueCatPurchaseFulfillmentType.BUNDLE_CHATS);
+    expect(fulfillment?.grantedUnits).toBe(10);
+    expect(fulfillment?.purchasedUnits).toBe(10);
+  });
+
+  it('is idempotent for duplicate bundle webhooks', async () => {
+    const payload = makePayload({
+      userId: user.id,
+      type: 'NON_RENEWING_PURCHASE',
+      productId: MOBILE_CHAT_BUNDLE_PRODUCT_IDS.CHAT_BUNDLE_30,
+      transactionId: 'bundle_txn_duplicate',
+      price: 9.99,
+    });
+
+    await handleWebhookEvent(payload);
+    await handleWebhookEvent(payload);
+
+    const activeLimit = await prisma.userFeatureLimit.findFirst({
+      where: { userId: user.id, feature: Feature.RESEARCH_ASSISTANT, isActive: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(activeLimit?.useLimit).toBe(SCIWEAVE_FREE_LIMIT + 30);
+
+    const fulfillments = await prisma.revenueCatPurchaseFulfillment.findMany({
+      where: { revenueCatTransactionId: 'bundle_txn_duplicate' },
+    });
+    expect(fulfillments).toHaveLength(1);
+  });
+
+  it('reverses a bundle grant on cancellation', async () => {
+    const transactionId = 'bundle_txn_cancel';
+
+    await handleWebhookEvent(
+      makePayload({
+        userId: user.id,
+        type: 'NON_RENEWING_PURCHASE',
+        productId: MOBILE_CHAT_BUNDLE_PRODUCT_IDS.CHAT_BUNDLE_30,
+        transactionId,
+        price: 9.99,
+      }),
+    );
+
+    await handleWebhookEvent(
+      makePayload({
+        userId: user.id,
+        type: 'CANCELLATION',
+        productId: MOBILE_CHAT_BUNDLE_PRODUCT_IDS.CHAT_BUNDLE_30,
+        transactionId,
+        cancelReason: 'CUSTOMER_SUPPORT',
+      }),
+    );
+
+    const activeLimit = await prisma.userFeatureLimit.findFirst({
+      where: { userId: user.id, feature: Feature.RESEARCH_ASSISTANT, isActive: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(activeLimit?.useLimit).toBe(SCIWEAVE_FREE_LIMIT);
+
+    const fulfillment = await prisma.revenueCatPurchaseFulfillment.findUnique({
+      where: { revenueCatTransactionId: transactionId },
+    });
+    expect(fulfillment?.reversedAt).not.toBeNull();
+    expect(fulfillment?.reversalReason).toBe('CUSTOMER_SUPPORT');
+  });
+
+  it('grants lifetime access for the lifetime product', async () => {
+    const transactionId = 'lifetime_txn_1';
+
+    const result = await handleWebhookEvent(
+      makePayload({
+        userId: user.id,
+        type: 'NON_RENEWING_PURCHASE',
+        productId: MOBILE_CHAT_BUNDLE_PRODUCT_IDS.LIFETIME,
+        transactionId,
+        price: 199.99,
+      }),
+    );
+
+    expect(result).toEqual({ ok: true });
+
+    const activeLimit = await prisma.userFeatureLimit.findFirst({
+      where: { userId: user.id, feature: Feature.RESEARCH_ASSISTANT, isActive: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(activeLimit?.useLimit).toBeNull();
+
+    const subscription = await prisma.subscription.findFirst({
+      where: { stripeSubscriptionId: `revenuecat_lifetime_${transactionId}` },
+    });
+    expect(subscription?.planType).toBe(PlanType.SCIWEAVE_LIFETIME);
+    expect(subscription?.status).toBe(SubscriptionStatus.ACTIVE);
+
+    const fulfillment = await prisma.revenueCatPurchaseFulfillment.findUnique({
+      where: { revenueCatTransactionId: transactionId },
+    });
+    expect(fulfillment?.fulfillmentType).toBe(RevenueCatPurchaseFulfillmentType.LIFETIME_UNLOCK);
+  });
+});
+
+function makePayload({
+  userId,
+  type,
+  productId,
+  transactionId,
+  price,
+  cancelReason,
+}: {
+  userId: number;
+  type: string;
+  productId: string;
+  transactionId: string;
+  price?: number;
+  cancelReason?: string;
+}): RevenueCatWebhookPayload {
+  const now = Date.now();
+
+  return {
+    api_version: '1.0',
+    event: {
+      app_user_id: String(userId),
+      cancel_reason: cancelReason ?? null,
+      currency: 'USD',
+      event_timestamp_ms: now,
+      expiration_at_ms: now,
+      id: `${transactionId}_${type.toLowerCase()}`,
+      original_transaction_id: transactionId,
+      presented_offering_id: 'chat_bundles',
+      price: price ?? null,
+      product_id: productId,
+      store: 'PLAY_STORE',
+      subscriber_attributes: {
+        userId: {
+          updated_at_ms: now,
+          value: String(userId),
+        },
+      },
+      transaction_id: transactionId,
+      type,
+    },
+  };
+}


### PR DESCRIPTION
Closes #<GH_issue_number>

## Description of the Problem / Feature

## Explanation of the solution

## Instructions on making this work

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat bundle purchases now tracked and fulfilled with idempotent duplicate protection
  * Lifetime unlock purchases supported and recorded (creates a lifetime subscription record)
  * Automatic handling of cancellations/reversals with reversal records and timestamping
  * Persistent purchase fulfillment records for audit and feature-limit updates

* **Tests**
  * Integration tests added covering bundle fulfillment, idempotency, reversals, and lifetime unlocks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->