### PR TITLE
hotfix(ci): raise tsc heap so desci-server images build again

### DIFF
--- a/desci-server/Dockerfile.ci
+++ b/desci-server/Dockerfile.ci
@@ -21,8 +21,19 @@ COPY ./test ./test
 COPY ./vitest.config.ts ./vitest.config.ts
 COPY ./tsconfig.json ./tsconfig.json
 
+# tsc needs more than Node's default old-space heap (~2 GB) to compile this
+# codebase. Without this, `yarn build` dies with
+#   FATAL ERROR: Ineffective mark-compacts near heap limit - JavaScript heap out of
+#   memory
+# at ~2042 MB. `dist` is then never written, so the sentry:sourcemaps step fails on
+# "./dist: No such file or directory" and the whole image build exits 1.
+#
+# This first broke "Build desci-server" on the 2026-08-05 merge to main. It was not
+# that change's fault — main had not been merged to since 2026-05-25, and the
+# codebase outgrew the default heap somewhere in between, so the failure had simply
+# never been triggered. Raising the cap is the fix; the runner has ample RAM.
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
-    yarn build
+    NODE_OPTIONS="--max-old-space-size=4096" yarn build
 
 # ── Test stage (used by docker-compose.test.yml) ─────────────
 FROM builder AS test


### PR DESCRIPTION
## Urgency

**`Build desci-server` is failing on `main`, so no new desci-server image can be published.** Prod keeps serving the last good image, so this is a deploy blocker rather than an outage — but nothing ships until it's fixed.

## Cause

```
[builder 13/13] RUN yarn build
  $ rimraf dist && tsc && yarn copy-files; if [ "$SENTRY_AUTH_TOKEN" ]; then ...
  FATAL ERROR: Ineffective mark-compacts near heap limit
               - JavaScript heap out of memory          (at ~2042 MB)
  ...
  sentry-cli sourcemaps inject ./dist
  error: ./dist: IO error ... No such file or directory
  ERROR: process "/bin/sh -c yarn build" did not complete successfully: exit 1
```

`tsc` exhausts Node's default ~2 GB old-space heap. `dist` is never written, so the sourcemap step fails on the missing directory and takes the image build with it.

One line: `NODE_OPTIONS="--max-old-space-size=4096"` on that build step.

## This is not a regression from #1303

That workflow last ran **green on 2026-05-25**. `main` had no merges between then and 2026-08-05, and the codebase outgrew the default heap somewhere in that window. The first merge after the ten-week gap simply exposed it.

## Worth knowing

When `SENTRY_AUTH_TOKEN` is **unset**, this failure is invisible. The script is:

```
rimraf dist && tsc && yarn copy-files; if [ "$SENTRY_AUTH_TOKEN" ]; then ... fi
```

The `;` before `if` means the exit code comes from the trailing block, so a `tsc` failure is **swallowed** and the image builds anyway. That's why CI jobs without the token have been "passing" with a broken compile.

Making the build fail honestly is worth doing, but **not in a hotfix** — desci-server currently has ~12 files with pre-existing type errors, so turning `tsc` into a hard gate would block everyone until they're cleaned up.

## Note

The same one-line change is also in #1302. Whichever lands second can drop its copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqLbzeMDBb8tsefynU7K5L