### PR TITLE
feat(admin): /v1/admin/metrics/sciweave-subscriptions

### DIFF
--- a/desci-server/src/controllers/admin/metrics/sciweaveSubscriptionMetrics.ts
+++ b/desci-server/src/controllers/admin/metrics/sciweaveSubscriptionMetrics.ts
@@ -1,0 +1,93 @@
+import { PlanType, StripeInvoiceStatus, SubscriptionStatus } from '@prisma/client';
+import { Response } from 'express';
+
+import { SuccessResponse } from '../../../core/ApiResponse.js';
+import { logger as parentLogger } from '../../../logger.js';
+import { RequestWithUser } from '../../../middleware/index.js';
+import { prisma } from '../../../client.js';
+
+const logger = parentLogger.child({ module: 'AdminSciweaveSubscriptionMetrics' });
+
+/**
+ * GET /v1/admin/metrics/sciweave-subscriptions
+ *
+ * Aggregate Stripe subscription metrics for the sciweave admin dashboard.
+ * No query params today — the dashboard always wants "now" + a fixed
+ * trailing-30d window for new/canceled and revenue.
+ *
+ * Returns:
+ *   - byStatus: count of Subscriptions per SubscriptionStatus
+ *   - byPlan: count of ACTIVE/TRIALING subs per PlanType
+ *   - new30d: count where createdAt >= now-30d
+ *   - canceled30d: count where canceledAt >= now-30d
+ *   - revenue30dCents: sum of paid Invoice rows in the last 30d
+ *   - mrrCents: sum of paid Invoice rows in last 30d that are linked to an
+ *     active subscription. This is "cash MRR" rather than booked MRR — it
+ *     undercounts annual subs in their non-renewal months but stays honest
+ *     without needing per-plan price lookup tables.
+ */
+export const getSciweaveSubscriptionMetrics = async (_req: RequestWithUser, res: Response) => {
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  try {
+    const [byStatusRaw, byPlanRaw, new30d, canceled30d, revenueAgg, mrrAgg] = await Promise.all([
+      prisma.subscription.groupBy({
+        by: ['status'],
+        _count: { _all: true },
+      }),
+      prisma.subscription.groupBy({
+        by: ['planType', 'billingInterval'],
+        where: { status: { in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING] } },
+        _count: { _all: true },
+      }),
+      prisma.subscription.count({
+        where: { createdAt: { gte: thirtyDaysAgo } },
+      }),
+      prisma.subscription.count({
+        where: { canceledAt: { gte: thirtyDaysAgo } },
+      }),
+      prisma.invoice.aggregate({
+        where: {
+          status: StripeInvoiceStatus.PAID,
+          paidAt: { gte: thirtyDaysAgo },
+        },
+        _sum: { amount: true },
+      }),
+      prisma.invoice.aggregate({
+        where: {
+          status: StripeInvoiceStatus.PAID,
+          paidAt: { gte: thirtyDaysAgo },
+          subscription: {
+            status: { in: [SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING] },
+          },
+        },
+        _sum: { amount: true },
+      }),
+    ]);
+
+    const byStatus = Object.fromEntries(
+      Object.values(SubscriptionStatus).map((s) => [s, 0]),
+    ) as Record<SubscriptionStatus, number>;
+    for (const row of byStatusRaw) byStatus[row.status] = row._count._all;
+
+    const byPlan: Array<{ planType: PlanType; billingInterval: string; count: number }> = byPlanRaw.map((row) => ({
+      planType: row.planType,
+      billingInterval: row.billingInterval,
+      count: row._count._all,
+    }));
+
+    return new SuccessResponse({
+      asOf: now.toISOString(),
+      byStatus,
+      byPlan,
+      new30d,
+      canceled30d,
+      revenue30dCents: revenueAgg._sum.amount ?? 0,
+      mrrCents: mrrAgg._sum.amount ?? 0,
+    }).send(res);
+  } catch (err) {
+    logger.error({ err }, 'getSciweaveSubscriptionMetrics failed');
+    throw err;
+  }
+};

--- a/desci-server/src/routes/v1/admin/metrics/index.ts
+++ b/desci-server/src/routes/v1/admin/metrics/index.ts
@@ -4,6 +4,7 @@ import { getFeatureAdoptionMetrics } from '../../../../controllers/admin/metrics
 import { getPublishMetrics } from '../../../../controllers/admin/metrics/publishMetrics.js';
 import { getResearchObjectMetrics } from '../../../../controllers/admin/metrics/researchObjectMetrics.js';
 import { getRetentionMetrics } from '../../../../controllers/admin/metrics/retentionMetrics.js';
+import { getSciweaveSubscriptionMetrics } from '../../../../controllers/admin/metrics/sciweaveSubscriptionMetrics.js';
 import { getUserEngagementMetrics } from '../../../../controllers/admin/metrics/userEngagements.js';
 import { metricsApiSchema } from '../../../../controllers/admin/schema.js';
 import { ensureUserIsAdmin } from '../../../../middleware/ensureAdmin.js';
@@ -29,6 +30,11 @@ router.get(
   '/feature-adoption-metrics',
   [ensureUser, ensureUserIsAdmin, validateInputs(metricsApiSchema)],
   asyncHandler(getFeatureAdoptionMetrics),
+);
+router.get(
+  '/sciweave-subscriptions',
+  [ensureUser, ensureUserIsAdmin],
+  asyncHandler(getSciweaveSubscriptionMetrics),
 );
 
 export default router;


### PR DESCRIPTION
## Summary
Aggregate Stripe subscription metrics endpoint for the sciweave admin dashboard. Today the dashboard only surfaces API-credit revenue; recurring subscription data is invisible despite Stripe webhooks already syncing it into the local `Subscription` + `Invoice` tables.

## API
```
GET /v1/admin/metrics/sciweave-subscriptions
Auth: ensureUser + ensureUserIsAdmin (matches sibling /metrics endpoints)

→ 200 {
  asOf,
  byStatus: { ACTIVE, CANCELED, INCOMPLETE, INCOMPLETE_EXPIRED, PAST_DUE, TRIALING, UNPAID },
  byPlan: [{ planType, billingInterval, count }],
  new30d,
  canceled30d,
  revenue30dCents,
  mrrCents
}
```

## MRR caveat
`mrrCents` is "cash MRR" — sum of paid invoices in the trailing 30 days, filtered to invoices linked to active/trialing subscriptions. Annual subs only contribute in their renewal month, so this undercounts compared to "booked MRR." Trade-off: stays honest without needing per-plan price lookup tables. We can swap to booked MRR later if needed.

## Test plan
- [ ] curl with admin cookie → 200 with shape above
- [ ] curl without auth → 401
- [ ] `byStatus` totals match `SELECT status, COUNT(*) FROM "Subscription" GROUP BY status`
- [ ] `revenue30dCents` matches manual SQL on Invoice
- [ ] sciweave-web admin panel renders new Subscriptions card after deploy

## Related
- Consumed by: sciweave-web admin panel update (separate PR)
- Pattern: matches existing `/v1/admin/metrics/*` controllers (`userEngagements`, `publishMetrics`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)