### PR TITLE
feat(internal): /v1/internal/sciweave/signups for admin bot

### DIFF
--- a/desci-server/src/controllers/internal/getSciweaveSignupCount.ts
+++ b/desci-server/src/controllers/internal/getSciweaveSignupCount.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+
+import { sendError, sendSuccess } from '../../core/api.js';
+import { logger as parentLogger } from '../../logger.js';
+import { getNewSciweaveUsersInRange } from '../../services/user.js';
+
+const logger = parentLogger.child({ module: 'InternalSciweaveSignups' });
+
+const MAX_LOOKBACK_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+/**
+ * GET /v1/internal/sciweave/signups?since=<ISO date>
+ *
+ * Counts new sciweave users created at or after `since` (defaults to 24h ago).
+ * "New sciweave user" matches the existing admin analytics definition: a User
+ * with an InteractionLog entry of action=USER_SIGNUP_SUCCESS and
+ * extra->>'isSciweave' = 'true', joined on User.createdAt within the window.
+ *
+ * Auth: X-Internal-Secret header (validated by ensureInternalSecret middleware
+ * on the route). Used by the sciweave-web admin Telegram bot's /status command.
+ */
+export const getSciweaveSignupCount = async (req: Request, res: Response) => {
+  const sinceParam = typeof req.query.since === 'string' ? req.query.since : undefined;
+  const now = new Date();
+  let since: Date;
+  if (sinceParam) {
+    since = new Date(sinceParam);
+    if (Number.isNaN(since.getTime())) {
+      return sendError(res, "Invalid 'since' query param — must be an ISO date", 400);
+    }
+  } else {
+    since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  }
+
+  // Cap lookback to 90d to keep the query bounded.
+  const earliest = new Date(now.getTime() - MAX_LOOKBACK_MS);
+  if (since < earliest) since = earliest;
+
+  try {
+    const users = await getNewSciweaveUsersInRange({ from: since, to: now });
+    return sendSuccess(res, { count: users.length, since: since.toISOString(), to: now.toISOString() });
+  } catch (err) {
+    logger.error({ err, since }, 'getSciweaveSignupCount failed');
+    return sendError(res, 'Internal error', 500);
+  }
+};

--- a/desci-server/src/routes/v1/internal/index.ts
+++ b/desci-server/src/routes/v1/internal/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import { getFeatureStatus } from '../../../controllers/internal/getFeatureStatus.js';
+import { getSciweaveSignupCount } from '../../../controllers/internal/getSciweaveSignupCount.js';
 import { postFeatureUsage } from '../../../controllers/internal/postFeatureUsage.js';
 import { ensureInternalSecret } from '../../../middleware/internalSecret.js';
 import { validateInputs } from '../../../middleware/validator.js';
@@ -16,5 +17,9 @@ router.post(
   [ensureInternalSecret, validateInputs(postFeatureUsageSchema)],
   postFeatureUsage,
 );
+
+// Count new sciweave users in a window. Used by the sciweave-web admin
+// Telegram bot. See controller for definition of "new sciweave user".
+router.get('/sciweave/signups', [ensureInternalSecret], getSciweaveSignupCount);
 
 export default router;


### PR DESCRIPTION
## Summary
- Exposes the existing `getNewSciweaveUsersInRange` query as an internal endpoint protected by `ensureInternalSecret`.
- Used by sciweave-web's new admin Telegram bot ([sciweave-web#315](https://github.com/desci-labs/sciweave-web/pull/315)) to populate the "Signups" field in `/status`.

## Why
Bot was previously reading sciweave-web's local `users` cache table, which is empty until login flows trigger `upsert_user`. Real signup signal lives here in `InteractionLog` (`USER_SIGNUP_SUCCESS` + `extra->>'isSciweave' = 'true'`).

## API
```
GET /v1/internal/sciweave/signups?since=<ISO date>
Headers: X-Internal-Secret: <INTERNAL_SERVICE_SECRET>

→ 200 { count, since, to }
→ 400 { error } on invalid `since`
→ 401 on missing/wrong secret
```
- `since` defaults to 24h ago when omitted
- Lookback capped at 90d to bound the underlying query

## Test plan
- [ ] curl with valid secret + no `since` → returns count over last 24h
- [ ] curl with valid secret + `?since=2026-04-01` → returns count since that date
- [ ] curl with missing/wrong secret → 401
- [ ] curl with malformed `since` → 400
- [ ] sciweave-web admin bot `/status` shows non-zero signup count after this deploys to dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)